### PR TITLE
Add init --here and ship-pr guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `al init --here` flag installs Agent Layer in the current directory without walking up to an ancestor `.agent-layer/` or `.git`. Lets users add a separate `.agent-layer/` inside a subfolder of an existing repo. When `al init` resolves to an already-initialized ancestor, the error now points at `--here` so the option is discoverable.
 - `agent_specific.permissions.deny = ["AskUserQuestion"]` shipped in the install seed (`internal/templates/config.toml`). Fresh `al init` now disables Claude Code's structured clarification-question tool by default; remove the line to keep it. Existing repos are unaffected.
 
 ### Changed
+- Built-in skill frontmatter descriptions are shorter and more routing-focused, reducing Claude skill listing budget pressure while keeping key trigger language.
 - Claude `agent_specific` is now deep-merged into `.claude/settings.json` for object values (arrays and scalars still replace at their key). Previously, top-level objects were replaced wholesale. `permissions.deny` is additive and does not trigger an override warning; `permissions.allow` continues to warn when present.
+- `ship-pr` skill adds a human-gated Phase 9: the agent merges the PR only when the user replies with the exact phrase `I approve merging PR #<N>` matching the run's PR number, using an unambiguous GitHub merge method or pausing for a strategy choice when multiple methods are available; on a successful merge it deletes the source branch locally and remotely. The skill refuses to delete the repository's default branch.
+- `ship-pr` skill adds an upfront "Continuation rule" framing sub-skill returns as intermediate, not terminal. Addresses a recurring failure where the orchestrator stopped after `audit-and-fix-uncommitted-changes` returned, mistaking the sub-skill's closeout summary for ship-pr's completion.
 
 ## v0.10.0 - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ al doctor
 Notes:
 - `al init` prompts to run `al wizard` after seeding files. Use `al init --no-wizard` to skip; non-interactive shells skip automatically.
 - `al init` is intended to be run once per repo. If the repo is already initialized, use `al upgrade plan` and `al upgrade` to refresh template-managed files.
+- By default `al init` first walks up for an ancestor `.agent-layer/`, then for an ancestor `.git`. To install a separate Agent Layer in a subfolder of an existing repo (for example a sub-project that needs its own `.agent-layer/`), pass `al init --here` to target the current directory.
 - `al upgrade` is the recommended path. For CI-safe non-interactive apply, use `al upgrade --yes --apply-managed-updates`. Add `--apply-memory-updates` and/or `--apply-deletions` only when you explicitly want those categories.
 - `al upgrade` automatically creates a managed-file snapshot and rolls changes back if an upgrade step fails. Snapshots are written under `.agent-layer/state/upgrade-snapshots/`.
 - Agent Layer does not install clients. Install the target client CLI and ensure it is on your `PATH` (Gemini CLI, Claude Code CLI, Codex, Copilot CLI, VS Code, etc.).

--- a/cmd/al/init.go
+++ b/cmd/al/init.go
@@ -51,12 +51,13 @@ var validatePinnedReleaseVersionFunc = validatePinnedReleaseVersion
 func newInitCmd() *cobra.Command {
 	var noWizard bool
 	var pinVersion string
+	var here bool
 
 	cmd := &cobra.Command{
 		Use:   messages.InitUse,
 		Short: messages.InitShort,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			root, err := resolveInitRoot()
+			root, cwd, err := resolveInitRoot(here)
 			if err != nil {
 				return err
 			}
@@ -64,6 +65,9 @@ func newInitCmd() *cobra.Command {
 			if info, err := statAgentLayerPath(agentLayerPath); err == nil {
 				if !info.IsDir() {
 					return fmt.Errorf(messages.RootPathNotDirFmt, agentLayerPath)
+				}
+				if root != cwd {
+					return fmt.Errorf(messages.InitAlreadyInitializedAncestorFmt, root, cwd)
 				}
 				return fmt.Errorf(messages.InitAlreadyInitialized)
 			} else if !errors.Is(err, os.ErrNotExist) {
@@ -103,6 +107,7 @@ func newInitCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&noWizard, "no-wizard", false, messages.InitFlagNoWizard)
 	cmd.Flags().StringVar(&pinVersion, "version", "", messages.InitFlagVersion)
+	cmd.Flags().BoolVar(&here, "here", false, messages.InitFlagHere)
 
 	return cmd
 }

--- a/cmd/al/init_test.go
+++ b/cmd/al/init_test.go
@@ -784,6 +784,108 @@ func TestInitCmd_StatAgentLayerErrorFailsFast(t *testing.T) {
 	}
 }
 
+func TestInitCmd_HereInstallsInSubfolderOfExistingAgentLayer(t *testing.T) {
+	origGetwd := getwd
+	origIsTerminal := isTerminal
+	origInstallRun := installRun
+	origRunWizard := runWizard
+	origCheckForUpdate := checkForUpdate
+	t.Cleanup(func() {
+		getwd = origGetwd
+		isTerminal = origIsTerminal
+		installRun = origInstallRun
+		runWizard = origRunWizard
+		checkForUpdate = origCheckForUpdate
+	})
+
+	parent := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(parent, ".agent-layer"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(parent, "child")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	getwd = func() (string, error) { return sub, nil }
+	isTerminal = func() bool { return false }
+	checkForUpdate = func(context.Context, string) (update.CheckResult, error) {
+		return update.CheckResult{Current: "1.0.0", Latest: "1.0.0"}, nil
+	}
+	runWizard = func(string, string) error { return nil }
+
+	var gotRoot string
+	installRun = func(root string, _ install.Options) error {
+		gotRoot = root
+		return nil
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{"--no-wizard", "--here"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --here failed: %v", err)
+	}
+	wantAbs, err := filepath.Abs(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantAbs {
+		t.Fatalf("installRun root = %q, want %q (--here should target cwd, not ancestor)", gotRoot, wantAbs)
+	}
+}
+
+func TestInitCmd_AncestorAgentLayerErrorHintsHere(t *testing.T) {
+	origGetwd := getwd
+	origIsTerminal := isTerminal
+	origInstallRun := installRun
+	origCheckForUpdate := checkForUpdate
+	t.Cleanup(func() {
+		getwd = origGetwd
+		isTerminal = origIsTerminal
+		installRun = origInstallRun
+		checkForUpdate = origCheckForUpdate
+	})
+
+	parent := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(parent, ".agent-layer"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(parent, "child")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	getwd = func() (string, error) { return sub, nil }
+	isTerminal = func() bool { return false }
+	checkForUpdate = func(context.Context, string) (update.CheckResult, error) {
+		return update.CheckResult{Current: "1.0.0", Latest: "1.0.0"}, nil
+	}
+	installRun = func(string, install.Options) error {
+		t.Fatal("installRun should not be called when ancestor already initialized")
+		return nil
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{"--no-wizard"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when ancestor is already initialized")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ancestor directory") {
+		t.Fatalf("error should mention ancestor directory, got %q", msg)
+	}
+	if !strings.Contains(msg, "al init --here") {
+		t.Fatalf("error should hint at --here, got %q", msg)
+	}
+}
+
 func TestInitCmd_AgentLayerIsFileErrors(t *testing.T) {
 	origGetwd := getwd
 	origIsTerminal := isTerminal

--- a/cmd/al/root_resolve.go
+++ b/cmd/al/root_resolve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/conn-castle/agent-layer/internal/messages"
 	"github.com/conn-castle/agent-layer/internal/root"
@@ -28,11 +29,25 @@ func resolveRepoRoot() (string, error) {
 	return repoRoot, nil
 }
 
-// resolveInitRoot finds the best candidate root for initialization (prefers .agent-layer, then .git).
-func resolveInitRoot() (string, error) {
-	cwd, err := getwd()
+// resolveInitRoot finds the candidate root for initialization and returns it alongside the absolute cwd.
+// When here is true the absolute cwd is returned verbatim so users can install in a subfolder of an
+// existing agent-layer or git repo; otherwise the closest ancestor with .agent-layer/ (preferred) or
+// .git is returned, falling back to cwd.
+func resolveInitRoot(here bool) (root string, cwd string, err error) {
+	wd, err := getwd()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return findRepoRoot(cwd)
+	absCwd, err := filepath.Abs(wd)
+	if err != nil {
+		return "", "", fmt.Errorf(messages.RootResolvePathFmt, wd, err)
+	}
+	if here {
+		return absCwd, absCwd, nil
+	}
+	root, err = findRepoRoot(wd)
+	if err != nil {
+		return "", "", err
+	}
+	return root, absCwd, nil
 }

--- a/cmd/al/wizard.go
+++ b/cmd/al/wizard.go
@@ -30,7 +30,7 @@ func newWizardCmd() *cobra.Command {
 		Long:  messages.WizardLong,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			root, err := resolveInitRoot()
+			root, _, err := resolveInitRoot(false)
 			if err != nil {
 				return err
 			}

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,11 +27,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
-- Issue 2026-03-22 init-subfolder-of-repo: `al init` cannot install in a subfolder of another git repo
-    Priority: Medium. Area: internal/root / init.
-    Description: `FindRepoRoot` first calls `FindAgentLayerRoot` (walks upward for `.agent-layer/`) then falls back to walking upward for `.git`. Both walks return the first ancestor match, so running `al init` in a subfolder of a repo that already has agent-layer installed always resolves to the parent. Even `git init` in the subfolder doesn't help because the `.agent-layer` check takes priority. No clean workaround exists.
-    Next step: Add a flag or heuristic so `al init` can target the current directory when the user intends to install in a subfolder (e.g. `--here` flag, or prompt when cwd != detected root).
-
 - Issue 2026-03-02 color-gating-consistency: Centralize CLI color gating beyond fatih/color built-in detection
     Priority: Low. Area: CLI output / color handling.
     Description: `color.YellowString()` gates ANSI output via fatih/color's global `NoColor` flag (terminal detection + `NO_COLOR` env var), but `shouldColorizeDiffOutput()` uses a separate `isTerminal() && !color.NoColor` check for unified-diff rendering with custom `color.New()` objects. The two gating mechanisms are inconsistent — `color.YellowString()` self-gates while diff colors require explicit gating. If Cobra's `io.Writer` is redirected (e.g., `cmd.SetOut()` in tests or embedding), `color.YellowString()` still checks `os.Stdout` for terminal detection, which could emit ANSI codes to non-terminal outputs.

--- a/internal/messages/cli.go
+++ b/internal/messages/cli.go
@@ -23,10 +23,14 @@ const (
 	InitShort = "Initialize Agent Layer in this repository"
 	// InitAlreadyInitialized is returned when init is invoked on an already-initialized repo.
 	InitAlreadyInitialized = "agent layer is already initialized (or partially initialized) in this repository; run 'al upgrade' to upgrade or repair templates"
-	InitRunWizardPrompt    = "Run the setup wizard now? (recommended)"
+	// InitAlreadyInitializedAncestorFmt is returned when init walks up to an ancestor that is already initialized,
+	// so the user knows they can scope the install to the current directory with --here.
+	InitAlreadyInitializedAncestorFmt = "agent layer is already initialized in an ancestor directory (%s); run 'al upgrade' there to upgrade or repair templates, or re-run as `al init --here` to install a separate agent-layer in %s"
+	InitRunWizardPrompt               = "Run the setup wizard now? (recommended)"
 
 	InitFlagNoWizard = "Skip prompting to run the setup wizard after init"
 	InitFlagVersion  = "Pin the repo to a specific Agent Layer version (vX.Y.Z or X.Y.Z) or latest"
+	InitFlagHere     = "Install in the current directory without walking up to an ancestor .agent-layer/ or .git"
 
 	UpgradeUse                            = "upgrade"
 	UpgradeShort                          = "Apply template-managed updates and update the repo pin"

--- a/internal/templates/skills/address-pr-comments/SKILL.md
+++ b/internal/templates/skills/address-pr-comments/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: address-pr-comments
 description: >-
-  Review comments on an open pull request, implement agreed fixes, reply to
-  every comment, audit changes, then commit and push. Use when the user asks to
-  handle PR review comments or reviewer feedback. Use `fix-ci` for failing
-  checks and `ship-pr` to create or ship a PR.
+  Handle reviewer feedback on an open PR: evaluate comments, implement agreed
+  fixes, justify or track deferrals, reply to every comment, audit changes,
+  then commit and push. Use `fix-ci` for failing checks.
 ---
 
 # address-pr-comments

--- a/internal/templates/skills/audit-and-fix-uncommitted-changes/SKILL.md
+++ b/internal/templates/skills/audit-and-fix-uncommitted-changes/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: audit-and-fix-uncommitted-changes
 description: >-
-  Audit and iteratively fix all uncommitted working-tree changes until a
-  confirming review finds no remaining actionable issues. Use when the agent
-  needs to stabilize in-progress diffs from any author or process, run repeated
-  review/fix cycles, and deliver a round-by-round severity report of what was
-  found and fixed.
+  Audit and iteratively fix uncommitted working-tree changes until a confirming
+  review finds no remaining actionable issues. Use to stabilize in-progress
+  diffs and report each review/fix round with severity.
 ---
 
 # audit-and-fix-uncommitted-changes

--- a/internal/templates/skills/audit-documentation/SKILL.md
+++ b/internal/templates/skills/audit-documentation/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: audit-documentation
 description: >-
-  Audit Markdown documentation for static accuracy and cross-document
-  consistency against the repository, and fix what can be fixed. Excludes agent
-  memory files by default (use `audit-memory` for those).
+  Audit Markdown docs for static accuracy and cross-document consistency
+  against the repo, fixing what is safe. Excludes memory files by default; use
+  `audit-memory` for those.
 ---
 
 # audit-documentation

--- a/internal/templates/skills/audit-memory/SKILL.md
+++ b/internal/templates/skills/audit-memory/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: audit-memory
 description: >-
-  Audit the agent memory files (ISSUES, BACKLOG, ROADMAP, DECISIONS, COMMANDS,
-  CONTEXT) for structural compliance, staleness, misplacement, cross-file
-  consistency, and DECISIONS.md bloat, then fix accepted findings. Use
-  `audit-documentation` for repo documentation accuracy.
+  Audit agent memory files (ISSUES, BACKLOG, ROADMAP, DECISIONS, COMMANDS,
+  CONTEXT) for structure, staleness, placement, consistency, and DECISIONS.md
+  bloat; fix accepted findings.
 ---
 
 # audit-memory

--- a/internal/templates/skills/audit-tests/SKILL.md
+++ b/internal/templates/skills/audit-tests/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: audit-tests
 description: >-
-  Audit the test suite for redundancy, quality gaps, and organizational health
-  across unit, integration, and e2e tiers. Discovers test conventions from the
-  project, classifies tests by tier, identifies duplicate, tautological, or
-  self-confirming tests, finds coverage gaps that metrics miss, fixes what can be
-  fixed safely, and reports findings. Use `boost-coverage` to fill gaps; use
-  this skill to assess and clean up the existing test suite.
+  Audit the test suite for redundancy, quality gaps, and organization across
+  unit, integration, and e2e tiers. Finds duplicate or self-confirming tests,
+  coverage gaps metrics miss, and safe cleanup fixes.
 ---
 
 # audit-tests

--- a/internal/templates/skills/boost-coverage/SKILL.md
+++ b/internal/templates/skills/boost-coverage/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: boost-coverage
 description: >-
-  Raise test coverage by discovering the repo's real coverage command,
-  selecting under-covered files, adding tests, and iterating to the documented
-  target or blocker. Use when the user asks to increase coverage. Use
-  `audit-tests` for suite-quality cleanup and `debug-issue` for reproducing a
-  specific bug.
+  Raise coverage by finding the real coverage command, selecting under-covered
+  files, adding behavior-focused tests, and iterating to target or blocker. Use
+  `audit-tests` for suite cleanup.
 ---
 
 # boost-coverage

--- a/internal/templates/skills/complete-current-phase/SKILL.md
+++ b/internal/templates/skills/complete-current-phase/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: complete-current-phase
 description: >-
-  Complete the current roadmap phase through planning, plan review,
-  implementation, verification, audit, cleanup, and closeout. Use when the user
-  asks to finish, complete, or work through a roadmap phase. Use `plan-work`
-  for planning only, `implement-plan` when artifacts already exist, and
-  `finish-task` for non-roadmap closeout.
+  Complete the current roadmap phase through planning, review, implementation,
+  verification, audit, cleanup, and closeout. Use `plan-work` for planning only
+  and `finish-task` for non-roadmap closeout.
 ---
 
 # complete-current-phase

--- a/internal/templates/skills/debug-issue/SKILL.md
+++ b/internal/templates/skills/debug-issue/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: debug-issue
 description: >-
-  Investigate a reported bug or unexpected behavior from symptom to root cause:
-  reproduce, narrow down, diagnose, write a failing test, fix, and verify. Use
-  when the root cause is unknown and investigation is needed before a fix can be
-  planned.
+  Investigate a reported bug from symptom to root cause: reproduce, narrow,
+  diagnose, write a failing test, fix, and verify. Use when the cause is unknown
+  and investigation must precede planning.
 ---
 
 # debug-issue

--- a/internal/templates/skills/finish-task/SKILL.md
+++ b/internal/templates/skills/finish-task/SKILL.md
@@ -2,10 +2,8 @@
 name: finish-task
 description: >-
   Close out finished work by checking plan alignment, updating only necessary
-  memory/docs, running credible verification, and summarizing outcome. Use when
-  code work is done but no PR is needed. Use `ship-pr` for commit/push/PR,
-  `verify-against-plan` for read-only checks, and `complete-current-phase` for
-  roadmap phases.
+  memory/docs, running credible verification, and summarizing outcome. Use
+  `ship-pr` for PR work or `verify-against-plan` for read-only checks.
 ---
 
 # finish-task

--- a/internal/templates/skills/fix-ci/SKILL.md
+++ b/internal/templates/skills/fix-ci/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: fix-ci
 description: >-
-  Diagnose and fix failing CI/checks on an open PR, iterating through diagnose,
-  patch, audit, commit, push, and re-check until green or blocked. Use when a
-  PR's GitHub checks are failing. Use `repair-checks` for local checks and
-  `address-pr-comments` for reviewer feedback.
+  Diagnose and fix failing CI/checks on an open PR: inspect logs/artifacts,
+  create a local reproducer when possible, patch, audit, commit, push, and
+  re-check. Use `repair-checks` for local failures.
 ---
 
 # fix-ci

--- a/internal/templates/skills/fix-issues/SKILL.md
+++ b/internal/templates/skills/fix-issues/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: fix-issues
 description: >-
-  Fix open items in `ISSUES.md` by default: plan the set, batch work,
-  implement, audit, verify, and keep the ledger current. Use when the user asks
-  to clear or work through known issues. Use `debug-issue` for one unexplained
-  symptom and `resolve-findings` for a review findings report.
+  Fix open `ISSUES.md` items: plan a batch, implement, audit, verify, and keep
+  the ledger current. Use `debug-issue` for one unexplained symptom or
+  `resolve-findings` for review reports.
 ---
 
 # fix-issues

--- a/internal/templates/skills/implement-plan/SKILL.md
+++ b/internal/templates/skills/implement-plan/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: implement-plan
 description: >-
-  Execute an existing plan/task/context artifact set: make code changes, keep
-  them aligned to the artifacts, and verify code, tests, docs, and memory before
-  closeout. Use when the user asks to implement an already-written plan. Use
-  `plan-work` when no plan exists and `complete-current-phase` for roadmap
-  phases.
+  Execute an existing plan/task/context artifact set: make aligned code changes
+  and verify code, tests, docs, and memory before closeout. Use `plan-work`
+  when no plan exists.
 ---
 
 # implement-plan

--- a/internal/templates/skills/improve-codebase/SKILL.md
+++ b/internal/templates/skills/improve-codebase/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: improve-codebase
 description: >-
-  Deep, autonomous audit and improvement of the entire codebase (or user-specified
-  subsystems): survey the repository structure, decompose into reviewable chunks,
-  run parallel multi-lens reviews, fix findings iteratively, and delegate to
-  complementary skills (simplify-code, boost-coverage, audit-tests, fix-issues) where
-  appropriate. Use after a release, during a maintenance window, or whenever a
-  thorough independent quality sweep is needed.
+  Run a deep autonomous quality sweep of the whole codebase or named
+  subsystems: survey, split into reviewable chunks, run multi-lens reviews, fix
+  findings iteratively, and delegate to cleanup/test skills as needed.
 ---
 
 # improve-codebase

--- a/internal/templates/skills/plan-work/SKILL.md
+++ b/internal/templates/skills/plan-work/SKILL.md
@@ -2,9 +2,8 @@
 name: plan-work
 description: >-
   Write a scoped implementation plan, task list, and context file for a
-  requested change. Use when the user asks for a plan, roadmap slice, execution
-  strategy, task breakdown, current roadmap-phase slice, or pre-implementation
-  design artifact before coding.
+  requested change, roadmap slice, execution strategy, task breakdown, or
+  pre-implementation design artifact.
 ---
 
 # plan-work

--- a/internal/templates/skills/repair-checks/SKILL.md
+++ b/internal/templates/skills/repair-checks/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: repair-checks
 description: >-
-  Run the repo's documented local checks, fix in-scope failures, and repeat
-  until checks pass or a real blocker remains. Use when the user asks to fix
-  lint, typecheck, tests, format, or pre-PR checks. Use `fix-ci` for remote PR
-  checks and `audit-and-fix-uncommitted-changes` for broader diff review.
+  Run documented local checks, fix in-scope failures, and repeat until checks
+  pass or a real blocker remains. Use for lint, typecheck, tests, format, or
+  pre-PR check failures.
 ---
 
 # repair-checks

--- a/internal/templates/skills/resolve-findings/SKILL.md
+++ b/internal/templates/skills/resolve-findings/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: resolve-findings
 description: >-
-  Triage an existing review findings report, verify each finding, implement
-  accepted fixes, and record rejected, deferred, or already-resolved items. Use
-  when the user asks to work through review findings. Use `fix-issues` for
-  `ISSUES.md` and `address-pr-comments` for GitHub PR review comments.
+  Triage a review findings report: verify each finding, implement accepted
+  fixes, and record rejected, deferred, or already-resolved items. Use for
+  report-driven follow-up work.
 ---
 
 # resolve-findings

--- a/internal/templates/skills/review-plan/SKILL.md
+++ b/internal/templates/skills/review-plan/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: review-plan
 description: >-
-  Review a plan/task/context artifact set before execution and produce a
-  findings report covering scope gaps, sequencing problems, weak verification,
-  and missing docs/tests/memory updates. Use this instead of `review-scope`
-  when the target is specifically a workflow plan.
+  Review a plan/task/context artifact set before execution, reporting scope
+  gaps, sequencing problems, weak verification, and missing docs/tests/memory
+  updates.
 ---
 
 # review-plan

--- a/internal/templates/skills/review-scope/SKILL.md
+++ b/internal/templates/skills/review-scope/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: review-scope
 description: >-
-  Review explicit files, directories, diffs, uncommitted changes, or a
-  proactive hotspot set and produce a findings report covering correctness,
-  gaps, risks, architecture, tests, docs, performance, reliability, and
-  maintainability. Use the `review-plan` skill instead when the target is
-  specifically a plan/task/context artifact set.
+  Review explicit files, directories, diffs, uncommitted changes, or proactive
+  hotspots for correctness, gaps, risks, architecture, tests, docs, performance,
+  reliability, and maintainability. Use `review-plan` for plans.
 ---
 
 # review-scope

--- a/internal/templates/skills/schedule-backlog/SKILL.md
+++ b/internal/templates/skills/schedule-backlog/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: schedule-backlog
 description: >-
-  Propose backlog-to-roadmap scheduling updates by mapping `BACKLOG.md` items
-  into roadmap phases, checking issue/decision impacts, and pausing before
-  roadmap edits. Use when the user asks to schedule backlog work or reshape the
-  roadmap. Use `plan-work` for a single implementation plan and `fix-issues`
-  for `ISSUES.md` execution.
+  Map BACKLOG.md items into roadmap phases, checking issue/decision impacts and
+  pausing before roadmap edits. Use when scheduling backlog work or reshaping
+  the roadmap; use `plan-work` for one implementation plan.
 ---
 
 # schedule-backlog

--- a/internal/templates/skills/ship-pr/SKILL.md
+++ b/internal/templates/skills/ship-pr/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: ship-pr
 description: >-
-  Run the full PR lifecycle for completed local work: audit changes, commit,
-  push, open PR, monitor CI, handle review comments, and finish green. Use when
-  the user asks to ship, open, or take work to a PR. Use `fix-ci` for an
-  existing failing PR, `address-pr-comments` for review feedback, and
-  `finish-task` when no PR is needed.
+  Run completed local work through PR delivery: audit changes, verify locally,
+  commit, push, open PR, monitor CI, handle review comments, and finish green.
+  After exact approval (`I approve merging PR #<N>`), merge the PR and clean up
+  its source branch. Use `fix-ci` for failing PR checks.
 ---
 
 # ship-pr
@@ -42,6 +41,12 @@ Delegate to:
 - `repair-checks` for pre-push local verification when the current session has not already observed the repo-defined local lane passing after the latest changes
 - `fix-ci` for CI failure diagnosis and repair
 - `address-pr-comments` for review comment handling
+
+## Continuation rule
+
+Sub-skill returns are intermediate, not terminal. After every delegation (`audit-and-fix-uncommitted-changes`, `repair-checks`, `fix-ci`, `address-pr-comments`), continue to the next numbered step in the same turn — the sub-skill's closing summary is not ship-pr's closeout. The most common failure is stopping after `audit-and-fix-uncommitted-changes` returns, before staging and commit happen.
+
+The loop exits only at end of Phase 8, a listed human checkpoint, or a mirrored sub-skill checkpoint (e.g., `fix-ci` halting without pushing — Phase 3 step 3c, Phase 6 step 1c).
 
 ## Global constraints
 
@@ -147,6 +152,36 @@ Do not trust the sub-skill output alone — re-fetch the PR state and validate.
    - every comment has a reply that passes the Phase 7 audit
    - all changes are committed and pushed
 2. Summarize the PR lifecycle outcome.
+3. Tell the user the exact phrase required to authorize merge (Phase 9). For example: `Reply "I approve merging PR #<N>" to merge this PR and delete the source branch.`
+
+### Phase 9: Merge — only on explicit human authorization
+
+This phase does not run automatically. After Phase 8 the skill stops and waits.
+
+**Authorization trigger.** The agent may merge the PR only when the user replies with the exact phrase `I approve merging PR #<N>` (case-insensitive), where `<N>` is the exact PR number for this run. No other wording — "approved", "looks good", "merge it", "ship it", a thumbs-up, etc. — counts as authorization. If the user uses a similar but non-matching phrase, ask them to issue the exact phrase rather than inferring intent. If the PR number in the user's message does not match the PR for this run, refuse the merge and tell the user which PR number the skill is operating on. Authorization is single-use and scoped to the PR number it names.
+
+**Merge steps (after authorization):**
+
+1. Re-verify the PR is mergeable and CI is still green: `gh pr view <N> --json mergeable,mergeStateStatus,state`.
+2. Determine the merge method without guessing:
+   a. Run `gh repo view --json mergeCommitAllowed,rebaseMergeAllowed,squashMergeAllowed,viewerDefaultMergeMethod`.
+   b. If exactly one method is allowed, run `gh pr merge <N>` with that explicit flag (`--merge`, `--rebase`, or `--squash`).
+   c. If multiple methods are allowed and `viewerDefaultMergeMethod` names one of them, run `gh pr merge <N>` with the matching explicit flag.
+   d. If multiple methods are allowed and no explicit default method is available, stop and ask the user to choose one of the allowed methods. Do not infer a method from branch names, commit history, or personal preference.
+3. Do not pass `--admin`. Do not bypass branch protections. If the merge fails, surface the error and stop. Do not retry destructively.
+
+**Post-merge cleanup (after a successful merge):**
+
+1. Fetch PR head metadata: `gh pr view <N> --json baseRefName,headRefName,headRepository,headRepositoryOwner,isCrossRepository,state`.
+2. Switch to the base branch and update it: `git checkout <base> && git pull`.
+3. Delete the local branch: `git branch -d <branch>`. If `-d` refuses, re-confirm the PR is merged via `gh pr view <N> --json state` before considering `-D`; never force-delete an unmerged branch.
+4. Delete the remote branch only after mapping the PR head repository to a local git remote. Use `git remote -v` to find the remote whose fetch or push URL matches `headRepository`; if no remote maps unambiguously, stop and report the unmapped head repository instead of deleting from `origin` by assumption.
+5. Delete the mapped remote branch: `git push <remote> --delete <headRefName>`. If `git ls-remote --heads <remote> <headRefName>` shows it is already gone (e.g., GitHub auto-deleted it), skip this step.
+6. Verify the branch is gone:
+   - Local: `git branch --list <branch>` returns no output.
+   - Remote: `git ls-remote --heads <remote> <headRefName>` returns no output.
+
+**Never delete the repository's default branch under any circumstances**, regardless of what the user says.
 
 ## Guardrails
 
@@ -154,6 +189,8 @@ Do not trust the sub-skill output alone — re-fetch the PR state and validate.
 - Do not end with CI failing.
 - Do not force-push or rewrite history unless explicitly instructed.
 - Do not create duplicate PRs.
+- Do not merge the PR unless the user issues the exact authorization phrase `I approve merging PR #<N>` with a number that matches this run's PR.
+- Never delete the repository's default branch.
 
 ## Definition of done
 
@@ -161,6 +198,7 @@ Do not trust the sub-skill output alone — re-fetch the PR state and validate.
 - The repo-defined local check lane passed before the first push/PR, and CI-fix commits were not pushed without a local reproducer and passing post-fix local verification.
 - `address-pr-comments` reached its definition of done, and Phase 7 independently verified that result by re-fetching the PR state.
 - The skill did not force-push, did not create a duplicate PR, and did not end with CI failing.
+- The skill ends after Phase 8 with the PR open and green unless the user issues the exact authorization phrase `I approve merging PR #<N>`; in that case the PR is merged with an explicit, unambiguous GitHub merge method and the source branch is deleted both locally and remotely.
 
 ## Final handoff
 
@@ -170,3 +208,5 @@ After the run:
 3. For any CI fixes, summarize the `fix-ci` local-reproducer evidence.
 4. State whether all comments passed the Phase 7 audit or if any require further human attention.
 5. If any comments were re-addressed during the audit, list them and explain what was corrected.
+6. State the exact phrase required to authorize merge: `I approve merging PR #<N>` with this PR's number. If the user has not issued it, do not merge.
+7. If a merge was performed, report the merge outcome and confirm both local and remote branch deletion succeeded.

--- a/internal/templates/skills/simplify-code/SKILL.md
+++ b/internal/templates/skills/simplify-code/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: simplify-code
 description: >-
-  Assess code complexity, remove dead code, simplify overly complex functions,
-  and split files that mix unrelated responsibilities. Uses complexity metrics
-  as diagnostic signals and applies judgment rather than rigid thresholds.
-  Scoped to uncommitted changes when they exist, otherwise the full codebase.
-  Use for cleanup/refactor requests. Use `improve-codebase` for broad audits,
-  test skills for test-suite work, and `debug-issue` for bug investigations.
+  Simplify code by removing dead code, reducing overly complex functions, and
+  splitting files with mixed responsibilities. Uses complexity metrics as
+  signals, scoped to uncommitted changes when present. Use for cleanup/refactor
+  requests.
 ---
 
 # simplify-code

--- a/internal/templates/skills/verify-against-plan/SKILL.md
+++ b/internal/templates/skills/verify-against-plan/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: verify-against-plan
 description: >-
-  Read-only check of the current implementation and working tree against an
-  existing plan/task/context set. Reports completeness gaps, regressions,
-  missing tests/docs, and scope drift without edits. Use when the user wants a
-  plan-alignment check. Use `review-plan` to critique the plan, `finish-task`
-  for closeout, and `implement-plan` to fix gaps.
+  Read-only check of current implementation and working tree against a
+  plan/task/context set, reporting completeness gaps, regressions, missing
+  tests/docs, and scope drift. Use `review-plan` to critique the plan.
 ---
 
 # verify-against-plan

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -271,6 +271,27 @@ func TestCISkillsRequireLocalReproducerBeforePush(t *testing.T) {
 	}
 }
 
+func TestShipPRSkillRequiresExplicitMergeAuthorizationAndSafeCleanup(t *testing.T) {
+	data, err := Read("skills/ship-pr/SKILL.md")
+	if err != nil {
+		t.Fatalf("Read error: %v", err)
+	}
+	content := string(data)
+	for _, snippet := range []string{
+		"Sub-skill returns are intermediate, not terminal.",
+		"I approve merging PR #<N>",
+		"Do not pass `--admin`.",
+		"viewerDefaultMergeMethod",
+		"stop and ask the user to choose one of the allowed methods",
+		"no remote maps unambiguously",
+		"Never delete the repository's default branch",
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("expected %q in ship-pr skill", snippet)
+		}
+	}
+}
+
 func TestPRCommentPolicyLivesInAddressPRComments(t *testing.T) {
 	addressData, err := Read("skills/address-pr-comments/SKILL.md")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `al init --here` so subfolders can install their own `.agent-layer/` without ancestor resolution
- shorten built-in skill routing descriptions
- strengthen `ship-pr` continuation, merge authorization, and branch cleanup guardrails

## Verification
- go test ./cmd/al ./internal/root ./internal/templates
- go test ./internal/templates -run TestShipPRSkillRequiresExplicitMergeAuthorizationAndSafeCleanup
- git diff --check
- make dev