### PR TITLE
feat: add al --quiet doctor and skill catalog size warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ env = { MY_TOKEN = "${AL_MY_TOKEN}" }
 version_update_on_sync = true
 # Warning output noise control: "default" keeps all warnings, "reduce" hides suppressible non-critical warnings,
 # "quiet" suppresses agent-layer informational output (warnings, update checks, dispatch banners). Configured
-# quiet does not hide `al doctor` output; pass `--quiet` to a doctor run to suppress warning-only notifications.
+# quiet does not hide `al doctor` output; use `al --quiet doctor` to suppress warning-only doctor output.
 noise_mode = "default"
 instruction_token_threshold = 10000
 mcp_server_threshold = 15

--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ env = { MY_TOKEN = "${AL_MY_TOKEN}" }
 # Warn when a newer Agent Layer version is available during sync runs.
 version_update_on_sync = true
 # Warning output noise control: "default" keeps all warnings, "reduce" hides suppressible non-critical warnings,
-# "quiet" suppresses agent-layer informational output (warnings, update checks, dispatch banners). `al doctor`
-# always prints warnings regardless of this setting.
+# "quiet" suppresses agent-layer informational output (warnings, update checks, dispatch banners). Configured
+# quiet does not hide `al doctor` output; pass `--quiet` to a doctor run to suppress warning-only notifications.
 noise_mode = "default"
 instruction_token_threshold = 10000
 mcp_server_threshold = 15
@@ -439,7 +439,7 @@ Omit `http_transport` to default to `sse`.
 Warning thresholds are optional. When a threshold is omitted, its warning is disabled. Values must be positive integers (zero/negative are rejected by config validation). `al sync` uses `instruction_token_threshold` and, when `version_update_on_sync = true`, warns if a newer Agent Layer release is available. `al doctor` evaluates all configured MCP warning thresholds.
 
 Set `version_update_on_sync = true` to opt in to update warnings during `al sync` and `al <client>`; omit it or set it to `false` to keep update warnings limited to `al init`, `al doctor`, and `al wizard`.
-Set `noise_mode = "default"` to keep all warnings (recommended), `noise_mode = "reduce"` to hide only suppressible non-critical warnings, or `noise_mode = "quiet"` to suppress agent-layer informational output. Errors still print, client output is unaffected, and `al doctor` always prints warnings regardless of noise mode.
+Set `noise_mode = "default"` to keep all warnings (recommended), `noise_mode = "reduce"` to hide only suppressible non-critical warnings, or `noise_mode = "quiet"` to suppress agent-layer informational output. Errors still print, client output is unaffected, and `al doctor` prints warnings by default regardless of noise mode. For one-off doctor runs, `al --quiet doctor` suppresses warning-only doctor output while still showing failures.
 
 Use `al <client> --quiet` (or `-q`) for one-off quiet runs; the flag always wins over config.
 
@@ -492,7 +492,8 @@ Agent Layer aligns with the [Agent Skills specification](https://agentskills.io/
 - `name` validation (`al doctor`):
   - NFKC-normalized and compared against the canonical source name (filename stem or directory name) using normalization-aware matching
   - Maximum 64 Unicode characters, lowercase letters/digits/hyphens only, and no leading/trailing/consecutive hyphens
-- Length limits (`al doctor`): `description` max 1024 Unicode characters; `compatibility` max 500 Unicode characters.
+- Length warnings (`al doctor`): `description` max 1024 Unicode characters per skill; `compatibility` max 500 Unicode characters.
+- Catalog warning (`al doctor`): all skill names plus descriptions should stay at or below 10,000 Unicode characters.
 - Size recommendation (`al doctor`): warns when a skill source exceeds 500 lines.
 - Backward compatibility: skills with missing `name` still load (name derived from path), but `al doctor` warns.
 - Missing or empty `description` is a load/sync error (fail-loud); it is not warning-only.

--- a/cmd/al/doctor.go
+++ b/cmd/al/doctor.go
@@ -147,7 +147,7 @@ func newDoctorCmd() *cobra.Command {
 				warningList = warnings.ApplyNoiseControl(warningList, noiseMode)
 			}
 
-			if len(warningList) > 0 {
+			if len(warningList) > 0 && !quiet {
 				for _, w := range warningList {
 					_, _ = fmt.Fprintln(out, w.String())
 					_, _ = fmt.Fprintln(out) // Spacer

--- a/cmd/al/doctor.go
+++ b/cmd/al/doctor.go
@@ -31,6 +31,7 @@ func newDoctorCmd() *cobra.Command {
 		Short: messages.DoctorShort,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
+			quiet, _ := cmd.Flags().GetBool("quiet")
 			root, err := resolveRepoRoot()
 			if err != nil {
 				return err
@@ -94,6 +95,9 @@ func newDoctorCmd() *cobra.Command {
 
 			hasFail := false
 			for _, r := range allResults {
+				if quiet && r.Status == doctor.StatusWarn {
+					continue
+				}
 				printResult(out, r)
 				if r.Status == doctor.StatusFail {
 					hasFail = true
@@ -104,7 +108,9 @@ func newDoctorCmd() *cobra.Command {
 			// Only run if basic config loaded successfully, otherwise we might crash or be useless.
 			var warningList []warnings.Warning
 			if cfg != nil {
-				_, _ = fmt.Fprintln(out, messages.DoctorWarningSystemHeader)
+				if !quiet {
+					_, _ = fmt.Fprintln(out, messages.DoctorWarningSystemHeader)
+				}
 
 				// Instructions check
 				instWarnings, err := checkInstructions(root, cfg.Config.Warnings.InstructionTokenThreshold)
@@ -117,7 +123,11 @@ func newDoctorCmd() *cobra.Command {
 
 				// MCP check (Doctor runs discovery)
 				enabledServerIDs := enabledMCPServerIDs(cfg.Config.MCP.Servers)
-				reportProgress, stopProgress := startMCPDiscoveryReporter(enabledServerIDs, out)
+				progressOut := out
+				if quiet {
+					progressOut = io.Discard
+				}
+				reportProgress, stopProgress := startMCPDiscoveryReporter(enabledServerIDs, progressOut)
 				mcpWarnings, err := checkMCPServers(cmd.Context(), cfg, nil, reportProgress)
 				stopProgress()
 				if err != nil {
@@ -129,7 +139,9 @@ func newDoctorCmd() *cobra.Command {
 
 				warningList = append(warningList, checkPolicy(cfg)...)
 				noiseMode := cfg.Config.Warnings.NoiseMode
-				if strings.EqualFold(strings.TrimSpace(noiseMode), warnings.NoiseModeQuiet) {
+				if quiet {
+					noiseMode = warnings.NoiseModeQuiet
+				} else if strings.EqualFold(strings.TrimSpace(noiseMode), warnings.NoiseModeQuiet) {
 					noiseMode = warnings.NoiseModeDefault
 				}
 				warningList = warnings.ApplyNoiseControl(warningList, noiseMode)

--- a/cmd/al/root_doctor_test.go
+++ b/cmd/al/root_doctor_test.go
@@ -350,6 +350,74 @@ instruction_token_threshold = 1
 	}
 }
 
+func TestDoctorCommand_QuietFlagSuppressesWarningNotifications(t *testing.T) {
+	root := t.TempDir()
+	writeDoctorTestRepoWithWarnings(t, root)
+	calls := stubUpdateCheck(t, update.CheckResult{Current: "1.0.0", Latest: "2.0.0", Outdated: true}, nil)
+
+	skillDir := filepath.Join(root, ".agent-layer", "skills", "alpha")
+	if err := os.MkdirAll(skillDir, 0o700); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	skillContent := `---
+description: test
+---
+Body.
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o600); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	var out bytes.Buffer
+	testutil.WithWorkingDir(t, root, func() {
+		cmd := newRootCmd()
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{"--quiet", "doctor"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("doctor --quiet failed: %v\noutput:\n%s", err, out.String())
+		}
+	})
+
+	output := out.String()
+	if strings.Contains(output, "[WARN]") {
+		t.Fatalf("expected --quiet to suppress warning results, got:\n%s", output)
+	}
+	if strings.Contains(output, "WARNING INSTRUCTIONS_TOO_LARGE") {
+		t.Fatalf("expected --quiet to suppress warning-system output, got:\n%s", output)
+	}
+	if strings.Contains(output, messages.DoctorWarningSystemHeader) {
+		t.Fatalf("expected --quiet to suppress warning-system header, got:\n%s", output)
+	}
+	if *calls == 0 {
+		t.Fatal("expected update check to run")
+	}
+}
+
+func TestDoctorCommand_QuietFlagPreservesFailures(t *testing.T) {
+	root := t.TempDir()
+	writeTestRepoInvalidConfig(t, root)
+	calls := stubUpdateCheck(t, update.CheckResult{Current: "1.0.0", Latest: "1.0.0"}, nil)
+
+	var out bytes.Buffer
+	var execErr error
+	testutil.WithWorkingDir(t, root, func() {
+		cmd := newRootCmd()
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{"--quiet", "doctor"})
+		execErr = cmd.Execute()
+	})
+
+	if execErr == nil {
+		t.Fatalf("expected --quiet doctor to return non-nil error on FAIL; output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), messages.DoctorStatusFailLabel) {
+		t.Fatalf("expected --quiet to preserve %q in output, got:\n%s", messages.DoctorStatusFailLabel, out.String())
+	}
+	if *calls == 0 {
+		t.Fatal("expected update check to run")
+	}
+}
+
 func TestDoctorCommand_InstructionsError(t *testing.T) {
 	root := t.TempDir()
 	writeDoctorTestRepo(t, root)

--- a/docs/SKILL-DESIGN.md
+++ b/docs/SKILL-DESIGN.md
@@ -54,6 +54,8 @@ explicitly labeled as a local heuristic.
   into `scripts/`, `references/`, and `assets`.
 - At the catalog level, each skill adds roughly 50-100 tokens (name +
   description only) [ref 1]. Full instructions load only on activation.
+- `al doctor` warns when all skill names plus descriptions exceed a 10,000
+  Unicode-character budget.
 - `al doctor` warns when a skill source exceeds 500 lines.
 - Treat 500 lines as a warning threshold, not a design target.
 

--- a/docs/agent-layer/DECISIONS.md
+++ b/docs/agent-layer/DECISIONS.md
@@ -63,7 +63,7 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Tradeoffs: Disabled by default means no isolation unless configured. Claude Code stores auth in the OS credential store regardless of `CLAUDE_CONFIG_DIR` (upstream limitation), so `local_config_dir` currently isolates settings and caches but not auth.
 
 - Decision 2026-02-24 quiet-supersedes-p7a: Warnings verbosity policy (`reduce`, `quiet`, and `--quiet`)
-    Decision: `warnings.noise_mode` supports `reduce` and `quiet`, and `--quiet`/`-q` provides command-line suppression. `reduce` suppresses only non-critical suppressible warnings; `quiet` suppresses all warnings (including critical) except `al doctor`, which always prints warnings.
+    Decision: `warnings.noise_mode` supports `reduce` and `quiet`, and `--quiet`/`-q` provides command-line suppression. `reduce` suppresses only non-critical suppressible warnings. Configured `quiet` suppresses warnings, update checks, and dispatch banners for normal runs, while `al doctor` still prints warnings by default; an explicit `al --quiet doctor` suppresses warning-only doctor output while preserving failure output.
     Reason: Users need one coherent verbosity model that serves both safer daily use (`reduce`) and zero-noise scripted flows (`quiet`/`--quiet`).
     Tradeoffs: Quiet mode can hide high-risk warnings by design, and older pinned binaries may ignore quiet behavior until upgraded.
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
@@ -29,6 +30,8 @@ var (
 
 const antigravityVersionTimeout = 5 * time.Second
 const antigravityVersionWaitDelay = 100 * time.Millisecond
+
+const maxSkillCatalogMetadataChars = 10000
 
 func commandOutputWithTimeout(timeout time.Duration, name string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -502,6 +505,16 @@ func CheckSkills(cfg *config.ProjectConfig) []Result {
 		}
 	}
 
+	catalogChars := skillCatalogMetadataChars(skills)
+	if catalogChars > maxSkillCatalogMetadataChars {
+		results = append(results, Result{
+			Status:         StatusWarn,
+			CheckName:      messages.DoctorCheckNameSkills,
+			Message:        fmt.Sprintf(messages.DoctorSkillCatalogTooLargeFmt, maxSkillCatalogMetadataChars, catalogChars, len(skills)),
+			Recommendation: messages.DoctorSkillValidationRecommend,
+		})
+	}
+
 	if len(results) > 0 {
 		return results
 	}
@@ -510,6 +523,15 @@ func CheckSkills(cfg *config.ProjectConfig) []Result {
 		CheckName: messages.DoctorCheckNameSkills,
 		Message:   fmt.Sprintf(messages.DoctorSkillsValidatedFmt, len(skills)),
 	}}
+}
+
+func skillCatalogMetadataChars(skills []config.Skill) int {
+	total := 0
+	for _, skill := range skills {
+		total += utf8.RuneCountInString(strings.TrimSpace(skill.Name))
+		total += utf8.RuneCountInString(strings.TrimSpace(skill.Description))
+	}
+	return total
 }
 
 func relPathForDoctor(root string, path string) string {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -505,7 +505,11 @@ func CheckSkills(cfg *config.ProjectConfig) []Result {
 		}
 	}
 
-	catalogChars := skillCatalogMetadataChars(skills)
+	catalogChars := 0
+	for _, skill := range skills {
+		catalogChars += utf8.RuneCountInString(strings.TrimSpace(skill.Name))
+		catalogChars += utf8.RuneCountInString(strings.TrimSpace(skill.Description))
+	}
 	if catalogChars > maxSkillCatalogMetadataChars {
 		results = append(results, Result{
 			Status:         StatusWarn,
@@ -523,15 +527,6 @@ func CheckSkills(cfg *config.ProjectConfig) []Result {
 		CheckName: messages.DoctorCheckNameSkills,
 		Message:   fmt.Sprintf(messages.DoctorSkillsValidatedFmt, len(skills)),
 	}}
-}
-
-func skillCatalogMetadataChars(skills []config.Skill) int {
-	total := 0
-	for _, skill := range skills {
-		total += utf8.RuneCountInString(strings.TrimSpace(skill.Name))
-		total += utf8.RuneCountInString(strings.TrimSpace(skill.Description))
-	}
-	return total
 }
 
 func relPathForDoctor(root string, path string) string {

--- a/internal/doctor/checks_misc_test.go
+++ b/internal/doctor/checks_misc_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
@@ -642,6 +643,37 @@ func TestCheckSkills_CatalogMetadataOneOverBoundaryWarns(t *testing.T) {
 	}
 	if catalogWarns[0].Status != StatusWarn {
 		t.Fatalf("status = %s, want %s (%#v)", catalogWarns[0].Status, StatusWarn, catalogWarns[0])
+	}
+}
+
+// TestCheckSkills_CatalogMetadataMultibyteRuneBoundary locks the rune-count
+// semantics of catalog metadata sizing. A description of 9,995 `界` runes plus
+// a 5-rune name sums to exactly 10,000 runes (no warn) but 29,990 bytes (would
+// warn if `len()` were used instead of `utf8.RuneCountInString`).
+func TestCheckSkills_CatalogMetadataMultibyteRuneBoundary(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".agent-layer", "skills", "alpha")
+	if err := os.MkdirAll(skillsDir, 0o700); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	name := "alpha"
+	description := strings.Repeat("界", maxSkillCatalogMetadataChars-utf8.RuneCountInString(name))
+	skillPath := filepath.Join(skillsDir, "SKILL.md")
+	content := fmt.Sprintf("---\nname: %s\ndescription: %s\n---\nBody.\n", name, description)
+	if err := os.WriteFile(skillPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	results := CheckSkills(&config.ProjectConfig{
+		Root: root,
+		Skills: []config.Skill{
+			{Name: name, Description: description, SourcePath: skillPath},
+		},
+	})
+	for _, result := range results {
+		if strings.Contains(result.Message, "Skill catalog metadata exceeds") {
+			t.Fatalf("expected no catalog-size warning at multibyte-rune boundary, got: %#v", result)
+		}
 	}
 }
 

--- a/internal/doctor/checks_misc_test.go
+++ b/internal/doctor/checks_misc_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
+	"github.com/conn-castle/agent-layer/internal/skillvalidator"
 )
 
 func TestCheckConfig_LenientFallback_InjectsBuiltInEnv_NoEnvFile(t *testing.T) {
@@ -504,6 +505,143 @@ Body.
 		if result.CheckName != messages.DoctorCheckNameSkills {
 			t.Fatalf("check name = %q, want %q", result.CheckName, messages.DoctorCheckNameSkills)
 		}
+	}
+}
+
+func TestCheckSkills_DescriptionTooLongWarns(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".agent-layer", "skills")
+	if err := os.MkdirAll(filepath.Join(skillsDir, "alpha"), 0o700); err != nil {
+		t.Fatalf("mkdir skills: %v", err)
+	}
+	skillPath := filepath.Join(skillsDir, "alpha", "SKILL.md")
+	description := strings.Repeat("a", skillvalidator.MaxDescriptionLength+1)
+	content := `---
+name: alpha
+description: ` + description + `
+---
+Body.
+`
+	if err := os.WriteFile(skillPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	cfg := &config.ProjectConfig{
+		Root: root,
+		Skills: []config.Skill{
+			{Name: "alpha", Description: description, SourcePath: skillPath},
+		},
+	}
+	results := CheckSkills(cfg)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %#v", len(results), results)
+	}
+	if results[0].Status != StatusWarn {
+		t.Fatalf("status = %s, want %s (%#v)", results[0].Status, StatusWarn, results[0])
+	}
+	if !strings.Contains(results[0].Message, "description") || !strings.Contains(results[0].Message, "exceeds") {
+		t.Fatalf("unexpected message: %q", results[0].Message)
+	}
+}
+
+func TestCheckSkills_CatalogMetadataTooLargeWarns(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".agent-layer", "skills")
+	description := strings.Repeat("a", 910)
+	skills := make([]config.Skill, 0, 11)
+	for i := 0; i < 11; i++ {
+		name := fmt.Sprintf("skill-%02d", i)
+		skillDir := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(skillDir, 0o700); err != nil {
+			t.Fatalf("mkdir skill %s: %v", name, err)
+		}
+		skillPath := filepath.Join(skillDir, "SKILL.md")
+		content := fmt.Sprintf(`---
+name: %s
+description: %s
+---
+Body.
+`, name, description)
+		if err := os.WriteFile(skillPath, []byte(content), 0o600); err != nil {
+			t.Fatalf("write skill %s: %v", name, err)
+		}
+		skills = append(skills, config.Skill{Name: name, Description: description, SourcePath: skillPath})
+	}
+
+	results := CheckSkills(&config.ProjectConfig{Root: root, Skills: skills})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %#v", len(results), results)
+	}
+	if results[0].Status != StatusWarn {
+		t.Fatalf("status = %s, want %s (%#v)", results[0].Status, StatusWarn, results[0])
+	}
+	if !strings.Contains(results[0].Message, "Skill catalog metadata exceeds") {
+		t.Fatalf("unexpected message: %q", results[0].Message)
+	}
+}
+
+// writeCatalogBoundarySkills writes ten directory-format skills whose names
+// ("alpha0".."alpha9", 6 chars each) and per-skill description lengths add
+// up to a precise catalog metadata character count. descLengths must have
+// length 10. Returns the config.Skill slice the caller can pass to
+// CheckSkills along with a *config.ProjectConfig{Root: root, ...}.
+func writeCatalogBoundarySkills(t *testing.T, root string, descLengths [10]int) []config.Skill {
+	t.Helper()
+	skillsDir := filepath.Join(root, ".agent-layer", "skills")
+	skills := make([]config.Skill, 0, 10)
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("alpha%d", i)
+		description := strings.Repeat("a", descLengths[i])
+		skillDir := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(skillDir, 0o700); err != nil {
+			t.Fatalf("mkdir skill %s: %v", name, err)
+		}
+		skillPath := filepath.Join(skillDir, "SKILL.md")
+		content := fmt.Sprintf(`---
+name: %s
+description: %s
+---
+Body.
+`, name, description)
+		if err := os.WriteFile(skillPath, []byte(content), 0o600); err != nil {
+			t.Fatalf("write skill %s: %v", name, err)
+		}
+		skills = append(skills, config.Skill{Name: name, Description: description, SourcePath: skillPath})
+	}
+	return skills
+}
+
+func TestCheckSkills_CatalogMetadataAtBoundaryNoWarn(t *testing.T) {
+	root := t.TempDir()
+	// 10 skills * (6-char name + 994-char description) = 10,000 chars exactly.
+	descLengths := [10]int{994, 994, 994, 994, 994, 994, 994, 994, 994, 994}
+	skills := writeCatalogBoundarySkills(t, root, descLengths)
+
+	results := CheckSkills(&config.ProjectConfig{Root: root, Skills: skills})
+	for _, result := range results {
+		if strings.Contains(result.Message, "Skill catalog metadata exceeds") {
+			t.Fatalf("expected no catalog-size warning at boundary, got: %#v", result)
+		}
+	}
+}
+
+func TestCheckSkills_CatalogMetadataOneOverBoundaryWarns(t *testing.T) {
+	root := t.TempDir()
+	// 9 skills * (6 + 994) + 1 skill * (6 + 995) = 9,000 + 1,001 = 10,001 chars.
+	descLengths := [10]int{995, 994, 994, 994, 994, 994, 994, 994, 994, 994}
+	skills := writeCatalogBoundarySkills(t, root, descLengths)
+
+	results := CheckSkills(&config.ProjectConfig{Root: root, Skills: skills})
+	var catalogWarns []Result
+	for _, result := range results {
+		if strings.Contains(result.Message, "Skill catalog metadata exceeds") {
+			catalogWarns = append(catalogWarns, result)
+		}
+	}
+	if len(catalogWarns) != 1 {
+		t.Fatalf("expected exactly 1 catalog-size warn at boundary+1, got %d: %#v", len(catalogWarns), results)
+	}
+	if catalogWarns[0].Status != StatusWarn {
+		t.Fatalf("status = %s, want %s (%#v)", catalogWarns[0].Status, StatusWarn, catalogWarns[0])
 	}
 }
 

--- a/internal/messages/doctor.go
+++ b/internal/messages/doctor.go
@@ -49,6 +49,7 @@ const (
 	DoctorSkillValidationRecommend = "Update skill frontmatter/path conventions in .agent-layer/skills to match agentskills.io recommendations."
 	DoctorSkillValidationFailedFmt = "Failed to validate skill %s: %v"
 	DoctorSkillsLoadFailedFmt      = "Failed to load skills from %s: %v"
+	DoctorSkillCatalogTooLargeFmt  = "Skill catalog metadata exceeds %d characters (%d across %d skills)"
 
 	DoctorCheckNameFlatSkills = "FlatSkills"
 

--- a/internal/templates/config.toml
+++ b/internal/templates/config.toml
@@ -86,7 +86,8 @@ enabled = true
 version_update_on_sync = true
 # warning noise mode: default | reduce | quiet
 # quiet suppresses agent-layer informational output (warnings, update checks, dispatch banners),
-# but does not affect `al doctor` (doctor always prints warnings).
+# but configured quiet does not affect `al doctor`; pass `--quiet` to a doctor run
+# to suppress warning-only doctor output.
 noise_mode = "default"
 instruction_token_threshold = 10000
 mcp_server_threshold = 15

--- a/internal/templates/config.toml
+++ b/internal/templates/config.toml
@@ -86,7 +86,7 @@ enabled = true
 version_update_on_sync = true
 # warning noise mode: default | reduce | quiet
 # quiet suppresses agent-layer informational output (warnings, update checks, dispatch banners),
-# but configured quiet does not affect `al doctor`; pass `--quiet` to a doctor run
+# but configured quiet does not affect `al doctor`; use `al --quiet doctor`
 # to suppress warning-only doctor output.
 noise_mode = "default"
 instruction_token_threshold = 10000


### PR DESCRIPTION
## Summary

- `al --quiet doctor` suppresses warning-only doctor output (per-finding `[WARN]` rows, the warning-system header, MCP discovery progress text, and the noise-mode-driven warning list); failure output and the update check still print. Quiet-mode also collapses the warning-derived exit 1 so the flag has clean "fail-only" CI-gate semantics.
- New `CheckSkills` warning when the sum of skill names + descriptions exceeds 10,000 Unicode characters, surfacing catalog bloat that would inflate every model invocation. Budget is documented in `docs/SKILL-DESIGN.md`.

## Test plan

- [x] `go test ./cmd/al/... ./internal/doctor/...` — all green
- [x] `make ci` — full local CI lane (tidy-check + fmt-check + lint + coverage + release tests + e2e harness + 596-test e2e suite + docs CTA) — all green
- [x] New tests cover: warning suppression under `--quiet`, failure preservation under `--quiet`, per-skill description-too-long path, catalog over-budget path, and the boundary at exactly 10,000 vs 10,001 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `al --quiet doctor` now suppresses warning-only output while still showing failures.
  * Doctor now warns if combined skill names+descriptions exceed a configured character budget.

* **Documentation**
  * Clarified how `noise_mode`/quiet settings interact with normal runs and `al doctor` behavior.
  * Added guidance on the skill catalog character budget.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/conn-castle/agent-layer/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->