### PR TITLE
chore: migrate to go-toml/v2, mark disabled agents OK, prune memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ coverage.out
 # These may contain resolved secrets from .agent-layer/.env — keep gitignored.
 /.agent/
 /.agents/
+/.antigravitycli/
+/.agy-cfg/
 /.mcp.json
 /.codex/
 /.copilot/

--- a/docs/SKILL-DESIGN.md
+++ b/docs/SKILL-DESIGN.md
@@ -3,6 +3,11 @@
 This document is the canonical skill-authoring guide for repo-local skill
 sources such as `.agent-layer/skills/<name>/SKILL.md`.
 
+This guide is the skill-authoring counterpart to `docs/INSTRUCTION-DESIGN.md`,
+which covers instruction-file authoring. The two documents share several
+foundational references (context engineering, instruction density, primacy
+effects) but apply them to different authoring surfaces.
+
 Research and standards in this guide were re-verified on 2026-04-18. The guide
 intentionally separates:
 - specification or product requirements

--- a/docs/agent-layer/BACKLOG.md
+++ b/docs/agent-layer/BACKLOG.md
@@ -195,9 +195,3 @@ Unscheduled user-visible features and tasks (distinct from issues; not refactors
     Description: Evaluate using a generic shell/command MCP server to enforce a unified allowlist for shell commands across all agents, rather than relying on agent-specific implementations.
     Acceptance criteria: Feasibility study and prototype of a unified shell MCP with granular allowlisting.
     Notes: Deep backlog item. Consider only after high-priority improvements are complete. Goal is centralized control.
-
-- Backlog 2026-01-27 2b3c4d5: Support Codex-as-MCP for multi-agent use
-    Priority: Medium. Area: agent collaboration
-    Description: Support running Codex as an MCP server to allow multi-agent collaboration. Investigate similar capabilities for Claude and Gemini.
-    Acceptance criteria: Codex can be exposed as an MCP server. Investigation into Claude/Gemini MCP agent support is complete.
-    Notes: Enables agents to call other agents as tools.

--- a/docs/agent-layer/CONTEXT.md
+++ b/docs/agent-layer/CONTEXT.md
@@ -25,3 +25,40 @@ Do not duplicate information that belongs in other memory files:
 - Insert all content below `<!-- ENTRIES START -->`.
 
 <!-- ENTRIES START -->
+
+## Secrets
+
+- Codex is the one exception to "never embed secrets in generated configs": it embeds secrets in URLs/env via `bearer_token_env_var`, and shell environment takes precedence over `.agent-layer/.env`. All other clients use placeholder syntax in generated configs.
+
+## VS Code and editor integrations
+
+- The Codex VS Code extension reads `CODEX_HOME` only at process startup. The generated repo-specific launchers exist to set `CODEX_HOME` before launch — there is no in-extension reload path.
+- The Claude VS Code extension shares MCP scope with Claude CLI: both read the same `.mcp.json`/`.claude/settings.json`. Configuring separate MCP server sets for the two surfaces is not possible. `[agents.claude_vscode]` is config-only.
+- `.vscode/settings.json` updates only validate JSONC content inside the managed markers. Invalid JSONC outside the markers is not detected once the markers are present.
+
+## Codex MCP headers
+
+- Codex MCP header projection accepts exactly three placeholder formats: `bearer_token_env_var` for `Authorization: Bearer ${VAR}`, `env_http_headers` for exact `${VAR}` values, and `http_headers` for literal strings. Mixed literal + env placeholder (e.g. `Token ${VAR}`) is rejected and must be restructured.
+
+## Antigravity
+
+- Antigravity supports instructions and skills only — no MCP, no approvals. Skills are projected through shared `.agents/skills/<name>/SKILL.md`. Singular `.agent/skills/` is treated as legacy generated output.
+
+## Pin file recovery
+
+- Empty or non-semver `.agent-layer/al.version` pin files are treated as "no pin" and auto-repaired by `al init`/`al upgrade` without prompts. The user sees a warning, never a hard error. A broken pin file must never make the CLI unusable.
+
+## Upgrade and migration internals
+
+- When source version cannot be resolved during `al upgrade`, source-agnostic migration operations still execute; source-gated operations are skipped with deterministic report entries. Ambiguous repos may need an explicit follow-up if the skip report flags missed transitions.
+- Multi-version upgrades chain migration manifests: all manifests between source (exclusive) and target (inclusive) load in order with per-operation deduplication by ID. When source is unknown, only the target manifest loads (backward compatible). Manifests must have unique operation IDs across the chain or later duplicates are silently skipped.
+- The required-field migration guardrail uses a baseline allowlist for fields that predate manifest enforcement (baseline version `0.8.1`). The allowlist must be maintained when introducing new required fields; stale entries can hide drift if not reviewed.
+
+## Gemini
+
+- `al sync` writes the repo root as `TRUST_FOLDER` to `~/.gemini/trustedFolders.json` when Gemini is enabled. This is the one case where `al sync` writes outside the repo boundary. Failure is non-fatal (warning, not error). Required because Gemini's Trusted Folders feature silently replaces untrusted project settings with `{}`, discarding all MCP servers.
+- Workspace-tier `.gemini/policies/` is NOT auto-loaded by Gemini CLI 0.41.2 without an explicit `policyPaths` setting. The generated `.gemini/settings.json` therefore writes `policyPaths: [".gemini/policies"]`. Gemini CLI < v0.18 (pre-policy-engine) loses auto-allow behavior because `tools.allowed` is no longer emitted.
+
+## E2E test harness
+
+- `scripts/test-e2e/harness.sh` authenticates GitHub API calls with `GITHUB_TOKEN`/`GH_TOKEN` when available (raises the limit from 60 req/hr to 5000 req/hr). CI exports the token to `make ci`. Unauthenticated fallback is preserved for local offline runs.

--- a/docs/agent-layer/DECISIONS.md
+++ b/docs/agent-layer/DECISIONS.md
@@ -27,21 +27,6 @@ A rolling log of important, non-obvious decisions that materially affect future 
 
 <!-- ENTRIES START -->
 
-- Decision 2026-01-17 a7b8c9d: VS Code launchers for CODEX_HOME
-    Decision: Provide repo-specific VS Code launchers that set `CODEX_HOME` at process start.
-    Reason: The Codex extension reads `CODEX_HOME` only at startup; launchers ensure correct repo context.
-    Tradeoffs: Launching through generated scripts is required to guarantee repo-scoped Codex context.
-
-- Decision 2026-01-17 c9d0e1f: Antigravity limited support
-    Decision: Antigravity supports instructions and skills only (no MCP, no approvals). Skills are projected through shared `.agents/skills/<name>/SKILL.md`; singular `.agent/skills/` is treated as legacy generated output.
-    Reason: Antigravity integration is best-effort; core clients (Gemini, Claude, VS Code, Codex, Copilot CLI) have full parity, and current skill support aligns with the shared Agent Skills path.
-    Tradeoffs: Antigravity users get reduced functionality compared with core clients.
-
-- Decision 2026-01-18 e1f2a3b: Secret handling (Codex exception)
-    Decision: Generated configs use client-specific placeholder syntax so secrets are never embedded. Exception: Codex embeds secrets in URLs/env and uses `bearer_token_env_var` for headers. Shell environment takes precedence over `.agent-layer/.env`.
-    Reason: Prevents accidental secret exposure; Codex limitations require an exception.
-    Tradeoffs: Cross-client secret behavior is not fully uniform because Codex has transport-specific constraints.
-
 - Decision 2026-01-22 f1e2d3c: Distribution model (global CLI with per-repo pinning)
     Decision: Ship a single globally installed `al` CLI with per-repo version pinning via `.agent-layer/al.version` and cached binaries.
     Reason: A single entrypoint reduces support burden while pinning keeps multi-repo setups reproducible.
@@ -57,40 +42,10 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Reason: Keeps artifacts invisible to humans while avoiding collisions for concurrent agents without relying on env vars or per-chat IDs.
     Tradeoffs: Files can accumulate until manually cleaned; agents must echo paths in chat to retain context.
 
-- Decision 2026-01-27 d4e7a1b: VS Code settings merge scoped to managed block
-    Decision: When the managed markers exist in `.vscode/settings.json`, update only the managed block and do not validate unrelated JSONC content; if markers are missing, parse the root object to insert the block.
-    Reason: Avoid partial JSONC parsing dependencies while still supporting first-time insertion.
-    Tradeoffs: Invalid JSONC outside the managed block is no longer detected once the markers are present.
-
-- Decision 2026-01-28 5c8e2a1: Codex custom MCP headers
-    Decision: Codex projects MCP headers using `bearer_token_env_var` for `Authorization: Bearer ${VAR}`, `env_http_headers` for exact `${VAR}` values, and `http_headers` for literals; other placeholder formats error.
-    Reason: Support custom headers across clients without embedding secrets or relying on placeholder expansion in Codex.
-    Tradeoffs: Headers with mixed literal + env placeholder (for example, `Token ${VAR}`) are rejected for Codex and must be restructured.
-
-- Decision 2026-02-03 c7d2a1f: Curated CLI docs in site/
-    Decision: Stop generating CLI docs during website publish; use the curated `site/docs/reference.mdx` section as the source of truth.
-    Reason: Help-output dumps duplicated content and reduced usability compared to a curated guide.
-    Tradeoffs: The guide can drift from exact flags; users should rely on `al --help` for authoritative flag output.
-
-- Decision 2026-02-03 d9e3a7b: Consolidate docs into single-page sections
-    Decision: Merge Concepts, Getting started, Reference, and Troubleshooting into single pages under `site/docs/`.
-    Reason: Reduce fragmentation and make the docs feel cohesive and professional, with fewer small pages.
-    Tradeoffs: Breaking URLs for old per-topic pages; cross-links must use anchors on the consolidated pages.
-
-- Decision 2026-02-05 b6c1d2e: Gitignore block templating and validation
-    Decision: Store `.agent-layer/gitignore.block` as the verbatim template content; inject managed markers, hash, and header only when writing the root `.gitignore`, and error if the block contains managed markers or a hash line.
-    Reason: Keep the template file clean and user-editable while ensuring the root `.gitignore` stays managed and consistent.
-    Tradeoffs: Legacy blocks with markers/hash now require `al upgrade` to restore the template file before `al sync` will succeed.
-
-- Decision 2026-02-07 p0a-pin-recovery: Empty/corrupt pin files produce warnings, not errors
-    Decision: `readPinnedVersion()` treats empty and non-semver pin files as "no pin" (returns a warning string instead of an error). `writeVersionFile()` auto-repairs empty/corrupt pins without requiring prompts.
-    Reason: A broken pin file should never make the CLI completely unusable. `al init`/`al upgrade` must always be able to self-heal the pin state.
-    Tradeoffs: Corrupt pins silently fall through to the current binary version; users see a warning but may not notice it in noisy terminal output.
-
-- Decision 2026-02-09 p1b-ownership-baseline: Ownership classification now uses embedded manifests plus canonical baseline state
-    Decision: `al upgrade plan` ownership classification now uses committed per-release manifests (`internal/templates/manifests/*.json`) and canonical repo baseline state (`.agent-layer/state/managed-baseline.json`) with section-aware policies (`memory_entries_v1`, `memory_roadmap_v1`, `allowlist_lines_v1`), and emits `unknown_no_baseline` when evidence is insufficient.
-    Reason: Distinguishes upstream template deltas from true local customization without runtime network/tag lookups and avoids silent guesses in ambiguous cases.
-    Tradeoffs: Release workflow must generate/commit manifests for each tag; repos lacking credible baseline evidence may show `unknown no baseline` until a baseline refresh run (for example `al upgrade`).
+- Decision 2026-02-03 docs-curated-pages: Curated single-page docs are the source of truth (supersedes c7d2a1f + d9e3a7b)
+    Decision: Stop generating CLI docs during website publish. The curated `site/docs/reference.mdx` (and the consolidated Concepts, Getting started, Reference, and Troubleshooting single-page sections under `site/docs/`) are the source of truth. Users rely on `al --help` for authoritative flag output.
+    Reason: Help-output dumps duplicated content and reduced usability; fragmented per-topic pages hurt cohesion. Curation gives a single editable home for each topic.
+    Tradeoffs: The guide can drift from exact flags. Old per-topic URLs broke; cross-links must use anchors on the consolidated pages.
 
 - Decision 2026-02-10 p1c-init-upgrade-ownership: Init scaffolding only; user-owned config/env; agent-only .gitignore
     Decision: `al init` is one-time scaffolding (errors if `.agent-layer/` already exists). Upgrades/repairs are done via `al upgrade plan` + `al upgrade`. `.agent-layer/.env` and `.agent-layer/config.toml` are user-owned and seeded only when missing (never overwritten by init/upgrade). `.agent-layer/.gitignore` is agent-owned internal and is always overwritten and excluded from upgrade plans/diffs.
@@ -102,65 +57,25 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Reason: Changing historical entries undermines trust in the changelog as a factual record and can confuse readers comparing old entries against old tags.
     Tradeoffs: Stale references in old entries (e.g., renamed files) remain; readers must consult current docs for the latest names.
 
-- Decision 2026-02-12 p1f-upgrade-diff-previews: Always show line-level diffs in upgrade previews and prompts
-    Decision: `al upgrade plan` and interactive `al upgrade` overwrite prompts now render unified line-level diffs by default, with per-file truncation at 40 lines and an explicit `--diff-lines` override.
-    Reason: Issue #30 required users to see specific line changes before accepting/rejecting overwrite decisions; always-on previews remove blind yes/no prompts.
-    Tradeoffs: Default output is noisier for large files; users who need deeper context must opt in with a larger `--diff-lines` value.
-
-- Decision 2026-02-14 p2a-upgrade-snapshot-transaction: Upgrade snapshot/rollback boundary and retention policy
-    Decision: `al upgrade` now captures full-byte snapshots for the transactional upgrade mutation set (managed files/dirs, memory files, `.gitignore`, launcher outputs, and scanned unknown deletion targets), runs rollback on transactional-step failure, and retains the newest 20 snapshots under `.agent-layer/state/upgrade-snapshots/`.
-    Reason: Deliver Phase 11 safety guarantees now while keeping snapshot artifacts available for the upcoming explicit rollback command.
-    Tradeoffs: Snapshot files can grow in large repos because payloads are full-content; retention is bounded but no per-snapshot size budget is enforced yet.
-
 - Decision 2026-02-14 p2b-upgrade-apply-flags: Remove `--force`; require explicit apply categories
     Decision: `al upgrade` no longer supports `--force`. Non-interactive runs require `--yes` plus one or more explicit apply flags (`--apply-managed-updates`, `--apply-memory-updates`, `--apply-deletions`), and deletion remains gated behind explicit `--apply-deletions`.
     Reason: Prevent accidental destructive upgrades and make non-interactive intent explicit per mutation category.
     Tradeoffs: Existing `al upgrade --force` automation breaks and must be migrated to explicit apply flags.
-
-- Decision 2026-02-15 p3a-migration-source-fallback: Upgrade migrations run source-agnostic operations when source version cannot be resolved
-    Decision: Release migration manifests are required per supported target version (`internal/templates/migrations/<target>.json`) with `min_prior_version`. During `al upgrade`, source-agnostic operations still execute when source version resolution fails; source-gated operations are skipped with deterministic report entries.
-    Reason: Users expect upgrades to continue to the latest version even when legacy repos lack reliable source-version evidence.
-    Tradeoffs: Some source-dependent migrations may be deferred in ambiguous repos and require explicit follow-up if skip reports indicate missed transitions.
-
-- Decision 2026-02-15 rel-working-tree-manifest: Manifest generation reads from working tree, not git tags
-    Decision: `gentemplatemanifest` reads template files from the working tree via `os.ReadFile`/`filepath.WalkDir` instead of `git show <tag>:<path>`. The `--tag` flag is replaced with `--version`.
-    Reason: Eliminates the tag chicken-and-egg problem where the manifest must be committed before tagging but the tool required a tag to generate the manifest.
-    Tradeoffs: The manifest is no longer guaranteed to match tag content; the release preflight gate mitigates this risk.
 
 - Decision 2026-02-17 p12-yolo-mode: Approvals policy expanded to 5-mode system (supersedes f6a7b8c)
     Decision: Add `yolo` as a fifth `approvals.mode` value. YOLO mode auto-approves commands and MCP (like `all`) and also sends full-auto flags to each client: Claude `--dangerously-skip-permissions`, Gemini `--approval-mode=yolo`, Codex `approval_policy=never` + `sandbox_mode=danger-full-access`, VS Code `chat.tools.global.autoApprove=true`.
     Reason: Users running in sandboxed/ephemeral environments want to skip all permission prompts without per-client manual configuration.
     Tradeoffs: YOLO bypasses all safety prompts; a single-line `[yolo]` acknowledgement on stderr (not a structured warning) informs users on every sync and launch. The template config comment and documentation carry the risk explanation. No `al doctor` warning — YOLO is a deliberate choice, not a health issue.
 
-- Decision 2026-02-17 p12-unified-vscode-launcher: Unified VS Code launcher and shared Claude MCP scope
-    Decision: Use a single `al vscode` command for Codex and Claude VS Code extension launches. The Claude VS Code config section remains config-only (`[agents.claude_vscode]`), and Claude MCP filtering is shared with CLI via the `"claude"` client filter because both surfaces read the same `.mcp.json`/`.claude/settings.json`.
-    Reason: VS Code is a single runtime surface, and separate launcher/MCP-filter paths would duplicate behavior while conflicting with extension file-path expectations.
-    Tradeoffs: Users cannot configure separate MCP server sets for Claude CLI vs Claude VS Code extension; both use the same Claude-scoped MCP configuration.
-
-- Decision 2026-02-18 config-resilience: Replace silent Migrate() with lenient parsing + interactive upgrade prompts (supersedes config-migrate)
-    Decision: Remove `Config.Migrate()` entirely. Instead: (1) add `ParseConfigLenient`/`LoadConfigLenient` that unmarshal without validation, (2) `al wizard` and `al doctor` fall back to lenient loading so they always work on broken configs, (3) `al upgrade` uses `config_set_default` migration operations that prompt the user interactively for new required field values, (4) runtime commands (`al sync`, `al claude`, etc.) remain strict and fail with actionable guidance.
-    Reason: Silent defaults violate the "no silent fallbacks" rule. Repair tools must always be runnable. Every config value should come from an explicit user choice.
-    Tradeoffs: Users must run `al wizard` or `al upgrade` to fix broken configs instead of having them auto-repaired; accepted because explicit consent is a design principle.
-
-- Decision 2026-02-18 migration-chain: Migration manifests are chained during multi-version upgrades
-    Decision: When source version is known, all manifests between source (exclusive) and target (inclusive) are loaded and applied in order with per-operation deduplication by ID. When source is unknown, only the target manifest is loaded (backward compatible). Migrations that missed a release are placed in the next release's manifest with an expanded `min_prior_version`.
-    Reason: Without chaining, users jumping multiple versions (e.g., 0.8.0 → 0.8.2) miss intermediate migrations. The v0.8.1 config migration shipped after the binary, so it was moved to 0.8.2's manifest to catch all users.
-    Tradeoffs: Manifest ordering depends on semver sort of filenames; manifests must have unique operation IDs across the chain or later duplicates are silently skipped.
-
-- Decision 2026-02-20 e2e-mandatory-upgrade-ci: Upgrade scenarios mandatory in CI via auto-detected manifest version (supersedes e2e-two-lane-hermetic skip behavior)
-    Decision: E2E testing uses a scenario-based bash harness with contract-level assertions, authentic upgrade source state from downloaded prior release binaries, mandatory upgrade coverage in CI (`test-e2e-ci` with online + required-upgrade flags), and HOME isolation to avoid host config pollution.
-    Reason: The previous monolithic flow allowed silent upgrade-scenario skips and weak "no-crash" checks, reducing confidence in real user workflows (`init -> upgrade -> sync -> launch`).
-    Tradeoffs: First CI/local online runs require network access and cache warm-up; scenario assertions are stricter and need upkeep when intentional output changes.
+- Decision 2026-02-18 config-resilience: Strict-by-default parsing with lenient repair path (supersedes config-migrate, unknown-key-repairable)
+    Decision: Remove `Config.Migrate()` entirely. Runtime commands (`al sync`, `al claude`, etc.) parse strictly via `ParseConfig`/`LoadConfig` and reject unknown TOML keys (including in enable-only agent sections). `al wizard` and `al doctor` use `ParseConfigLenient`/`LoadConfigLenient` to fall back to lenient loading so they always work on broken configs. `al upgrade` uses `config_set_default` migration operations that prompt the user interactively for new required field values. Unknown-key failures are wrapped as `ErrConfigValidation` so repair tools can still load leniently and guide repair.
+    Reason: Silent defaults violate the "no silent fallbacks" rule. Repair tools must always be runnable. Every config value should come from an explicit user choice. Silent unknown-key acceptance hid invalid config; hard-failing repair tools made recovery impossible.
+    Tradeoffs: Users must run `al wizard` or `al upgrade` to fix broken configs instead of having them auto-repaired; runtime commands fail fast on unknown keys until users repair through wizard/doctor or manual edits. Accepted because explicit consent is a design principle.
 
 - Decision 2026-02-20 gemini-auto-trust: `al sync` auto-trusts repo in `~/.gemini/trustedFolders.json`
     Decision: When Gemini is enabled, `al sync` writes the repo root as `TRUST_FOLDER` to `~/.gemini/trustedFolders.json` (outside the repo). Failures produce a non-fatal warning, never a sync error.
     Reason: Gemini CLI's Trusted Folders feature silently replaces untrusted project settings with `{}`, discarding all MCP servers. Users already expressed trust by enabling Gemini in `config.toml`; propagating that trust to the Gemini runtime is the expected behavior.
     Tradeoffs: Writes to a file outside the repo boundary (`~/.gemini/`). Acceptable because this is a user-level runtime config (analogous to existing `~/.codex/` writes) and failure is non-fatal.
-
-- Decision 2026-02-20 unknown-key-repairable: Strict unknown-key validation with lenient repair path
-    Decision: Runtime config parsing rejects unknown TOML keys via strict decode (including enable-only agent sections), while unknown-key failures are wrapped as `ErrConfigValidation` so `al wizard` and `al doctor` can still load leniently and guide repair.
-    Reason: Silent unknown-key acceptance hid invalid config (for example, unsupported agent fields), but hard-failing repair tools made recovery impossible.
-    Tradeoffs: Runtime commands fail fast on unknown keys until users repair config through wizard/doctor or manual edits.
 
 - Decision 2026-02-22 claude-config-dir: Opt-in repo-local `CLAUDE_CONFIG_DIR` via `local_config_dir` config field
     Decision: Gate `CLAUDE_CONFIG_DIR=<repo>/.claude-config` behind `[agents.claude] local_config_dir = true` (opt-in, default false). When enabled, `al claude` uses warn-and-preserve on mismatch and `al vscode` uses config-flag-based set/unset (matching `CODEX_HOME` pattern). Use `.claude-config/` (not `.claude/`) to avoid collision with the project-level `.claude/settings.json` generated by `al sync`. Keep `.claude-config/` in the gitignore block unconditionally.
@@ -171,36 +86,6 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Decision: `warnings.noise_mode` supports `reduce` and `quiet`, and `--quiet`/`-q` provides command-line suppression. `reduce` suppresses only non-critical suppressible warnings; `quiet` suppresses all warnings (including critical) except `al doctor`, which always prints warnings.
     Reason: Users need one coherent verbosity model that serves both safer daily use (`reduce`) and zero-noise scripted flows (`quiet`/`--quiet`).
     Tradeoffs: Quiet mode can hide high-risk warnings by design, and older pinned binaries may ignore quiet behavior until upgraded.
-
-- Decision 2026-02-24 wizard-order-policy: Wizard config writes now use explicit preferred section order (supersedes f7a3c9d)
-    Decision: Wizard-managed `config.toml` writes iterate an explicit preferred section order (`approvals`, enabled agents, `mcp`, `warnings`) instead of relying on template parse order as the implicit ordering source.
-    Reason: The previous "template order is policy" coupling made ordering intent implicit and brittle when templates were reorganized.
-    Tradeoffs: Existing user files are still rewritten to canonical wizard order; manual ordering/layout edits are not preserved.
-
-- Decision 2026-02-24 required-field-migration-guardrail: Required config fields need migration defaults with a legacy baseline allowlist
-    Decision: Add an automated guardrail test that enforces migration-manifest `config_set_default` coverage for required config fields introduced after baseline version `0.8.1`, with an explicit allowlist for legacy required fields that predate manifest enforcement.
-    Reason: A naive all-fields check would fail forever because historical required fields existed before migration manifests had operations.
-    Tradeoffs: The baseline allowlist must be maintained deliberately when introducing new required fields; stale allowlist entries can hide drift if not reviewed.
-
-- Decision 2026-02-25 docs-retention-policy: Website publish enforces docs version retention and artifact pruning
-    Decision: `cmd/publish-site` now enforces a bounded stable-release retention policy after `docs:version`: keep up to 4 newest patch releases from the newest minor line plus the newest patch release for each of the newest 4 minor lines, drop prerelease entries, and prune dropped versions from `versions.json`, `versioned_docs/`, and `versioned_sidebars/`. Release publishing currently supports stable tags only (`vX.Y.Z`); prerelease tags are intentionally rejected.
-    Reason: Unbounded version snapshots in `agent-layer-web` grow maintenance and deploy footprint over time; retention must be enforced in the publisher because deploy only publishes `main`.
-    Tradeoffs: Older historical docs snapshots beyond the retention window are intentionally removed on each release publish; maintainers must run publisher manually if immediate cleanup is needed before the next release. Prerelease docs publication is unavailable until prerelease support is explicitly reintroduced end-to-end.
-
-- Decision 2026-02-26 phase15-skill-frontmatter-validation: Skill frontmatter parsing stays YAML-based and validator-enforced
-    Decision: Parse/serialize skill frontmatter with `go.yaml.in/yaml/v3`; keep parsing backward-compatible (path-derived names, unknown frontmatter tolerated), and enforce Agent Skills spec checks in `internal/skillvalidator` / `al doctor`.
-    Reason: YAML parsing replaces brittle line scanning and supports metadata serialization; validator-level diagnostics preserve upgradeability for existing flat/legacy skills while still driving standards alignment.
-    Tradeoffs: `gopkg.in/yaml.v3` may appear transitively, non-compliant skills can still load/sync until users act on doctor warnings, and strict parse-time enforcement needs an explicit migration path.
-
-- Decision 2026-02-27 e2e-github-api-auth: E2E harness authenticates GitHub API calls with GITHUB_TOKEN
-    Decision: `resolve_latest_release_version()` in `scripts/test-e2e/harness.sh` now passes `GITHUB_TOKEN` (or `GH_TOKEN`) as a Bearer token in the Authorization header when available. CI workflow exports `GITHUB_TOKEN` to the `make ci` step.
-    Reason: Unauthenticated GitHub API calls are rate-limited to 60 req/hr per IP. GitHub Actions runners share IPs, causing intermittent CI failures when the rate limit is hit during the "Resolve upgrade binaries" phase.
-    Tradeoffs: Authenticated requests raise the limit to 5000 req/hr but require a token; unauthenticated fallback is preserved for local offline runs.
-
-- Decision 2026-03-01 breaking-change-metadata: Breaking-change display is data-driven from migration manifests
-    Decision: Move breaking-change notices and details into the migration manifest (`breaking`, `breaking_notice`, `breaking_details` fields) instead of hardcoding per-kind display logic in the upgrade report renderer.
-    Reason: Hardcoded display logic couples the renderer to specific migration kinds and requires code changes for every new breaking migration. Data-driven display lets future breaking migrations carry their own user-facing copy without touching the renderer.
-    Tradeoffs: Migration manifest validation is now stricter (breaking requires notice; notice/details require breaking flag); accepted because manifest authoring is a release-time activity with clear validation feedback.
 
 - Decision 2026-03-02 user-owned-conventions: Extract project-specific conventions to user-managed `04_conventions.md`
     Decision: Move 5 project-specific instruction items (frontend rules, test coverage thresholds, package policies, typing requirements, schema safety) from `00_base.md` into a new `04_conventions.md` that is user-managed: seeded on `al init`, never overwritten on `al upgrade`, and excluded from managed diffs. A new `append_to_file` migration kind enables delivering new conventions to existing users via opt-in migration entries.
@@ -217,40 +102,35 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Reason: Research shows (1) prompt length alone degrades accuracy starting ~3K tokens (ACL 2024, 2025), (2) conditional branching is among the hardest instruction types (ComplexBench 2024), (3) constraint interference is a primary failure mode in multi-constraint prompts (ComplexBench 2024), (4) Anthropic recommends the routing pattern over mode-switching, (5) Rule of Three says wait until N=3 before extracting shared abstractions (Fowler). The two skills have different domain knowledge (target selection, phases, delegation targets) despite sharing an audit loop shape.
     Tradeoffs: ~70% structural similarity between the two skills is accepted as accidental duplication. If a third audit-loop skill appears, that triggers extraction per Rule of Three. See `docs/SKILL-DESIGN.md` for full research references.
 
-- Decision 2026-03-06 skill-review-scope-dual-mode-close: review-scope dual-mode design is intentional and within thresholds
-    Decision: Keep `review-scope` as a single skill with explicit-scope and proactive-hotspot modes. Do not split into separate skills.
-    Reason: Deep-dive analysis showed: (1) modes share Phases 2-3, diverging only in Phase 1 target selection; splitting would duplicate ~45% of the skill; (2) constraint count (~46) is under the 50-constraint threshold; (3) target-resolution is a sequential 4-step cascade (not nested branching); (4) ComplexBench shows splitting skills has worse interference than conditional branching within thresholds.
-    Tradeoffs: Phase 1 has 3 target-type paths, but they are mutually exclusive and well-scoped.
-
-- Decision 2026-03-06 skill-broader-orchestrator-close: "broader orchestrator" wording is precise and contextually determinable
-    Decision: Keep the current "when no broader orchestrator already owns closeout" phrasing in implement-plan, fix-issues, and debug-issue. Do not replace with explicit skill enumeration.
-    Reason: Deep-dive analysis showed: (1) the phrase is reliably determinable from conversation context (the agent knows whether it was invoked standalone or by a parent skill); (2) enumerating parent skills would couple these skills to the orchestrator roster, requiring updates whenever an orchestrator is added/removed; (3) all three skills use identical phrasing, confirming it is a stable cross-cutting convention.
-    Tradeoffs: Requires the model to reason about invocation context, but this is standard MCP/delegation behavior.
+- Decision 2026-03-06 skill-design-closures: Considered-and-rejected skill design refactors (review-scope split, orchestrator enumeration)
+    Decision: Keep `review-scope` as a single skill with explicit-scope and proactive-hotspot modes (do not split). Keep the "when no broader orchestrator already owns closeout" phrasing in `implement-plan`, `fix-issues`, and `debug-issue` (do not enumerate parent skills).
+    Reason: For `review-scope`: modes share Phases 2–3 and diverge only in Phase 1; splitting would duplicate ~45% of the skill; constraint count (~46) is under the 50-constraint threshold; target-resolution is a sequential 4-step cascade (not nested branching); ComplexBench shows splitting skills has worse interference than conditional branching within thresholds. For "broader orchestrator" phrasing: it is reliably determinable from conversation context; enumerating parent skills would couple to the orchestrator roster and require updates whenever an orchestrator is added/removed.
+    Tradeoffs: `review-scope` Phase 1 has 3 target-type paths (mutually exclusive and well-scoped). The orchestrator phrasing requires the model to reason about invocation context, but this is standard MCP/delegation behavior. Both kept open as closures to prevent re-litigation.
 
 - Decision 2026-03-21 native-skill-sync: Replace MCP prompt delivery with native skill directory sync
     Decision: Removed the internal `al mcp-prompts` MCP server. Claude receives skills via `.claude/skills/`; Codex, Gemini, Antigravity, VS Code/Copilot, and Copilot CLI share `.agents/skills/`. Full subdirectory support (`scripts/`, `references/`, `assets/`) is preserved. Supersedes Decision 2026-01-17 e5f6a7b and Decision 2026-02-23 mcp-prompts-dispatch-bypass.
     Reason: MCP prompts return flat text only, while current client docs support directory-format Agent Skills and several clients now document `.agents/skills/` as an interoperable project path. Shared sync avoids duplicate skill catalogs.
     Tradeoffs: Lost the unified MCP prompt API for skill delivery and stopped generating legacy client-specific skill folders; gained full Agent Skills resource support and fewer duplicate projections.
 
-- Decision 2026-05-07 reasoning-effort-capability-matrix: Reasoning effort is per-client and custom-tolerant where upstream cadence demands it
-    Decision: Support Codex and Claude `reasoning_effort` as custom-tolerant fields; reject Gemini/Copilot CLI effort until a verified control exists; for Claude, require Opus, pass all values via `--effort`, and write settings `effortLevel` only for non-`max` values.
-    Reason: Silent omission breaks fail-loud behavior, but strict Claude catalogs broke when upstream added values such as `xhigh`; `max` is session-only while low/medium/high/xhigh are cataloged.
-    Tradeoffs: Typos surface as sync warnings instead of hard errors for Claude/Codex; Gemini/Copilot configs still fail fast until support is intentionally added.
-
 - Decision 2026-05-07 mcp-catalog-seed-split: MCP server catalog moves to wizard-only embedded file; install seed ships zero `[[mcp.servers]]`
     Decision: Default MCP blocks now live in a wizard-only embedded catalog; the install seed ships only an empty `[mcp]` section with docs guidance. Interactive wizard selection inserts selected catalog blocks and prunes disabled catalog IDs, including customized variants. Profile mode remains verbatim and does not prune.
     Reason: Fresh `al init` should produce a minimal config instead of ~70 disabled MCP lines, while the wizard remains the place to discover curated defaults.
     Tradeoffs: Unticking a customized catalog ID in the interactive wizard removes that block after diff preview confirmation. Profile-mode users keep full responsibility for whatever their profile contains.
 
+- Decision 2026-05-07 reasoning-effort-capability-matrix: Reasoning effort is per-client and custom-tolerant where upstream cadence demands it
+    Decision: Support Codex and Claude `reasoning_effort` as custom-tolerant fields; reject Gemini/Copilot CLI effort until a verified control exists; for Claude, require Opus, pass all values via `--effort`, and write settings `effortLevel` only for non-`max` values.
+    Reason: Silent omission breaks fail-loud behavior, but strict Claude catalogs broke when upstream added values such as `xhigh`; `max` is session-only while low/medium/high/xhigh are cataloged.
+    Tradeoffs: Typos surface as sync warnings instead of hard errors for Claude/Codex; Gemini/Copilot configs still fail fast until support is intentionally added.
+
+- Decision 2026-05-07 gemini-policy-engine: Migrate Gemini allowlist to Policy Engine TOML with explicit `policyPaths`
+    Decision: Stop emitting `tools.allowed` in `.gemini/settings.json`. Generate `.gemini/policies/agent-layer.toml` with one `[[rule]]` block per allowed shell command (`toolName = "run_shell_command"`, `commandPrefix = <cmd>`, `decision = "allow"`, `priority = 100`, `allowRedirection = true`), and write `policyPaths: [".gemini/policies"]` in settings.json so Gemini CLI loads the file.
+    Reason: Gemini CLI v0.30+ deprecates `tools.allowed` ("removed in 1.0"). Workspace tier `.gemini/policies/` is NOT auto-loaded by Gemini CLI 0.41.2 without `policyPaths`, so an explicit pointer is required. `commandPrefix` mirrors the previous `run_shell_command(<cmd>)` substring semantics; `commandRegex` would have required escaping plain user-provided strings. `allowRedirection = true` preserves the prior `tools.allowed` behavior for headless workflows that pipe output (`git ... > out.txt`).
+    Tradeoffs: Two managed artifacts per repo instead of one; users on Gemini CLI < v0.18 (pre-policy-engine) lose the auto-allow behavior, but that release is over six months old.
+
 - Decision 2026-05-09 claude-agent-specific-deep-merge: Claude agent_specific deep-merge with additive permissions.deny default
     Decision: Claude `agent_specific` is deep-merged into `.claude/settings.json` for object values (arrays and scalars still replace at their key). `permissions.deny` is additive and silent; `permissions.allow` and `effortLevel` still trigger override warnings. Install seed ships `agent_specific.permissions.deny = ["AskUserQuestion"]` so new repos disable Claude Code's structured clarification tool by default.
     Reason: Shallow-replace forced users to repeat the entire `permissions` block (re-listing managed `allow` entries) just to add a `deny`. The default deny enforces text-only clarifications, which agents in this repo prefer. Asymmetry vs Codex `agent_specific` is intentional: Codex projection still emits TOML at the root and remains shallow.
     Tradeoffs: Override-warning logic for Claude is bespoke (`claudeAgentSpecificOverrideWarning`) instead of the generic reserved-keys helper. `cloneClaudeSettingValue` deep-clones the types Agent Layer projects (`map[string]any`, `[]any`, `[]string`); other slice types fall through to a shallow copy and would need to be added if the projection grows beyond those.
-
-- Decision 2026-05-07 gemini-policy-engine: Migrate Gemini allowlist to Policy Engine TOML with explicit `policyPaths`
-    Decision: Stop emitting `tools.allowed` in `.gemini/settings.json`. Generate `.gemini/policies/agent-layer.toml` with one `[[rule]]` block per allowed shell command (`toolName = "run_shell_command"`, `commandPrefix = <cmd>`, `decision = "allow"`, `priority = 100`, `allowRedirection = true`), and write `policyPaths: [".gemini/policies"]` in settings.json so Gemini CLI loads the file.
-    Reason: Gemini CLI v0.30+ deprecates `tools.allowed` ("removed in 1.0"). Workspace tier `.gemini/policies/` is NOT auto-loaded by Gemini CLI 0.41.2 (verified by deliberately corrupting a TOML — Gemini ignored it without `policyPaths` and parsed-and-erred with it set), so an explicit pointer is required. `commandPrefix` mirrors the previous `run_shell_command(<cmd>)` substring semantics; `commandRegex` would have required escaping plain user-provided strings. `allowRedirection = true` preserves the prior `tools.allowed` behavior for headless workflows that pipe output (`git ... > out.txt`); without it the engine would prompt for confirmation even when a rule matches.
-    Tradeoffs: Two managed artifacts per repo instead of one; users on Gemini CLI < v0.18 (pre-policy-engine) lose the auto-allow behavior, but that release is over six months old.
 
 - Decision 2026-05-16 cleanup-skills-two-skill-split: Post-implementation cleanup is two diff-scoped skills (`prune-new-tests` + `simplify-new-code`), not one
     Decision: Add two narrow leaf skills wired between implementation and verification: `prune-new-tests` (burden-of-proof test deletion) and `simplify-new-code` (smell-pattern scope-creep removal). Rename `simplify-code` → `simplify-codebase` and explicitly scope it to the codebase, never the diff alone. Both new skills run automatically in `implement-plan` (between implementation and verification) and `audit-and-fix-uncommitted-changes` (before `review-scope`).

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -26,9 +26,3 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 ## Open issues
 
 <!-- ENTRIES START -->
-
-- Issue 2026-03-02 color-gating-consistency: Centralize CLI color gating beyond fatih/color built-in detection
-    Priority: Low. Area: CLI output / color handling.
-    Description: `color.YellowString()` gates ANSI output via fatih/color's global `NoColor` flag (terminal detection + `NO_COLOR` env var), but `shouldColorizeDiffOutput()` uses a separate `isTerminal() && !color.NoColor` check for unified-diff rendering with custom `color.New()` objects. The two gating mechanisms are inconsistent — `color.YellowString()` self-gates while diff colors require explicit gating. If Cobra's `io.Writer` is redirected (e.g., `cmd.SetOut()` in tests or embedding), `color.YellowString()` still checks `os.Stdout` for terminal detection, which could emit ANSI codes to non-terminal outputs.
-    Next step: Audit all CLI color usage and evaluate whether a unified color-gating helper (wrapping both `color.YellowString`-style calls and `color.New()`-style calls) is warranted, or whether fatih/color's built-in detection is sufficient for all current surfaces.
-    Notes: Deferred from PR #85 review. Current codebase uses `color.YellowString()` consistently in `doctor.go`, `upgrade.go` summary/readiness/breaking sections. The diff renderer is the only surface with explicit gating via `shouldColorizeDiffOutput()`.

--- a/docs/agent-layer/ROADMAP.md
+++ b/docs/agent-layer/ROADMAP.md
@@ -93,7 +93,45 @@ Incomplete:
 - Migrated embedded template skills to directory format (`skills/<name>/SKILL.md`), updated embed patterns/tests/manifests/migrations, and added the `review-plan` skill with deterministic `*.plan.md` discovery guidance.
 - Aligned public docs (`README.md`, `site/docs/reference.mdx`) with current frontmatter/spec rules and added individual skill-level workflow guidance.
 
-## Phase 16 — Profiles and multi-config
+## Phase 16 — Onboarding and developer experience
+
+### Goal
+- New users can reach initial productivity within five minutes.
+- Getting-started experience is exemplary, with clear guides, examples, and actionable error messages.
+
+### Tasks
+- [ ] quickstart-guide: Create a comprehensive quickstart guide with step-by-step instructions covering install, `al init`, first sync, and launching an agent.
+- [ ] example-repos: Create 2–3 example repository configurations (minimal single-agent, full-featured multi-agent, team/enterprise setup) that users can reference or clone.
+- [ ] wizard-polish: Audit and improve `al init` and `al wizard` flows for first-time users — reduce prompts, improve defaults, add contextual help text.
+- [ ] error-audit: Audit CLI error messages for clarity and actionability. Ensure every error tells the user what went wrong and what to do next.
+- [ ] demo-content: Create demo GIFs or short videos showing key workflows (init, sync, launch, skills) for embedding in documentation and README.
+
+### Task details
+- quickstart-guide
+  Description: Write a quickstart that takes a user from zero (no agent-layer installed) to productive (first agent launched and working) in clear, numbered steps. Cover macOS and Linux. Include what to expect at each step.
+  Acceptance criteria: Quickstart is published on the website and linked from README. A new user can follow it end-to-end without external help.
+- example-repos
+  Description: Create example `.agent-layer/` configurations that demonstrate common setups. Publish as a separate repository or as part of the docs site.
+  Acceptance criteria: At least 2 example configurations exist and are linked from quickstart/docs. Each example includes a README explaining the setup.
+- wizard-polish
+  Description: Identify friction points in `al init` and `al wizard` by walking through them as a first-time user. Reduce unnecessary prompts, improve default selections, and add inline help.
+  Acceptance criteria: First-time `al init` completes in fewer steps with better defaults. Wizard explains what each option does.
+  Progress: 2026-02-24 delivered a scoped wizard slice (Escape back-navigation with first-step exit confirmation, clearer back/cancel guidance on touched prompts, and warning when profile mode is replacing a TOML-corrupt existing config). 2026-05-07 split the MCP catalog out of the install seed (`internal/templates/mcp-catalog.toml`); fresh `al init` now ships zero `[[mcp.servers]]` blocks, and the interactive wizard prunes default-catalog entries the user disables (full prune — including hand-customized blocks). Profile-mode (`al wizard --profile X --yes`) is intentionally exempt from prune. Remaining phase scope still includes broader first-time `al init` flow reduction/default tuning.
+- error-audit
+  Description: Review all user-facing error messages in the CLI. Ensure each one is actionable (not just "error: failed").
+  Acceptance criteria: No error message leaves the user without a next step. Common errors include remediation commands.
+- demo-content
+  Description: Record short demos of key workflows for documentation.
+  Acceptance criteria: At least 3 demos exist (init, sync, launch) and are embedded in docs.
+
+### Exit criteria
+- Quickstart guide exists on the website and covers the full zero-to-productive flow.
+- At least 2 example repository configurations are published and linked.
+- `al init` and `al wizard` flows are audited and improved for first-time users.
+- CLI error messages are actionable across all commands.
+- Key workflows have visual demos in documentation.
+
+## Phase 17 — Profiles and multi-config
 
 ### Goal
 - Users can define named profiles with different instructions, skills, and configuration overrides.
@@ -143,41 +181,3 @@ Incomplete:
 - Profile merge semantics are deterministic, tested, and documented.
 - `al doctor` validates profile structure.
 - Profile system is documented with examples and use-case guidance.
-
-## Phase 17 — Onboarding and developer experience
-
-### Goal
-- New users can reach initial productivity within five minutes.
-- Getting-started experience is exemplary, with clear guides, examples, and actionable error messages.
-
-### Tasks
-- [ ] quickstart-guide: Create a comprehensive quickstart guide with step-by-step instructions covering install, `al init`, first sync, and launching an agent.
-- [ ] example-repos: Create 2–3 example repository configurations (minimal single-agent, full-featured multi-agent, team/enterprise setup) that users can reference or clone.
-- [ ] wizard-polish: Audit and improve `al init` and `al wizard` flows for first-time users — reduce prompts, improve defaults, add contextual help text.
-- [ ] error-audit: Audit CLI error messages for clarity and actionability. Ensure every error tells the user what went wrong and what to do next.
-- [ ] demo-content: Create demo GIFs or short videos showing key workflows (init, sync, launch, skills) for embedding in documentation and README.
-
-### Task details
-- quickstart-guide
-  Description: Write a quickstart that takes a user from zero (no agent-layer installed) to productive (first agent launched and working) in clear, numbered steps. Cover macOS and Linux. Include what to expect at each step.
-  Acceptance criteria: Quickstart is published on the website and linked from README. A new user can follow it end-to-end without external help.
-- example-repos
-  Description: Create example `.agent-layer/` configurations that demonstrate common setups. Publish as a separate repository or as part of the docs site.
-  Acceptance criteria: At least 2 example configurations exist and are linked from quickstart/docs. Each example includes a README explaining the setup.
-- wizard-polish
-  Description: Identify friction points in `al init` and `al wizard` by walking through them as a first-time user. Reduce unnecessary prompts, improve default selections, and add inline help.
-  Acceptance criteria: First-time `al init` completes in fewer steps with better defaults. Wizard explains what each option does.
-  Progress: 2026-02-24 delivered a scoped wizard slice (Escape back-navigation with first-step exit confirmation, clearer back/cancel guidance on touched prompts, and warning when profile mode is replacing a TOML-corrupt existing config). 2026-05-07 split the MCP catalog out of the install seed (`internal/templates/mcp-catalog.toml`); fresh `al init` now ships zero `[[mcp.servers]]` blocks, and the interactive wizard prunes default-catalog entries the user disables (full prune — including hand-customized blocks). Profile-mode (`al wizard --profile X --yes`) is intentionally exempt from prune. Remaining phase scope still includes broader first-time `al init` flow reduction/default tuning.
-- error-audit
-  Description: Review all user-facing error messages in the CLI. Ensure each one is actionable (not just "error: failed").
-  Acceptance criteria: No error message leaves the user without a next step. Common errors include remediation commands.
-- demo-content
-  Description: Record short demos of key workflows for documentation.
-  Acceptance criteria: At least 3 demos exist (init, sync, launch) and are embedded in docs.
-
-### Exit criteria
-- Quickstart guide exists on the website and covers the full zero-to-productive flow.
-- At least 2 example repository configurations are published and linked.
-- `al init` and `al wizard` flows are audited and improved for first-time users.
-- CLI error messages are actionable across all commands.
-- Key workflows have visual demos in documentation.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/golangci/golangci-lint/v2 v2.10.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
-	github.com/pelletier/go-toml v1.9.5
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -169,6 +168,7 @@ require (
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -251,7 +251,7 @@ func CheckAgents(cfg *config.ProjectConfig) []Result {
 			})
 		} else {
 			results = append(results, Result{
-				Status:    StatusWarn,
+				Status:    StatusOK,
 				CheckName: messages.DoctorCheckNameAgents,
 				Message:   fmt.Sprintf(messages.DoctorAgentDisabledFmt, a.Name),
 			})

--- a/internal/doctor/checks_misc_test.go
+++ b/internal/doctor/checks_misc_test.go
@@ -188,13 +188,13 @@ func TestCheckAgents(t *testing.T) {
 	}
 
 	if statusMap["Agent enabled: Gemini"] != StatusOK {
-		t.Error("Gemini should be enabled")
+		t.Error("Gemini should be reported enabled with StatusOK")
 	}
-	if statusMap["Agent disabled: Claude"] != StatusWarn {
-		t.Error("Claude should be disabled")
+	if statusMap["Agent disabled: Claude"] != StatusOK {
+		t.Error("disabled agents should report StatusOK (informational, not a problem)")
 	}
-	if statusMap["Agent disabled: Codex"] != StatusWarn {
-		t.Error("Codex should be disabled (nil)")
+	if statusMap["Agent disabled: Codex"] != StatusOK {
+		t.Error("agent with nil enabled flag should report StatusOK")
 	}
 }
 

--- a/internal/wizard/patch.go
+++ b/internal/wizard/patch.go
@@ -14,7 +14,7 @@
 //  3. Key positioning: When clearing optional keys (like model=""), we convert them
 //     to commented lines rather than deleting them, preserving the template structure.
 //
-// The go-toml library is still used for syntax validation before processing.
+// The go-toml/v2 library is still used for syntax validation before processing.
 package wizard
 
 import (
@@ -23,9 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	// toml is used for syntax validation only; actual manipulation uses custom
-	// line-based parsing to preserve comments and formatting.
-	toml "github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/conn-castle/agent-layer/internal/messages"
 	"github.com/conn-castle/agent-layer/internal/templates"
@@ -63,7 +61,8 @@ var legacySectionAliases = map[string]string{
 // PatchConfig applies wizard choices to TOML config content.
 // content is the current config; choices holds selections; returns updated content or error.
 func PatchConfig(content string, choices *Choices) (string, error) {
-	if _, err := toml.LoadBytes([]byte(content)); err != nil {
+	var parseCheck map[string]any
+	if err := toml.Unmarshal([]byte(content), &parseCheck); err != nil {
 		return "", fmt.Errorf(messages.WizardParseConfigFailedFmt, err)
 	}
 
@@ -95,7 +94,8 @@ func PatchConfig(content string, choices *Choices) (string, error) {
 	}
 
 	rendered := strings.Join(output, "\n")
-	if _, err := toml.LoadBytes([]byte(rendered)); err != nil {
+	var renderCheck map[string]any
+	if err := toml.Unmarshal([]byte(rendered), &renderCheck); err != nil {
 		return "", fmt.Errorf(messages.WizardRenderConfigFailedFmt, err)
 	}
 

--- a/internal/wizard/patch_test.go
+++ b/internal/wizard/patch_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	toml "github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -516,6 +516,129 @@ func TestPatchConfig_RestoreMissingMCPServer(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, out, fmt.Sprintf(`id = "%s"`, serverID))
+}
+
+// TestPatchConfig_Idempotent asserts that PatchConfig is idempotent across
+// representative choice sets: re-applying the same Choices to its own output
+// must produce byte-equal output. A regression in any code path that mutates
+// based on the *current* document shape (rather than the touched-flag intent)
+// will cause the second pass to diverge from the first.
+func TestPatchConfig_Idempotent(t *testing.T) {
+	defaults, err := loadDefaultMCPServers()
+	require.NoError(t, err)
+	require.NotEmpty(t, defaults)
+
+	mcpToggle := NewChoices()
+	mcpToggle.EnabledMCPServersTouched = true
+	mcpToggle.EnabledMCPServers = map[string]bool{defaults[0].ID: true}
+	mcpToggle.DefaultMCPServers = defaults
+
+	restoreMCP := NewChoices()
+	restoreMCP.RestoreMissingMCPServers = true
+	restoreMCP.MissingDefaultMCPServers = []string{defaults[0].ID}
+	restoreMCP.DefaultMCPServers = defaults
+
+	cases := []struct {
+		name    string
+		content string
+		choices *Choices
+	}{
+		{
+			name:    "approval mode change",
+			content: "[approvals]\nmode = \"none\"\n",
+			choices: func() *Choices {
+				c := NewChoices()
+				c.ApprovalModeTouched = true
+				c.ApprovalMode = "all"
+				return c
+			}(),
+		},
+		{
+			name:    "enable agent",
+			content: "[agents.claude]\nenabled = false\n",
+			choices: func() *Choices {
+				c := NewChoices()
+				c.EnabledAgentsTouched = true
+				c.EnabledAgents = map[string]bool{AgentClaude: true}
+				return c
+			}(),
+		},
+		{
+			name:    "set codex model and reasoning",
+			content: "[agents.codex]\nenabled = true\n",
+			choices: func() *Choices {
+				c := NewChoices()
+				c.CodexModelTouched = true
+				c.CodexModel = "gpt-5"
+				c.CodexReasoningTouched = true
+				c.CodexReasoning = "high"
+				return c
+			}(),
+		},
+		{
+			name:    "codex apps toggle on",
+			content: "[agents.codex]\nenabled = true\n",
+			choices: func() *Choices {
+				c := NewChoices()
+				c.EnabledAgentsTouched = true
+				c.EnabledAgents = map[string]bool{AgentCodex: true}
+				c.CodexAppsTouched = true
+				c.CodexApps = true
+				return c
+			}(),
+		},
+		{
+			name:    "warnings enabled with thresholds",
+			content: "",
+			choices: func() *Choices {
+				c := NewChoices()
+				c.WarningsEnabledTouched = true
+				c.WarningsEnabled = true
+				c.InstructionTokenThreshold = 10000
+				c.MCPServerThreshold = 15
+				c.MCPToolsTotalThreshold = 60
+				c.MCPServerToolsThreshold = 25
+				c.MCPSchemaTokensTotalThreshold = 30000
+				c.MCPSchemaTokensServerThreshold = 20000
+				return c
+			}(),
+		},
+		{
+			name:    "warnings disabled removes section",
+			content: "[warnings]\ninstruction_token_threshold = 5000\n",
+			choices: func() *Choices {
+				c := NewChoices()
+				c.WarningsEnabledTouched = true
+				c.WarningsEnabled = false
+				return c
+			}(),
+		},
+		{
+			name:    "mcp server toggle",
+			content: "[mcp]\n",
+			choices: mcpToggle,
+		},
+		{
+			name:    "restore missing mcp server",
+			content: "[mcp]\n",
+			choices: restoreMCP,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first, err := PatchConfig(tc.content, tc.choices)
+			require.NoError(t, err, "first pass must succeed")
+
+			second, err := PatchConfig(first, tc.choices)
+			require.NoError(t, err, "second pass must succeed")
+
+			if first != second {
+				t.Fatalf("PatchConfig is not idempotent for %q\n--- first pass ---\n%s\n--- second pass ---\n%s",
+					tc.name, first, second)
+			}
+		})
+	}
 }
 
 func TestParseTomlDocument_EmptyContent(t *testing.T) {
@@ -1147,7 +1270,7 @@ args = [
 	assert.Contains(t, out, `url = "https://api.example.com"`)
 
 	// Verify the output is valid TOML by parsing it.
-	_, parseErr := toml.LoadBytes([]byte(out))
+	parseErr := toml.Unmarshal([]byte(out), &map[string]any{})
 	require.NoError(t, parseErr, "patched output must be valid TOML")
 }
 
@@ -1210,7 +1333,7 @@ headers."X-Tools" = "action_list"
 	assert.Contains(t, out, `command = "npx"`)
 
 	// Verify the output is valid TOML.
-	_, parseErr := toml.LoadBytes([]byte(out))
+	parseErr := toml.Unmarshal([]byte(out), &map[string]any{})
 	require.NoError(t, parseErr, "patched output must be valid TOML")
 }
 
@@ -1241,7 +1364,7 @@ env.PATH = "/usr/bin"
 	assert.Contains(t, out, `transport = "http"`)
 	assert.Contains(t, out, `url = "https://api.example.com"`)
 
-	_, parseErr := toml.LoadBytes([]byte(out))
+	parseErr := toml.Unmarshal([]byte(out), &map[string]any{})
 	require.NoError(t, parseErr, "patched output must be valid TOML")
 }
 


### PR DESCRIPTION
## Summary
- Migrate `internal/wizard/patch.go` syntax-validation from `pelletier/go-toml` v1 to v2 (v1 stays as an indirect dep via golangci-lint); add `TestPatchConfig_Idempotent` covering approvals, agent enable, codex model/reasoning, codex apps, warnings on/off, and MCP toggle/restore.
- `internal/doctor`: report disabled agents as `StatusOK` (informational) instead of `StatusWarn` — a disabled agent is a deliberate user choice, not a problem.
- Hygiene: `.gitignore` now covers `/.antigravitycli/` and `/.agy-cfg/` alongside other agent-generated directories.
- Memory: prune resolved BACKLOG/ISSUES entries, fold durable details from DECISIONS.md into CONTEXT.md (decisions log shrinks ~150 lines), reorder ROADMAP so onboarding (Phase 16) precedes profiles (Phase 17). Add `docs/SKILL-DESIGN.md` cross-reference to `docs/INSTRUCTION-DESIGN.md`.

## Test plan
- [x] `go test ./...` (run via pre-commit hook)
- [x] `golangci-lint` (run via pre-commit hook)
- [x] `go mod tidy` clean (run via pre-commit hook)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded agent-layer operational guidance with memory conventions and tool behaviors
  * Clarified skill authoring documentation relationships
  * Updated project roadmap phases and decision log
  * Resolved reported CLI color handling issue

* **Bug Fixes**
  * Improved agent status reporting accuracy for disabled agents

* **Tests**
  * Added configuration validation and idempotency tests

* **Chores**
  * Updated dependency management and build configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/conn-castle/agent-layer/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->