### PR TITLE
feat(macos): attribute agent permission prompts and sign release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,18 @@ permissions:
 
 jobs:
   build-release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: |
+          set -euo pipefail
+          if ! command -v rg >/dev/null 2>&1; then
+            brew install ripgrep
+          fi
       - name: Validate stable release tag format
         run: |
           set -euo pipefail
@@ -30,10 +34,26 @@ jobs:
         run: |
           set -euo pipefail
           make docs-upgrade-check RELEASE_TAG="${GITHUB_REF_NAME}"
+      - name: Import Developer ID cert
+        uses: Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CERT_P12_PASSWORD }}
       - name: Build release artifacts
+        env:
+          AL_CODESIGN_IDENTITY: "Developer ID Application: Hardware Breakout LLC (DQCZX59J6D)"
+          AL_REQUIRE_CODESIGN: "1"
         run: |
           set -euo pipefail
           make release-dist AL_VERSION="${GITHUB_REF_NAME}" DIST_DIR=dist
+      - name: Notarize darwin binaries
+        env:
+          NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_API_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_API_KEY_ISSUER_ID }}
+          NOTARY_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          scripts/notarize-release.sh
 
       - name: Upload dist artifacts for downstream jobs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -198,43 +218,40 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: homebrew-tap
 
-      - name: Verify release tarball is available
+      - name: Verify release assets are available
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           SEMVER="${TAG#v}"
-          TARBALL="agent-layer-${SEMVER}.tar.gz"
-          URL="https://github.com/conn-castle/agent-layer/releases/download/${TAG}/${TARBALL}"
+          ASSETS=(
+            "agent-layer-${SEMVER}.tar.gz"
+            "al-darwin-arm64"
+            "al-linux-arm64"
+            "al-linux-amd64"
+          )
 
-          # Retry a few times in case GitHub is briefly eventual-consistent
-          for i in 1 2 3 4 5; do
-            if curl -fsIL "$URL" >/dev/null; then
-              exit 0
-            fi
-            sleep 3
+          for asset in "${ASSETS[@]}"; do
+            URL="https://github.com/conn-castle/agent-layer/releases/download/${TAG}/${asset}"
+            # Retry a few times in case GitHub is briefly eventual-consistent
+            for i in 1 2 3 4 5; do
+              if curl -fsIL "$URL" >/dev/null; then
+                continue 2
+              fi
+              sleep 3
+            done
+
+            echo "::error::Release asset not reachable: $URL"
+            exit 1
           done
 
-          echo "::error::Release asset not reachable: $URL"
-          exit 1
-
-      - name: Update formula url + sha256
+      - name: Update binary formula
         run: |
           set -euo pipefail
 
           TAG="${GITHUB_REF_NAME}"
-          SEMVER="${TAG#v}"
-          TARBALL="agent-layer-${SEMVER}.tar.gz"
-          URL="https://github.com/conn-castle/agent-layer/releases/download/${TAG}/${TARBALL}"
 
           if [ ! -f "dist/checksums.txt" ]; then
             echo "::error::dist/checksums.txt not found in workflow artifacts"
-            exit 1
-          fi
-
-          SHA="$(go run -tags tools ./internal/tools/extractchecksum dist/checksums.txt "${TARBALL}")"
-
-          if [ -z "${SHA}" ]; then
-            echo "::error::Failed to locate sha256 for ${TARBALL} in dist/checksums.txt"
             exit 1
           fi
 
@@ -244,7 +261,7 @@ jobs:
             exit 1
           fi
 
-          go run -tags tools ./internal/tools/updateformula "${FORMULA}" "${URL}" "${SHA}"
+          go run -tags tools ./internal/tools/updateformula "${FORMULA}" "${TAG}" dist/checksums.txt
 
           git -C homebrew-tap status --porcelain
           git -C homebrew-tap diff -- Formula/agent-layer.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+- Darwin release binaries are now Developer ID signed with hardened runtime and notarized in the release workflow. The install script and Homebrew formula both deliver the signed macOS binary.
+
 ### Changed
+- `al claude`, `al codex`, `al copilot`, and `al agy` now replace the `al` process with the agent CLI instead of spawning a child process. Agent exit codes now pass through directly and the old `Error: <agent> exited with error: ...` wrapper line is gone, matching the behavior of running the agent directly.
+- Homebrew installs now use prebuilt release binaries for macOS and Linux instead of building from the source tarball.
+- macOS users may see one permission prompt per agent after upgrading because permissions move from `al` to the actual agent binary. Old `al` entries in Privacy & Security are cosmetic.
 - `al wizard` no longer offers a workflow-bundle refresh when Agent Layer workflow files already exist. The workflow-bundle prompt is install-only for missing bundle files and preserves existing files; use `al upgrade` when you want managed workflow updates.
 - Claude model selection now includes `fable` in the built-in catalog.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -54,8 +54,8 @@ CI validates both manifests exist via `make docs-upgrade-check RELEASE_TAG=<tag>
 ## GitHub release (automatic)
 1. Tag push triggers the release workflow.
 2. The workflow validates upgrade-contract docs for the tag (`make docs-upgrade-check RELEASE_TAG=<tag>`), ensuring a matching migration-table row exists, blocking placeholder migration text when changelog notes breaking/manual migration impact, verifying the migration manifest and template ownership manifest exist, and enforcing upgrade CTA syntax drift checks in core docs/message surfaces.
-3. The workflow publishes `al-install.sh`, macOS/Linux platform binaries, `agent-layer-<version>.tar.gz` (source tarball; version without leading `v`), and `checksums.txt`.
-4. The workflow opens a PR against `conn-castle/homebrew-tap` to update `Formula/agent-layer.rb` with the new tarball URL + SHA256.
+3. The workflow imports the Developer ID certificate, builds release artifacts on macOS, signs the darwin binaries, writes checksums after signing, notarizes the darwin binaries, and publishes `al-install.sh`, macOS/Linux platform binaries, `agent-layer-<version>.tar.gz` (source tarball; version without leading `v`), and `checksums.txt`.
+4. The workflow opens a PR against `conn-castle/homebrew-tap` to render `Formula/agent-layer.rb` as a binary formula using the published macOS/Linux release assets and their SHA256 values.
 5. The workflow publishes website content by pushing directly to `conn-castle/agent-layer-web` on `main`. This is mandatory; the release fails if `cmd/publish-site/main.go` or `site/` is missing, or if the published Docusaurus site does not build.
 6. Release notes are automatically extracted from `CHANGELOG.md` by the workflow.
 
@@ -87,6 +87,13 @@ make website-build-check SITE_BUILD_TAG=v0.0.0 WEBSITE_REPO_DIR=agent-layer-web
 Required secrets for the tap PR:
 - `HOMEBREW_TAP_APP_ID`
 - `HOMEBREW_TAP_PRIVATE_KEY`
+
+Required secrets for darwin signing and notarization:
+- `MACOS_CERT_P12_BASE64`
+- `MACOS_CERT_P12_PASSWORD`
+- `MACOS_NOTARY_API_KEY_ID`
+- `MACOS_NOTARY_API_KEY_ISSUER_ID`
+- `MACOS_NOTARY_API_KEY_P8_BASE64`
 
 Required secrets for the website publish:
 - `AGENT_LAYER_WEB_APP_ID`

--- a/docs/agent-layer/COMMANDS.md
+++ b/docs/agent-layer/COMMANDS.md
@@ -274,4 +274,4 @@ make release-dist AL_VERSION=dev DIST_DIR=dist
 ```
 Run from: repo root
 Prerequisites: Go 1.26.0+, git, gzip, tar, `sha256sum` or `shasum`
-Notes: Runs `test-release` first to validate release scripts.
+Notes: Runs `test-release` first to validate release scripts. Local builds stay unsigned unless `AL_CODESIGN_IDENTITY` is set on macOS; `AL_REQUIRE_CODESIGN=1` fails if signing cannot run.

--- a/docs/agent-layer/DECISIONS.md
+++ b/docs/agent-layer/DECISIONS.md
@@ -166,3 +166,8 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Decision: `al sync` patches only known Agent Layer-owned Codex entries in `.codex/config.toml`, preserves unrelated Codex/user runtime entries, and seeds current repo project trust only when the exact project entry is absent.
     Reason: Codex writes durable runtime/project state into the same file Agent Layer must refresh for model, approval, statusline, feature toggles, and MCP projection.
     Tradeoffs: Invalid existing TOML and shape conflicts now block sync instead of being overwritten; arbitrary removed passthrough paths outside known Agent Layer-owned paths may require manual cleanup.
+
+- Decision 2026-07-02 cli-exec-handoff-signing: Agent launch exec handoff plus signed binary delivery
+    Decision: Interactive CLI launchers (`al claude`, `al codex`, `al copilot`, `al agy`) replace `al` with the target agent via `syscall.Exec`; darwin release binaries are Developer ID signed/notarized as `com.conncastle.agent-layer`; Homebrew renders a binary formula for release assets instead of building from source.
+    Reason: macOS TCC/keychain prompts must attribute protected access to the actual agent binary, and grants should survive Agent Layer upgrades for install-script and Homebrew users.
+    Tradeoffs: Agent exit codes and stderr now pass through without Agent Layer's wrapper; users get a one-time permission prompt under each agent identity, while stale `al` grants remain cosmetic.

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,6 +27,12 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
+- Issue 2026-07-02 launcher-exec-capture-test-harness-duplication: Exec-capture test harness duplicated across four launcher packages
+    Priority: Low. Area: internal/clients/{claude,codex,copilotcli,antigravity}/launch_test.go
+    Description: `execCall`/`captureExec`/`forbidExec`/`assertExecCalled` (all over the identical `func(string, []string, []string) error` execFunc seam) are copied near-verbatim into each launcher's launch_test.go, ~50 lines per package. Flagged as CodeRabbit nitpicks on PR #130. Not a defect — the tests pass and cover behavior — but a maintainability trap: a change to the mock's behavior must be made in four places.
+    Next step: Extract a shared helper into `internal/testutil` (e.g. `CaptureExec(t, target *func(...)error, err error) *ExecCall`) that takes a pointer to the package-local execFunc var, and update the four launcher suites to use it.
+    Notes: Deferred from PR #130 (macOS signing / exec-handoff) as a cross-package test refactor outside that PR's scope.
+
 - Issue 2026-07-02 lint-ci-local-goconst-false-negative-darwin: `make lint-ci-local` misses goconst violations on macOS
     Priority: Medium. Area: Makefile (`lint-ci-local`) / CI-parity lint tooling; COMMANDS.md guidance
     Description: `make lint-ci-local` runs golangci-lint with GOOS=linux GOARCH=amd64 on a darwin host; cross-GOOS package loading drops the package's `_test.go` files from the analyzed fileset, so goconst's per-package string-occurrence counts fall below the threshold and real violations do not fire. This caused a false negative during PR #128: local `make dev` and `make lint-ci-local` both passed, but CI's `verify` (`make ci` -> `make lint`) failed on `goconst` in internal/sync/codex_config_merge.go. The documented "CI-parity" command is not faithful for occurrence-counting linters.

--- a/internal/clients/antigravity/launch.go
+++ b/internal/clients/antigravity/launch.go
@@ -18,6 +18,9 @@ const disableAutoUpdateEnv = "AGY_CLI_DISABLE_AUTO_UPDATE"
 // from PATH without manipulating the test process's actual PATH.
 var lookPathFunc = exec.LookPath
 
+// execFunc is overridable for tests; on success it never returns.
+var execFunc = clients.ExecHandoff
+
 // Launch starts Antigravity through agy with a repo-local --gemini_dir.
 func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs []string) error {
 	if !filepath.IsAbs(cfg.Root) {
@@ -45,16 +48,9 @@ func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs
 	args = append(args, passArgs...)
 	env = clients.SetEnv(env, disableAutoUpdateEnv, "1")
 
-	// #nosec G204 -- agyPath is resolved from lookPathFunc, the launcher's only entrypoint.
-	cmd := exec.Command(agyPath, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = env
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf(messages.ClientsAntigravityExitErrorFmt, err)
+	argv := append([]string{"agy"}, args...)
+	if err := execFunc(agyPath, argv, env); err != nil {
+		return fmt.Errorf(messages.ClientsExecHandoffErrorFmt, "antigravity", err)
 	}
-
 	return nil
 }

--- a/internal/clients/antigravity/launch_test.go
+++ b/internal/clients/antigravity/launch_test.go
@@ -1,36 +1,91 @@
 package antigravity
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/conn-castle/agent-layer/internal/clients"
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/run"
 	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
+type execCall struct {
+	called bool
+	path   string
+	argv   []string
+	env    []string
+}
+
+func captureExec(t *testing.T, err error) *execCall {
+	t.Helper()
+	original := execFunc
+	call := &execCall{}
+	execFunc = func(path string, argv []string, env []string) error {
+		if call.called {
+			t.Fatal("execFunc called more than once")
+		}
+		call.called = true
+		call.path = path
+		call.argv = append([]string(nil), argv...)
+		call.env = append([]string(nil), env...)
+		return err
+	}
+	t.Cleanup(func() { execFunc = original })
+	return call
+}
+
+func forbidExec(t *testing.T) {
+	t.Helper()
+	original := execFunc
+	execFunc = func(string, []string, []string) error {
+		t.Fatal("execFunc should not be called")
+		return nil
+	}
+	t.Cleanup(func() { execFunc = original })
+}
+
+func writeResolvableAgy(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	testutil.WriteStub(t, binDir, "agy")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return filepath.Join(binDir, "agy")
+}
+
+func assertExecCalled(t *testing.T, call *execCall, wantPath string, wantArgv []string) {
+	t.Helper()
+	if !call.called {
+		t.Fatal("expected execFunc to be called")
+	}
+	if call.path != wantPath {
+		t.Fatalf("expected exec path %q, got %q", wantPath, call.path)
+	}
+	if !reflect.DeepEqual(call.argv, wantArgv) {
+		t.Fatalf("unexpected argv: got %#v want %#v", call.argv, wantArgv)
+	}
+}
+
 func TestLaunchAntigravity(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	writeLoggingStub(t, binDir, "agy", 0)
+	agyPath := writeResolvableAgy(t)
+	call := captureExec(t, nil)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{},
 		Root:   root,
 	}
 
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	// Explicitly clear AGY_CLI_DISABLE_AUTO_UPDATE before Launch so the log
-	// assertion below proves Launch is what set it (not the test process's
-	// pre-existing environment).
-	t.Setenv("AGY_CLI_DISABLE_AUTO_UPDATE", "")
-	env := os.Environ()
+	env := []string{"PATH=" + filepath.Dir(agyPath), disableAutoUpdateEnv + "=0"}
 	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, []string{"--debug"}); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
+
 	expectedGeminiDir := filepath.Join(root, ".agy")
 	if info, err := os.Stat(expectedGeminiDir); err != nil {
 		t.Fatalf("expected repo-local gemini dir: %v", err)
@@ -38,32 +93,17 @@ func TestLaunchAntigravity(t *testing.T) {
 		t.Fatalf("expected %s to be a directory", expectedGeminiDir)
 	}
 
-	logData, err := os.ReadFile(filepath.Join(binDir, "agy.log")) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read agy log: %v", err)
-	}
-	log := string(logData)
-	if !strings.Contains(log, "--gemini_dir="+expectedGeminiDir) {
-		t.Fatalf("expected --gemini_dir arg in log, got:\n%s", log)
-	}
-	if !strings.Contains(log, "--debug") {
-		t.Fatalf("expected pass-through arg in log, got:\n%s", log)
-	}
-	if !strings.Contains(log, "AGY_CLI_DISABLE_AUTO_UPDATE=1") {
-		t.Fatalf("expected auto-update env disable in log, got:\n%s", log)
-	}
-	// Regression guard: default approvals mode must NOT pass
-	// --dangerously-skip-permissions to agy. Only Approvals.Mode == YOLO
-	// should opt the user out of permission prompts.
-	if strings.Contains(log, "--dangerously-skip-permissions") {
-		t.Fatalf("did not expect --dangerously-skip-permissions for default approvals, got:\n%s", log)
+	assertExecCalled(t, call, agyPath, []string{"agy", "--gemini_dir=" + expectedGeminiDir, "--debug"})
+	value, ok := clients.GetEnv(call.env, disableAutoUpdateEnv)
+	if !ok || value != "1" {
+		t.Fatalf("expected %s=1 in exec env, got %#v", disableAutoUpdateEnv, call.env)
 	}
 }
 
 func TestLaunchAntigravityYOLO(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	writeLoggingStub(t, binDir, "agy", 0)
+	agyPath := writeResolvableAgy(t)
+	call := captureExec(t, nil)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -72,42 +112,31 @@ func TestLaunchAntigravityYOLO(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("AGY_CLI_DISABLE_AUTO_UPDATE", "")
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, []string{"--debug"}); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{"PATH=" + filepath.Dir(agyPath)}, []string{"--debug"}); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
 
-	logData, err := os.ReadFile(filepath.Join(binDir, "agy.log")) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read agy log: %v", err)
-	}
-	log := string(logData)
-	if !strings.Contains(log, "--dangerously-skip-permissions") {
-		t.Fatalf("expected --dangerously-skip-permissions arg when Approvals.Mode=yolo, got:\n%s", log)
-	}
-	// passArgs must still be forwarded after the YOLO flag so user-supplied
-	// args are preserved.
-	if !strings.Contains(log, "--debug") {
-		t.Fatalf("expected pass-through arg in log, got:\n%s", log)
-	}
+	expectedGeminiDir := filepath.Join(root, ".agy")
+	assertExecCalled(t, call, agyPath, []string{"agy", "--gemini_dir=" + expectedGeminiDir, "--dangerously-skip-permissions", "--debug"})
 }
 
-func TestLaunchAntigravityError(t *testing.T) {
+func TestLaunchAntigravityExecError(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubWithExit(t, binDir, "agy", 1)
+	writeResolvableAgy(t)
+	wantErr := errors.New("exec failed")
+	captureExec(t, wantErr)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{},
 		Root:   root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err == nil {
-		t.Fatalf("expected error")
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected exec error to wrap %v, got %v", wantErr, err)
+	}
+	if !strings.Contains(err.Error(), "antigravity exec handoff failed") {
+		t.Fatalf("expected exec handoff context, got %v", err)
 	}
 }
 
@@ -129,14 +158,14 @@ func TestLaunchAntigravityRelativeRootFails(t *testing.T) {
 	}
 }
 
-// TestLaunchAntigravityMissingBinary covers the new LookPath preflight: when
-// `agy` is not discoverable, the user must receive a targeted install hint
-// instead of a generic "exited with error" message that wrongly implies the
-// binary ran. Without the preflight (F-D-3) the failure mode is confusing.
+// TestLaunchAntigravityMissingBinary covers the LookPath preflight: when `agy`
+// is not discoverable, the user must receive a targeted install hint instead of
+// an exec handoff failure that wrongly implies the binary ran.
 func TestLaunchAntigravityMissingBinary(t *testing.T) {
 	originalLookPath := lookPathFunc
 	lookPathFunc = func(string) (string, error) { return "", fmt.Errorf("not found") }
 	t.Cleanup(func() { lookPathFunc = originalLookPath })
+	forbidExec(t)
 
 	root := t.TempDir()
 	cfg := &config.ProjectConfig{
@@ -153,19 +182,9 @@ func TestLaunchAntigravityMissingBinary(t *testing.T) {
 	if !strings.Contains(err.Error(), "antigravity.google") {
 		t.Fatalf("expected error to include install hint, got: %v", err)
 	}
-	// F-B2-5 regression guard: missing-binary failures must NOT pollute the
-	// user's repo with a stray .agy/ directory. The preflight now runs
-	// before MkdirAll.
+	// Missing-binary failures must NOT pollute the user's repo with a stray
+	// .agy/ directory. The preflight runs before MkdirAll.
 	if _, statErr := os.Stat(filepath.Join(root, ".agy")); !os.IsNotExist(statErr) {
 		t.Fatalf("expected no .agy/ directory after missing-binary failure, got stat err = %v", statErr)
-	}
-}
-
-func writeLoggingStub(t *testing.T, dir string, name string, exitCode int) {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	content := []byte(fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > \"$0.log\"\nenv >> \"$0.log\"\nexit %d\n", exitCode))
-	if err := os.WriteFile(path, content, 0o700); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write logging stub: %v", err)
 	}
 }

--- a/internal/clients/claude/launch.go
+++ b/internal/clients/claude/launch.go
@@ -13,6 +13,9 @@ import (
 	"github.com/conn-castle/agent-layer/internal/run"
 )
 
+// execFunc is overridable for tests; on success it never returns.
+var execFunc = clients.ExecHandoff
+
 // Launch starts the Claude Code CLI with the configured options.
 func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs []string) error {
 	args := []string{}
@@ -39,16 +42,15 @@ func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs
 		env = clearStaleClaudeConfigDir(cfg.Root, env)
 	}
 
-	cmd := exec.Command("claude", args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = env
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf(messages.ClientsClaudeExitErrorFmt, err)
+	path, err := exec.LookPath("claude")
+	if err != nil {
+		return fmt.Errorf(messages.ClientsExecLookupErrorFmt, "claude", err)
 	}
 
+	argv := append([]string{"claude"}, args...)
+	if err := execFunc(path, argv, env); err != nil {
+		return fmt.Errorf(messages.ClientsExecHandoffErrorFmt, "claude", err)
+	}
 	return nil
 }
 

--- a/internal/clients/claude/launch_test.go
+++ b/internal/clients/claude/launch_test.go
@@ -1,9 +1,11 @@
 package claude
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -14,10 +16,67 @@ import (
 	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
-func TestLaunchClaude(t *testing.T) {
-	root := t.TempDir()
+type execCall struct {
+	called bool
+	path   string
+	argv   []string
+	env    []string
+}
+
+func captureExec(t *testing.T, err error) *execCall {
+	t.Helper()
+	original := execFunc
+	call := &execCall{}
+	execFunc = func(path string, argv []string, env []string) error {
+		if call.called {
+			t.Fatal("execFunc called more than once")
+		}
+		call.called = true
+		call.path = path
+		call.argv = append([]string(nil), argv...)
+		call.env = append([]string(nil), env...)
+		return err
+	}
+	t.Cleanup(func() { execFunc = original })
+	return call
+}
+
+func forbidExec(t *testing.T) {
+	t.Helper()
+	original := execFunc
+	execFunc = func(string, []string, []string) error {
+		t.Fatal("execFunc should not be called")
+		return nil
+	}
+	t.Cleanup(func() { execFunc = original })
+}
+
+func writeResolvableClaude(t *testing.T) string {
+	t.Helper()
 	binDir := t.TempDir()
 	testutil.WriteStub(t, binDir, "claude")
+	t.Setenv("PATH", binDir)
+	return filepath.Join(binDir, "claude")
+}
+
+func assertExecCalled(t *testing.T, call *execCall, wantPath string, wantArgv []string) {
+	t.Helper()
+	if !call.called {
+		t.Fatal("expected execFunc to be called")
+	}
+	if call.path != wantPath {
+		t.Fatalf("expected exec path %q, got %q", wantPath, call.path)
+	}
+	if !reflect.DeepEqual(call.argv, wantArgv) {
+		t.Fatalf("unexpected argv: got %#v want %#v", call.argv, wantArgv)
+	}
+}
+
+func TestLaunchClaudeExecHandoff(t *testing.T) {
+	root := t.TempDir()
+	claudePath := writeResolvableClaude(t)
+	call := captureExec(t, nil)
+	env := []string{"PATH=" + filepath.Dir(claudePath), "CUSTOM=1"}
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -28,17 +87,21 @@ func TestLaunchClaude(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, []string{"--print", "hello"}); err != nil {
 		t.Fatalf("Launch error: %v", err)
+	}
+
+	assertExecCalled(t, call, claudePath, []string{"claude", "--model", "test-model", "--print", "hello"})
+	if !reflect.DeepEqual(call.env, env) {
+		t.Fatalf("expected env to pass through unchanged, got %#v want %#v", call.env, env)
 	}
 }
 
-func TestLaunchClaudeError(t *testing.T) {
+func TestLaunchClaudeExecError(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubWithExit(t, binDir, "claude", 1)
+	writeResolvableClaude(t)
+	wantErr := errors.New("exec failed")
+	captureExec(t, wantErr)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -49,173 +112,103 @@ func TestLaunchClaudeError(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err == nil {
-		t.Fatalf("expected error")
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected exec error to wrap %v, got %v", wantErr, err)
+	}
+	if !strings.Contains(err.Error(), "claude exec handoff failed") {
+		t.Fatalf("expected exec handoff context, got %v", err)
 	}
 }
 
-func TestLaunchClaudeEffort(t *testing.T) {
+func TestLaunchClaudeMissingBinary(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-
-	argsFile := filepath.Join(t.TempDir(), "args.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\n", argsFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
+	t.Setenv("PATH", t.TempDir())
+	forbidExec(t)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
 			Agents: config.AgentsConfig{
-				Claude: config.ClaudeConfig{
-					Model:           "opus",
-					ReasoningEffort: "max",
+				Claude: config.ClaudeConfig{Model: "test-model"},
+			},
+		},
+		Root: root,
+	}
+
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if err == nil {
+		t.Fatal("expected missing binary error")
+	}
+	if !strings.Contains(err.Error(), "claude launcher requires `claude` on PATH") {
+		t.Fatalf("expected lookup error to name claude, got %v", err)
+	}
+}
+
+func TestLaunchClaudeEffortArgs(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		name  string
+		agent config.ClaudeConfig
+		argv  []string
+	}{
+		{
+			name: "max effort is passed",
+			agent: config.ClaudeConfig{
+				Model:           "opus",
+				ReasoningEffort: "max",
+			},
+			argv: []string{"claude", "--model", "opus", "--effort", "max"},
+		},
+		{
+			name: "non-max effort is passed",
+			agent: config.ClaudeConfig{
+				Model:           "opus",
+				ReasoningEffort: "high",
+			},
+			argv: []string{"claude", "--model", "opus", "--effort", "high"},
+		},
+		{
+			name:  "empty effort is omitted",
+			agent: config.ClaudeConfig{Model: "opus"},
+			argv:  []string{"claude", "--model", "opus"},
+		},
+		{
+			name: "agent_specific effortLevel suppresses CLI effort",
+			agent: config.ClaudeConfig{
+				Model:           "opus",
+				ReasoningEffort: "high",
+				AgentSpecific: map[string]any{
+					"effortLevel": "low",
 				},
 			},
+			argv: []string{"claude", "--model", "opus"},
 		},
-		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
-		t.Fatalf("Launch error: %v", err)
-	}
-
-	got, err := os.ReadFile(argsFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read args file: %v", err)
-	}
-	args := string(got)
-	if !strings.Contains(args, "--effort max") {
-		t.Fatalf("expected --effort max in args, got: %s", args)
-	}
-	if !strings.Contains(args, "--model opus") {
-		t.Fatalf("expected --model opus in args, got: %s", args)
-	}
-}
-
-func TestLaunchClaudeEffortNonMax(t *testing.T) {
-	root := t.TempDir()
-	binDir := t.TempDir()
-
-	argsFile := filepath.Join(t.TempDir(), "args.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\n", argsFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
-
-	cfg := &config.ProjectConfig{
-		Config: config.Config{
-			Agents: config.AgentsConfig{
-				Claude: config.ClaudeConfig{
-					Model:           "opus",
-					ReasoningEffort: "high",
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claudePath := writeResolvableClaude(t)
+			call := captureExec(t, nil)
+			cfg := &config.ProjectConfig{
+				Config: config.Config{
+					Agents: config.AgentsConfig{Claude: tc.agent},
 				},
-			},
-		},
-		Root: root,
-	}
+				Root: root,
+			}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
-		t.Fatalf("Launch error: %v", err)
-	}
+			if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil); err != nil {
+				t.Fatalf("Launch error: %v", err)
+			}
 
-	got, err := os.ReadFile(argsFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read args file: %v", err)
-	}
-	if !strings.Contains(string(got), "--effort high") {
-		t.Fatalf("expected --effort high in args, got: %s", string(got))
-	}
-}
-
-func TestLaunchClaudeNoEffortWhenEmpty(t *testing.T) {
-	root := t.TempDir()
-	binDir := t.TempDir()
-
-	argsFile := filepath.Join(t.TempDir(), "args.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\n", argsFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
-
-	cfg := &config.ProjectConfig{
-		Config: config.Config{
-			Agents: config.AgentsConfig{
-				Claude: config.ClaudeConfig{Model: "opus"},
-			},
-		},
-		Root: root,
-	}
-
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
-		t.Fatalf("Launch error: %v", err)
-	}
-
-	got, err := os.ReadFile(argsFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read args file: %v", err)
-	}
-	if strings.Contains(string(got), "--effort") {
-		t.Fatalf("expected no --effort flag when effort is empty, got: %s", string(got))
-	}
-}
-
-func TestLaunchClaudeEffortSkippedWithAgentSpecificOverride(t *testing.T) {
-	root := t.TempDir()
-	binDir := t.TempDir()
-
-	argsFile := filepath.Join(t.TempDir(), "args.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\n", argsFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
-
-	cfg := &config.ProjectConfig{
-		Config: config.Config{
-			Agents: config.AgentsConfig{
-				Claude: config.ClaudeConfig{
-					Model:           "opus",
-					ReasoningEffort: "high",
-					AgentSpecific: map[string]any{
-						"effortLevel": "low",
-					},
-				},
-			},
-		},
-		Root: root,
-	}
-
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
-		t.Fatalf("Launch error: %v", err)
-	}
-
-	got, err := os.ReadFile(argsFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read args file: %v", err)
-	}
-	if strings.Contains(string(got), "--effort") {
-		t.Fatalf("expected --effort to be skipped when agent_specific.effortLevel is set, got: %s", string(got))
+			assertExecCalled(t, call, claudePath, tc.argv)
+		})
 	}
 }
 
 func TestLaunchClaudeYOLO(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubExpectArg(t, binDir, "claude", "--dangerously-skip-permissions")
+	claudePath := writeResolvableClaude(t)
+	call := captureExec(t, nil)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -227,11 +220,11 @@ func TestLaunchClaudeYOLO(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
+
+	assertExecCalled(t, call, claudePath, []string{"claude", "--model", "test-model", "--dangerously-skip-permissions"})
 }
 
 func TestEnsureClaudeConfigDirSetsDefault(t *testing.T) {
@@ -297,18 +290,11 @@ func TestEnsureClaudeConfigDirWarnsOnMismatch(t *testing.T) {
 	}
 }
 
-func TestLaunchClaude_NoLocalConfigDir(t *testing.T) {
+func TestLaunchClaudeNoLocalConfigDir(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
+	claudePath := writeResolvableClaude(t)
+	call := captureExec(t, nil)
 
-	envFile := filepath.Join(t.TempDir(), "env.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\n/usr/bin/env > %s\n", envFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
-
-	// LocalConfigDir is nil (default) — CLAUDE_CONFIG_DIR should NOT be set.
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
 			Agents: config.AgentsConfig{
@@ -318,36 +304,19 @@ func TestLaunchClaude_NoLocalConfigDir(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	var env []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "CLAUDE_CONFIG_DIR=") {
-			env = append(env, e)
-		}
-	}
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{"PATH=" + filepath.Dir(claudePath)}, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
 
-	got, err := os.ReadFile(envFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read env file: %v", err)
-	}
-	if strings.Contains(string(got), "CLAUDE_CONFIG_DIR=") {
+	if _, ok := clients.GetEnv(call.env, "CLAUDE_CONFIG_DIR"); ok {
 		t.Fatal("expected CLAUDE_CONFIG_DIR to NOT be set when local_config_dir is nil")
 	}
 }
 
-func TestLaunchClaude_SetsClaudeConfigDirWhenEnabled(t *testing.T) {
+func TestLaunchClaudeSetsClaudeConfigDirWhenEnabled(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-
-	envFile := filepath.Join(t.TempDir(), "env.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\n/usr/bin/env > %s\n", envFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
+	claudePath := writeResolvableClaude(t)
+	call := captureExec(t, nil)
 
 	localConfigDir := true
 	cfg := &config.ProjectConfig{
@@ -362,41 +331,22 @@ func TestLaunchClaude_SetsClaudeConfigDirWhenEnabled(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	var env []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "CLAUDE_CONFIG_DIR=") {
-			env = append(env, e)
-		}
-	}
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{"PATH=" + filepath.Dir(claudePath)}, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
 
-	got, err := os.ReadFile(envFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read env file: %v", err)
-	}
-	expected := "CLAUDE_CONFIG_DIR=" + filepath.Join(root, ".claude-config")
-	if !strings.Contains(string(got), expected) {
-		t.Fatalf("expected CLAUDE_CONFIG_DIR=%s, got env:\n%s", filepath.Join(root, ".claude-config"), string(got))
+	expected := filepath.Join(root, ".claude-config")
+	value, ok := clients.GetEnv(call.env, "CLAUDE_CONFIG_DIR")
+	if !ok || value != expected {
+		t.Fatalf("expected CLAUDE_CONFIG_DIR=%s, got %#v", expected, call.env)
 	}
 }
 
-func TestLaunchClaude_ClearsStaleClaudeConfigDir(t *testing.T) {
+func TestLaunchClaudeClearsStaleClaudeConfigDir(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
+	claudePath := writeResolvableClaude(t)
+	call := captureExec(t, nil)
 
-	envFile := filepath.Join(t.TempDir(), "env.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\n/usr/bin/env > %s\n", envFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
-
-	// local_config_dir is nil (disabled). Simulate stale inherited
-	// CLAUDE_CONFIG_DIR that matches the repo-local path Agent Layer
-	// would have set — it must be cleared.
 	stale := filepath.Join(root, ".claude-config")
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -407,34 +357,21 @@ func TestLaunchClaude_ClearsStaleClaudeConfigDir(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := []string{"PATH=" + binDir, "CLAUDE_CONFIG_DIR=" + stale}
+	env := []string{"PATH=" + filepath.Dir(claudePath), "CLAUDE_CONFIG_DIR=" + stale}
 	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
 
-	got, err := os.ReadFile(envFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read env file: %v", err)
-	}
-	if strings.Contains(string(got), "CLAUDE_CONFIG_DIR=") {
+	if _, ok := clients.GetEnv(call.env, "CLAUDE_CONFIG_DIR"); ok {
 		t.Fatal("expected stale CLAUDE_CONFIG_DIR to be cleared when local_config_dir is disabled")
 	}
 }
 
-func TestLaunchClaude_PreservesUserClaudeConfigDir(t *testing.T) {
+func TestLaunchClaudePreservesUserClaudeConfigDir(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
+	claudePath := writeResolvableClaude(t)
+	call := captureExec(t, nil)
 
-	envFile := filepath.Join(t.TempDir(), "env.txt")
-	stubPath := filepath.Join(binDir, "claude")
-	stubContent := fmt.Sprintf("#!/bin/sh\n/usr/bin/env > %s\n", envFile)
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil { // #nosec G306 -- test writes an executable shell stub (PATH-shadowed) for subprocess invocation.
-		t.Fatalf("write stub: %v", err)
-	}
-
-	// local_config_dir is nil (disabled). A user-set CLAUDE_CONFIG_DIR
-	// pointing elsewhere (not the repo-local path) must be preserved.
 	userDir := filepath.Join(t.TempDir(), "my-custom-claude")
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -445,18 +382,13 @@ func TestLaunchClaude_PreservesUserClaudeConfigDir(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := []string{"PATH=" + binDir, "CLAUDE_CONFIG_DIR=" + userDir}
+	env := []string{"PATH=" + filepath.Dir(claudePath), "CLAUDE_CONFIG_DIR=" + userDir}
 	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
 
-	got, err := os.ReadFile(envFile) // #nosec G304 -- path is constructed from test-controlled inputs.
-	if err != nil {
-		t.Fatalf("read env file: %v", err)
-	}
-	want := "CLAUDE_CONFIG_DIR=" + userDir
-	if !strings.Contains(string(got), want) {
-		t.Fatalf("expected user CLAUDE_CONFIG_DIR to be preserved, got env:\n%s", string(got))
+	value, ok := clients.GetEnv(call.env, "CLAUDE_CONFIG_DIR")
+	if !ok || value != userDir {
+		t.Fatalf("expected user CLAUDE_CONFIG_DIR to be preserved, got %#v", call.env)
 	}
 }

--- a/internal/clients/codex/launch.go
+++ b/internal/clients/codex/launch.go
@@ -12,22 +12,24 @@ import (
 	"github.com/conn-castle/agent-layer/internal/run"
 )
 
+// execFunc is overridable for tests; on success it never returns.
+var execFunc = clients.ExecHandoff
+
 // Launch starts the Codex CLI with the configured options.
 func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs []string) error {
 	args := append([]string{}, passArgs...)
 
 	env = configureCodexHome(cfg.Root, env, cfg.Config.Agents.Codex)
 
-	cmd := exec.Command("codex", args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = env
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf(messages.ClientsCodexExitErrorFmt, err)
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		return fmt.Errorf(messages.ClientsExecLookupErrorFmt, "codex", err)
 	}
 
+	argv := append([]string{"codex"}, args...)
+	if err := execFunc(path, argv, env); err != nil {
+		return fmt.Errorf(messages.ClientsExecHandoffErrorFmt, "codex", err)
+	}
 	return nil
 }
 

--- a/internal/clients/codex/launch_test.go
+++ b/internal/clients/codex/launch_test.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,62 @@ import (
 	"github.com/conn-castle/agent-layer/internal/run"
 	"github.com/conn-castle/agent-layer/internal/testutil"
 )
+
+type execCall struct {
+	called bool
+	path   string
+	argv   []string
+	env    []string
+}
+
+func captureExec(t *testing.T, err error) *execCall {
+	t.Helper()
+	original := execFunc
+	call := &execCall{}
+	execFunc = func(path string, argv []string, env []string) error {
+		if call.called {
+			t.Fatal("execFunc called more than once")
+		}
+		call.called = true
+		call.path = path
+		call.argv = append([]string(nil), argv...)
+		call.env = append([]string(nil), env...)
+		return err
+	}
+	t.Cleanup(func() { execFunc = original })
+	return call
+}
+
+func forbidExec(t *testing.T) {
+	t.Helper()
+	original := execFunc
+	execFunc = func(string, []string, []string) error {
+		t.Fatal("execFunc should not be called")
+		return nil
+	}
+	t.Cleanup(func() { execFunc = original })
+}
+
+func writeResolvableCodex(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	testutil.WriteStub(t, binDir, "codex")
+	t.Setenv("PATH", binDir)
+	return filepath.Join(binDir, "codex")
+}
+
+func assertExecCalled(t *testing.T, call *execCall, wantPath string, wantArgv []string) {
+	t.Helper()
+	if !call.called {
+		t.Fatal("expected execFunc to be called")
+	}
+	if call.path != wantPath {
+		t.Fatalf("expected exec path %q, got %q", wantPath, call.path)
+	}
+	if !reflect.DeepEqual(call.argv, wantArgv) {
+		t.Fatalf("unexpected argv: got %#v want %#v", call.argv, wantArgv)
+	}
+}
 
 func TestConfigureCodexHomeSetsDefaultWhenEnabled(t *testing.T) {
 	root := t.TempDir()
@@ -48,7 +105,7 @@ func TestConfigureCodexHomeNoopWhenDisabled(t *testing.T) {
 			// { return env }` early-return were removed, the unset case would
 			// gain CODEX_HOME=<root>/.codex (env assertion flips) and the
 			// elsewhere case would emit the mismatch warning (stderr assertion
-			// flips) — so this test can fail on a real defect.
+			// flips), so this test can fail on a real defect.
 			r, w, err := os.Pipe()
 			if err != nil {
 				t.Fatalf("pipe: %v", err)
@@ -79,10 +136,11 @@ func TestConfigureCodexHomeNoopWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestLaunchCodex(t *testing.T) {
+func TestLaunchCodexExecHandoff(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubWithExit(t, binDir, "codex", 0)
+	codexPath := writeResolvableCodex(t)
+	call := captureExec(t, nil)
+	env := []string{"PATH=" + filepath.Dir(codexPath), "CODEX_HOME=" + filepath.Join(t.TempDir(), "other")}
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -93,19 +151,47 @@ func TestLaunchCodex(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	t.Setenv("CODEX_HOME", filepath.Join(t.TempDir(), "other"))
-	env := os.Environ()
-
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, []string{"--search"}); err != nil {
 		t.Fatalf("Launch error: %v", err)
+	}
+
+	assertExecCalled(t, call, codexPath, []string{"codex", "--search"})
+	if !reflect.DeepEqual(call.env, env) {
+		t.Fatalf("expected env to pass through unchanged, got %#v want %#v", call.env, env)
 	}
 }
 
-func TestLaunchCodexError(t *testing.T) {
+func TestLaunchCodexSetsCodexHomeWhenEnabled(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubWithExit(t, binDir, "codex", 1)
+	codexPath := writeResolvableCodex(t)
+	call := captureExec(t, nil)
+	localConfigDir := true
+
+	cfg := &config.ProjectConfig{
+		Config: config.Config{
+			Agents: config.AgentsConfig{
+				Codex: config.CodexConfig{LocalConfigDir: &localConfigDir},
+			},
+		},
+		Root: root,
+	}
+
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{"PATH=" + filepath.Dir(codexPath)}, nil); err != nil {
+		t.Fatalf("Launch error: %v", err)
+	}
+
+	expected := filepath.Join(root, ".codex")
+	value, ok := clients.GetEnv(call.env, "CODEX_HOME")
+	if !ok || value != expected {
+		t.Fatalf("expected CODEX_HOME %s, got %#v", expected, call.env)
+	}
+}
+
+func TestLaunchCodexExecError(t *testing.T) {
+	root := t.TempDir()
+	writeResolvableCodex(t)
+	wantErr := errors.New("exec failed")
+	captureExec(t, wantErr)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -116,10 +202,35 @@ func TestLaunchCodexError(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err == nil {
-		t.Fatalf("expected error")
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected exec error to wrap %v, got %v", wantErr, err)
+	}
+	if !strings.Contains(err.Error(), "codex exec handoff failed") {
+		t.Fatalf("expected exec handoff context, got %v", err)
+	}
+}
+
+func TestLaunchCodexMissingBinary(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	forbidExec(t)
+
+	cfg := &config.ProjectConfig{
+		Config: config.Config{
+			Agents: config.AgentsConfig{
+				Codex: config.CodexConfig{},
+			},
+		},
+		Root: root,
+	}
+
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if err == nil {
+		t.Fatal("expected missing binary error")
+	}
+	if !strings.Contains(err.Error(), "codex launcher requires `codex` on PATH") {
+		t.Fatalf("expected lookup error to name codex, got %v", err)
 	}
 }
 

--- a/internal/clients/copilotcli/launch.go
+++ b/internal/clients/copilotcli/launch.go
@@ -2,13 +2,16 @@ package copilotcli
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 
+	"github.com/conn-castle/agent-layer/internal/clients"
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
 	"github.com/conn-castle/agent-layer/internal/run"
 )
+
+// execFunc is overridable for tests; on success it never returns.
+var execFunc = clients.ExecHandoff
 
 // Launch starts the GitHub Copilot CLI with the configured options.
 func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs []string) error {
@@ -25,15 +28,14 @@ func Launch(cfg *config.ProjectConfig, runInfo *run.Info, env []string, passArgs
 	}
 	args = append(args, passArgs...)
 
-	cmd := exec.Command("copilot", args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = env
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf(messages.ClientsCopilotExitErrorFmt, err)
+	path, err := exec.LookPath("copilot")
+	if err != nil {
+		return fmt.Errorf(messages.ClientsExecLookupErrorFmt, "copilot", err)
 	}
 
+	argv := append([]string{"copilot"}, args...)
+	if err := execFunc(path, argv, env); err != nil {
+		return fmt.Errorf(messages.ClientsExecHandoffErrorFmt, "copilot", err)
+	}
 	return nil
 }

--- a/internal/clients/copilotcli/launch_test.go
+++ b/internal/clients/copilotcli/launch_test.go
@@ -1,7 +1,10 @@
 package copilotcli
 
 import (
-	"os"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/config"
@@ -9,10 +12,67 @@ import (
 	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
-func TestLaunchCopilotCLI(t *testing.T) {
-	root := t.TempDir()
+type execCall struct {
+	called bool
+	path   string
+	argv   []string
+	env    []string
+}
+
+func captureExec(t *testing.T, err error) *execCall {
+	t.Helper()
+	original := execFunc
+	call := &execCall{}
+	execFunc = func(path string, argv []string, env []string) error {
+		if call.called {
+			t.Fatal("execFunc called more than once")
+		}
+		call.called = true
+		call.path = path
+		call.argv = append([]string(nil), argv...)
+		call.env = append([]string(nil), env...)
+		return err
+	}
+	t.Cleanup(func() { execFunc = original })
+	return call
+}
+
+func forbidExec(t *testing.T) {
+	t.Helper()
+	original := execFunc
+	execFunc = func(string, []string, []string) error {
+		t.Fatal("execFunc should not be called")
+		return nil
+	}
+	t.Cleanup(func() { execFunc = original })
+}
+
+func writeResolvableCopilot(t *testing.T) string {
+	t.Helper()
 	binDir := t.TempDir()
 	testutil.WriteStub(t, binDir, "copilot")
+	t.Setenv("PATH", binDir)
+	return filepath.Join(binDir, "copilot")
+}
+
+func assertExecCalled(t *testing.T, call *execCall, wantPath string, wantArgv []string) {
+	t.Helper()
+	if !call.called {
+		t.Fatal("expected execFunc to be called")
+	}
+	if call.path != wantPath {
+		t.Fatalf("expected exec path %q, got %q", wantPath, call.path)
+	}
+	if !reflect.DeepEqual(call.argv, wantArgv) {
+		t.Fatalf("unexpected argv: got %#v want %#v", call.argv, wantArgv)
+	}
+}
+
+func TestLaunchCopilotCLIExecHandoff(t *testing.T) {
+	root := t.TempDir()
+	copilotPath := writeResolvableCopilot(t)
+	call := captureExec(t, nil)
+	env := []string{"PATH=" + filepath.Dir(copilotPath), "CUSTOM=1"}
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -23,34 +83,59 @@ func TestLaunchCopilotCLI(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, []string{"--prompt", "hello"}); err != nil {
 		t.Fatalf("Launch error: %v", err)
+	}
+
+	assertExecCalled(t, call, copilotPath, []string{"copilot", "--model", "test-model", "--prompt", "hello"})
+	if !reflect.DeepEqual(call.env, env) {
+		t.Fatalf("expected env to pass through unchanged, got %#v want %#v", call.env, env)
 	}
 }
 
-func TestLaunchCopilotCLIError(t *testing.T) {
+func TestLaunchCopilotCLIExecError(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubWithExit(t, binDir, "copilot", 1)
+	writeResolvableCopilot(t)
+	wantErr := errors.New("exec failed")
+	captureExec(t, wantErr)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{},
 		Root:   root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err == nil {
-		t.Fatalf("expected error")
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected exec error to wrap %v, got %v", wantErr, err)
+	}
+	if !strings.Contains(err.Error(), "copilot exec handoff failed") {
+		t.Fatalf("expected exec handoff context, got %v", err)
+	}
+}
+
+func TestLaunchCopilotCLIMissingBinary(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	forbidExec(t)
+
+	cfg := &config.ProjectConfig{
+		Config: config.Config{},
+		Root:   root,
+	}
+
+	err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil)
+	if err == nil {
+		t.Fatal("expected missing binary error")
+	}
+	if !strings.Contains(err.Error(), "copilot launcher requires `copilot` on PATH") {
+		t.Fatalf("expected lookup error to name copilot, got %v", err)
 	}
 }
 
 func TestLaunchCopilotCLIYOLO(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubExpectArg(t, binDir, "copilot", "--yolo")
+	copilotPath := writeResolvableCopilot(t)
+	call := captureExec(t, nil)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -62,17 +147,17 @@ func TestLaunchCopilotCLIYOLO(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
+
+	assertExecCalled(t, call, copilotPath, []string{"copilot", "--model", "test-model", "--yolo"})
 }
 
 func TestLaunchCopilotCLIAllowAllTools(t *testing.T) {
 	root := t.TempDir()
-	binDir := t.TempDir()
-	testutil.WriteStubExpectArg(t, binDir, "copilot", "--allow-all-tools")
+	copilotPath := writeResolvableCopilot(t)
+	call := captureExec(t, nil)
 
 	cfg := &config.ProjectConfig{
 		Config: config.Config{
@@ -84,9 +169,9 @@ func TestLaunchCopilotCLIAllowAllTools(t *testing.T) {
 		Root: root,
 	}
 
-	t.Setenv("PATH", binDir)
-	env := os.Environ()
-	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, env, nil); err != nil {
+	if err := Launch(cfg, &run.Info{ID: "id", Dir: root}, []string{}, nil); err != nil {
 		t.Fatalf("Launch error: %v", err)
 	}
+
+	assertExecCalled(t, call, copilotPath, []string{"copilot", "--model", "test-model", "--allow-all-tools"})
 }

--- a/internal/clients/exec.go
+++ b/internal/clients/exec.go
@@ -1,0 +1,9 @@
+package clients
+
+import "syscall"
+
+// ExecHandoff replaces the current al process with the target binary.
+// On success it never returns. argv[0] must be the program name.
+func ExecHandoff(path string, argv []string, env []string) error {
+	return syscall.Exec(path, argv, env) // #nosec G204 -- launchers resolve the target path with LookPath before exec handoff.
+}

--- a/internal/messages/cli.go
+++ b/internal/messages/cli.go
@@ -301,10 +301,8 @@ const (
 	McpPromptsShort      = "Start the MCP prompt server (deprecated)"
 	McpPromptsDeprecated = "al mcp-prompts is deprecated: skills are now synced natively. Run 'al sync' to update."
 
-	ClientsClaudeExitErrorFmt            = "claude exited with error: %w"
-	ClientsCodexExitErrorFmt             = "codex exited with error: %w"
-	ClientsAntigravityExitErrorFmt       = "antigravity exited with error: %w"
-	ClientsCopilotExitErrorFmt           = "copilot exited with error: %w"
+	ClientsExecLookupErrorFmt            = "%[1]s launcher requires `%[1]s` on PATH: %w"
+	ClientsExecHandoffErrorFmt           = "%s exec handoff failed: %w"
 	ClientsVSCodeExitErrorFmt            = "vscode exited with error: %w"
 	ClientsVSCodeCodeNotFoundFmt         = "vscode preflight failed: 'code' command not found on PATH: %w"
 	ClientsVSCodeManagedBlockConflictFmt = "vscode preflight failed: managed settings block conflict in %s (%s); run `al sync` to repair `.vscode/settings.json`"

--- a/internal/messages/system.go
+++ b/internal/messages/system.go
@@ -137,11 +137,11 @@ const (
 	ExtractChecksumReadFailedFmt  = "Error: failed to read %s: %v\n"
 	ExtractChecksumNotFoundFmt    = "Error: %s not found in %s\n"
 
-	UpdateFormulaUsageFmt       = "Usage: %s <formula-file> <new-url> <new-sha256>\n"
-	UpdateFormulaFileMissingFmt = "Error: %s not found\n"
-	UpdateFormulaStatFailedFmt  = "Error: failed to stat %s: %v\n"
-	UpdateFormulaReadFailedFmt  = "Error: failed to read %s: %v\n"
-	UpdateFormulaWriteFailedFmt = "Error: failed to write %s: %v\n"
-	UpdateFormulaURLCountFmt    = "Error: expected 1 url line, found %d\n"
-	UpdateFormulaSHACountFmt    = "Error: expected 1 sha256 line, found %d\n"
+	UpdateFormulaUsageFmt           = "Usage: %s <formula-file> <tag> <checksums-file>\n"
+	UpdateFormulaFileMissingFmt     = "Error: %s not found\n"
+	UpdateFormulaStatFailedFmt      = "Error: failed to stat %s: %v\n"
+	UpdateFormulaReadFailedFmt      = "Error: failed to read %s: %v\n"
+	UpdateFormulaWriteFailedFmt     = "Error: failed to write %s: %v\n"
+	UpdateFormulaChecksumMissingFmt = "Error: checksum for %s not found in %s\n"
+	UpdateFormulaRenderFailedFmt    = "Error: failed to render formula: %v\n"
 )

--- a/internal/tools/updateformula/main.go
+++ b/internal/tools/updateformula/main.go
@@ -4,19 +4,65 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
-	"regexp"
+	"strings"
+	"text/template"
 
 	"github.com/conn-castle/agent-layer/internal/fsutil"
 	"github.com/conn-castle/agent-layer/internal/messages"
 )
 
-var (
-	urlPattern = regexp.MustCompile(`(?m)^(\s*url\s+").*("\s*)$`)
-	shaPattern = regexp.MustCompile(`(?m)^(\s*sha256\s+").*("\s*)$`)
+const (
+	releaseAssetURL = "https://github.com/conn-castle/agent-layer/releases/download"
 )
+
+var formulaTemplate = template.Must(template.New("formula").Parse(`class AgentLayer < Formula
+  desc "Config-first CLI for keeping coding agents in sync"
+  homepage "https://github.com/conn-castle/agent-layer"
+  version "{{ .Version }}"
+  license "MIT"
+
+  on_macos do
+    depends_on arch: :arm64
+
+    url "{{ .ReleaseBaseURL }}/al-darwin-arm64", using: :nounzip
+    sha256 "{{ .DarwinARM64SHA }}"
+  end
+
+  on_linux do
+    on_arm do
+      url "{{ .ReleaseBaseURL }}/al-linux-arm64", using: :nounzip
+      sha256 "{{ .LinuxARM64SHA }}"
+    end
+
+    on_intel do
+      url "{{ .ReleaseBaseURL }}/al-linux-amd64", using: :nounzip
+      sha256 "{{ .LinuxAMD64SHA }}"
+    end
+  end
+
+  def install
+    bin.install Dir["al-*"].first => "al"
+    generate_completions_from_executable(bin/"al", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/al --version")
+  end
+end
+`))
+
+type formulaData struct {
+	Version        string
+	ReleaseBaseURL string
+	DarwinARM64SHA string
+	LinuxARM64SHA  string
+	LinuxAMD64SHA  string
+}
 
 func main() {
 	os.Exit(run(os.Args, os.Stderr))
@@ -24,7 +70,7 @@ func main() {
 
 // run executes the Homebrew formula updater CLI.
 // args are the CLI arguments (including argv0). errOut is the error output stream.
-// It returns an exit code compatible with the original Python script.
+// It renders the binary formula for the provided release tag and checksum file.
 func run(args []string, errOut io.Writer) int {
 	if len(args) != 4 {
 		fmt.Fprintf(errOut, messages.UpdateFormulaUsageFmt, args[0])
@@ -32,8 +78,8 @@ func run(args []string, errOut io.Writer) int {
 	}
 
 	formulaPath := args[1]
-	newURL := args[2]
-	newSHA := args[3]
+	tag := args[2]
+	checksumsPath := args[3]
 
 	info, err := os.Stat(formulaPath)
 	if err != nil {
@@ -45,28 +91,47 @@ func run(args []string, errOut io.Writer) int {
 		return 1
 	}
 
-	content, err := os.ReadFile(formulaPath)
+	checksums, err := readChecksums(checksumsPath)
 	if err != nil {
-		fmt.Fprintf(errOut, messages.UpdateFormulaReadFailedFmt, formulaPath, err)
+		if os.IsNotExist(err) {
+			fmt.Fprintf(errOut, messages.UpdateFormulaFileMissingFmt, checksumsPath)
+			return 1
+		}
+		fmt.Fprintf(errOut, messages.UpdateFormulaReadFailedFmt, checksumsPath, err)
 		return 1
 	}
 
-	text := string(content)
-	urlMatches := urlPattern.FindAllStringSubmatch(text, -1)
-	if len(urlMatches) != 1 {
-		fmt.Fprintf(errOut, messages.UpdateFormulaURLCountFmt, len(urlMatches))
+	darwinARM64SHA, ok := checksums["al-darwin-arm64"]
+	if !ok {
+		fmt.Fprintf(errOut, messages.UpdateFormulaChecksumMissingFmt, "al-darwin-arm64", checksumsPath)
 		return 1
 	}
-	shaMatches := shaPattern.FindAllStringSubmatch(text, -1)
-	if len(shaMatches) != 1 {
-		fmt.Fprintf(errOut, messages.UpdateFormulaSHACountFmt, len(shaMatches))
+	linuxARM64SHA, ok := checksums["al-linux-arm64"]
+	if !ok {
+		fmt.Fprintf(errOut, messages.UpdateFormulaChecksumMissingFmt, "al-linux-arm64", checksumsPath)
+		return 1
+	}
+	linuxAMD64SHA, ok := checksums["al-linux-amd64"]
+	if !ok {
+		fmt.Fprintf(errOut, messages.UpdateFormulaChecksumMissingFmt, "al-linux-amd64", checksumsPath)
 		return 1
 	}
 
-	text = replaceLine(urlPattern, text, newURL)
-	text = replaceLine(shaPattern, text, newSHA)
+	data := formulaData{
+		Version:        strings.TrimPrefix(tag, "v"),
+		ReleaseBaseURL: releaseAssetURL + "/" + tag,
+		DarwinARM64SHA: darwinARM64SHA,
+		LinuxARM64SHA:  linuxARM64SHA,
+		LinuxAMD64SHA:  linuxAMD64SHA,
+	}
 
-	if err := fsutil.WriteFileAtomic(formulaPath, []byte(text), info.Mode()); err != nil {
+	var rendered bytes.Buffer
+	if err := formulaTemplate.Execute(&rendered, data); err != nil {
+		fmt.Fprintf(errOut, messages.UpdateFormulaRenderFailedFmt, err)
+		return 1
+	}
+
+	if err := fsutil.WriteFileAtomic(formulaPath, rendered.Bytes(), info.Mode()); err != nil {
 		fmt.Fprintf(errOut, messages.UpdateFormulaWriteFailedFmt, formulaPath, err)
 		return 1
 	}
@@ -74,14 +139,25 @@ func run(args []string, errOut io.Writer) int {
 	return 0
 }
 
-// replaceLine replaces the value inside a matched quoted line while preserving indentation.
-// pattern must capture the prefix and suffix as submatches; value is inserted between them.
-func replaceLine(pattern *regexp.Regexp, text string, value string) string {
-	return pattern.ReplaceAllStringFunc(text, func(match string) string {
-		parts := pattern.FindStringSubmatch(match)
-		if len(parts) < 3 {
-			return match
+func readChecksums(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	checksums := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
 		}
-		return parts[1] + value + parts[2]
-	})
+		filename := strings.TrimPrefix(fields[1], "./")
+		checksums[filename] = fields[0]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return checksums, nil
 }

--- a/internal/tools/updateformula/main.go
+++ b/internal/tools/updateformula/main.go
@@ -153,7 +153,10 @@ func readChecksums(path string) (map[string]string, error) {
 		if len(fields) < 2 {
 			continue
 		}
-		filename := strings.TrimPrefix(fields[1], "./")
+		// Strip the binary-mode marker ("*") and a leading "./" so names match
+		// the release asset keys regardless of how sha256sum/shasum emitted them,
+		// consistent with the extractchecksum tool.
+		filename := strings.TrimPrefix(strings.TrimPrefix(fields[1], "*"), "./")
 		checksums[filename] = fields[0]
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/tools/updateformula/main_test.go
+++ b/internal/tools/updateformula/main_test.go
@@ -1,0 +1,96 @@
+//go:build tools
+// +build tools
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunRendersBinaryFormula(t *testing.T) {
+	dir := t.TempDir()
+	formulaPath := filepath.Join(dir, "agent-layer.rb")
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(formulaPath, []byte("old formula\n"), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(checksumsPath, []byte(`1111111111111111111111111111111111111111111111111111111111111111  ./al-darwin-arm64
+2222222222222222222222222222222222222222222222222222222222222222  al-linux-arm64
+3333333333333333333333333333333333333333333333333333333333333333  al-linux-amd64
+`), 0o644); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if code := run([]string{"updateformula", formulaPath, "v1.2.3", checksumsPath}, &stderr); code != 0 {
+		t.Fatalf("run exit code %d, stderr: %s", code, stderr.String())
+	}
+
+	got, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Fatalf("read formula: %v", err)
+	}
+	want := `class AgentLayer < Formula
+  desc "Config-first CLI for keeping coding agents in sync"
+  homepage "https://github.com/conn-castle/agent-layer"
+  version "1.2.3"
+  license "MIT"
+
+  on_macos do
+    depends_on arch: :arm64
+
+    url "https://github.com/conn-castle/agent-layer/releases/download/v1.2.3/al-darwin-arm64", using: :nounzip
+    sha256 "1111111111111111111111111111111111111111111111111111111111111111"
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/conn-castle/agent-layer/releases/download/v1.2.3/al-linux-arm64", using: :nounzip
+      sha256 "2222222222222222222222222222222222222222222222222222222222222222"
+    end
+
+    on_intel do
+      url "https://github.com/conn-castle/agent-layer/releases/download/v1.2.3/al-linux-amd64", using: :nounzip
+      sha256 "3333333333333333333333333333333333333333333333333333333333333333"
+    end
+  end
+
+  def install
+    bin.install Dir["al-*"].first => "al"
+    generate_completions_from_executable(bin/"al", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/al --version")
+  end
+end
+`
+	if string(got) != want {
+		t.Fatalf("unexpected formula:\n%s", string(got))
+	}
+}
+
+func TestRunFailsWhenChecksumIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	formulaPath := filepath.Join(dir, "agent-layer.rb")
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(formulaPath, []byte("old formula\n"), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(checksumsPath, []byte(`1111111111111111111111111111111111111111111111111111111111111111  al-darwin-arm64
+2222222222222222222222222222222222222222222222222222222222222222  al-linux-arm64
+`), 0o644); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if code := run([]string{"updateformula", formulaPath, "v1.2.3", checksumsPath}, &stderr); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("checksum for al-linux-amd64 not found")) {
+		t.Fatalf("expected missing checksum error, got %s", stderr.String())
+	}
+}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -36,10 +36,37 @@ build() {
     go build -o "${dist_dir}/${output}" -ldflags "-s -w -X main.Version=${version}" ./cmd/al
 }
 
+sign_darwin_binaries() {
+  local identity="${AL_CODESIGN_IDENTITY:-}"
+  local require_codesign="${AL_REQUIRE_CODESIGN:-0}"
+
+  if [[ -z "$identity" ]]; then
+    if [[ "$require_codesign" == "1" ]]; then
+      echo "ERROR: AL_CODESIGN_IDENTITY is required when AL_REQUIRE_CODESIGN=1" >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    if [[ "$require_codesign" == "1" ]]; then
+      echo "ERROR: AL_REQUIRE_CODESIGN=1 requires running release signing on macOS" >&2
+      exit 1
+    fi
+    echo "Skipping codesign: host is not macOS." >&2
+    return 0
+  fi
+
+  ./scripts/codesign-release.sh "${dist_dir}/al-darwin-arm64"
+  ./scripts/codesign-release.sh "${dist_dir}/al-darwin-amd64"
+}
+
 build darwin arm64 al-darwin-arm64
 build darwin amd64 al-darwin-amd64
 build linux arm64 al-linux-arm64
 build linux amd64 al-linux-amd64
+
+sign_darwin_binaries
 
 git archive --format=tar --prefix="${source_name}/" HEAD > "$source_tar"
 gzip -n -f "$source_tar"

--- a/scripts/codesign-release.sh
+++ b/scripts/codesign-release.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Sign release-grade macOS binaries with Hardened Runtime and an Apple secure
+# timestamp so the binaries can be notarized and remain valid after the signing
+# certificate expires.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <binary-path>" >&2
+  exit 2
+fi
+
+binary="$1"
+identifier="com.conncastle.agent-layer"
+
+if [[ ! -f "$binary" ]]; then
+  echo "codesign-release: binary not found: $binary" >&2
+  exit 1
+fi
+
+identity="${AL_CODESIGN_IDENTITY:-}"
+if [[ -z "$identity" ]]; then
+  echo "codesign-release: AL_CODESIGN_IDENTITY is required for release signing." >&2
+  exit 1
+fi
+
+codesign \
+  --sign "$identity" \
+  --identifier "$identifier" \
+  --force \
+  --options runtime \
+  --timestamp \
+  "$binary" >/dev/null

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Submit signed macOS CLI binaries for Apple notarization. Bare Mach-O CLI
+# binaries cannot be stapled, so the release keeps the signed binary and relies
+# on Gatekeeper's online notarization check for quarantined browser downloads.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dist_dir="${root_dir}/dist"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "notarize-release: $name is required." >&2
+    exit 1
+  fi
+}
+
+notary_status_from_output() {
+  sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | tail -n 1
+}
+
+submission_id_from_output() {
+  sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | sed -n '1p'
+}
+
+require_env NOTARY_KEY_ID
+require_env NOTARY_ISSUER_ID
+require_env NOTARY_KEY_P8_BASE64
+
+binaries=(
+  "${dist_dir}/al-darwin-arm64"
+  "${dist_dir}/al-darwin-amd64"
+)
+
+for binary in "${binaries[@]}"; do
+  if [[ ! -f "$binary" ]]; then
+    echo "notarize-release: binary not found: $binary" >&2
+    exit 1
+  fi
+done
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+key_path="${tmp_dir}/AuthKey_${NOTARY_KEY_ID}.p8"
+printf '%s' "$NOTARY_KEY_P8_BASE64" | base64 -D >"$key_path"
+chmod 600 "$key_path"
+
+for binary in "${binaries[@]}"; do
+  archive="${tmp_dir}/$(basename "$binary").zip"
+  log_path="${tmp_dir}/$(basename "$binary").notarytool.json"
+
+  echo "Notarizing $(basename "$binary")..."
+  ditto -c -k --keepParent "$binary" "$archive"
+
+  if ! xcrun notarytool submit "$archive" \
+    --key "$key_path" \
+    --key-id "$NOTARY_KEY_ID" \
+    --issuer "$NOTARY_ISSUER_ID" \
+    --wait \
+    --timeout 30m \
+    --output-format json >"$log_path" 2>&1; then
+    cat "$log_path" >&2
+    submission_id="$(submission_id_from_output "$log_path")"
+    if [[ -n "$submission_id" ]]; then
+      xcrun notarytool log "$submission_id" \
+        --key "$key_path" \
+        --key-id "$NOTARY_KEY_ID" \
+        --issuer "$NOTARY_ISSUER_ID" || true
+    fi
+    exit 1
+  fi
+
+  status="$(notary_status_from_output "$log_path")"
+  if [[ "$status" != "Accepted" ]]; then
+    echo "notarize-release: notarization for $(basename "$binary") returned status ${status:-unknown}; expected Accepted." >&2
+    cat "$log_path" >&2
+    exit 1
+  fi
+done

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -56,7 +56,11 @@ chmod 600 "$key_path"
 
 for binary in "${binaries[@]}"; do
   archive="${tmp_dir}/$(basename "$binary").zip"
+  # Keep notarytool's JSON on stdout and its human-readable progress/errors on
+  # stderr in separate files. Mixing them corrupts the JSON that the status/id
+  # parsers read, so only log_path (stdout) is ever parsed.
   log_path="${tmp_dir}/$(basename "$binary").notarytool.json"
+  err_path="${tmp_dir}/$(basename "$binary").notarytool.err"
 
   echo "Notarizing $(basename "$binary")..."
   ditto -c -k --keepParent "$binary" "$archive"
@@ -67,8 +71,8 @@ for binary in "${binaries[@]}"; do
     --issuer "$NOTARY_ISSUER_ID" \
     --wait \
     --timeout 30m \
-    --output-format json >"$log_path" 2>&1; then
-    cat "$log_path" >&2
+    --output-format json >"$log_path" 2>"$err_path"; then
+    cat "$log_path" "$err_path" >&2
     submission_id="$(submission_id_from_output "$log_path")"
     if [[ -n "$submission_id" ]]; then
       xcrun notarytool log "$submission_id" \
@@ -82,7 +86,7 @@ for binary in "${binaries[@]}"; do
   status="$(notary_status_from_output "$log_path")"
   if [[ "$status" != "Accepted" ]]; then
     echo "notarize-release: notarization for $(basename "$binary") returned status ${status:-unknown}; expected Accepted." >&2
-    cat "$log_path" >&2
+    cat "$log_path" "$err_path" >&2
     exit 1
   fi
 done

--- a/scripts/test-e2e/scenarios/error-propagation.sh
+++ b/scripts/test-e2e/scenarios/error-propagation.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Non-zero mock exit code propagates through al claude with a clear error message.
+# Non-zero mock exit code passes through al claude without an Agent Layer wrapper.
 
 run_scenario_error_propagation() {
   section "Error propagation"
@@ -12,7 +12,7 @@ run_scenario_error_propagation() {
   # Install mock that exits with code 1
   install_mock_claude "$repo_dir" 1
 
-  # Capture output to verify error message
+  # Capture output to verify the agent failure is not wrapped by al.
   local error_output rc=0
   error_output=$(cd "$repo_dir" && al claude 2>&1) || rc=$?
   if [[ $rc -eq 1 ]]; then
@@ -23,9 +23,10 @@ run_scenario_error_propagation() {
     fail "al claude should have propagated mock failure, but got exit 0"
   fi
 
-  # Verify the error message describes what happened
-  assert_output_contains "$error_output" "exited with error" \
-    "error message says claude exited with error"
+  # Exec handoff means the mock agent owns stderr after launch. Agent Layer
+  # must not add its old "exited with error" wrapper.
+  assert_output_not_contains "$error_output" "exited with error" \
+    "al claude does not wrap agent exit errors"
   assert_output_not_contains "$error_output" "panic" \
     "no panic in error output"
 
@@ -35,9 +36,8 @@ run_scenario_error_propagation() {
   # Verify mock received env vars even on failure path
   assert_claude_mock_env "$MOCK_CLAUDE_LOG" "AL_RUN_DIR"
 
-  # ---- Verify subprocess exit code propagation (Issue exit-code-flatten fixed):
-  # al claude should preserve the subprocess exit code in runMain when launch
-  # returns a wrapped *exec.ExitError.
+  # ---- Verify direct agent exit code passthrough:
+  # After exec handoff, the mock agent's exit status is the al process status.
   reset_mock_claude_log
   export MOCK_CLAUDE_EXIT_CODE=42
 

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -53,6 +53,8 @@ section "Static Analysis & Setup"
 
 required_files=(
   "scripts/build-release.sh"
+  "scripts/codesign-release.sh"
+  "scripts/notarize-release.sh"
   "scripts/check-upgrade-docs.sh"
   "al-install.sh"
 )
@@ -65,14 +67,16 @@ for file in "${required_files[@]}"; do
   fi
 done
 
-if [[ -x "$ROOT_DIR/scripts/build-release.sh" ]]; then
-  pass "build-release.sh is executable"
-else
-  fail "build-release.sh is not executable"
-fi
+for script in "scripts/build-release.sh" "scripts/codesign-release.sh" "scripts/notarize-release.sh"; do
+  if [[ -x "$ROOT_DIR/$script" ]]; then
+    pass "$script is executable"
+  else
+    fail "$script is not executable"
+  fi
+done
 
 # Shell syntax validation
-for script in "scripts/build-release.sh" "scripts/check-upgrade-docs.sh" "al-install.sh"; do
+for script in "scripts/build-release.sh" "scripts/codesign-release.sh" "scripts/notarize-release.sh" "scripts/check-upgrade-docs.sh" "al-install.sh"; do
   if bash -n "$ROOT_DIR/$script" 2>/dev/null; then
     pass "$script has valid bash syntax"
   else
@@ -82,7 +86,7 @@ done
 
 # Optional: shellcheck
 if command -v shellcheck >/dev/null 2>&1; then
-  for script in "scripts/build-release.sh" "scripts/check-upgrade-docs.sh" "al-install.sh"; do
+  for script in "scripts/build-release.sh" "scripts/codesign-release.sh" "scripts/notarize-release.sh" "scripts/check-upgrade-docs.sh" "al-install.sh"; do
     if shellcheck -S error "$ROOT_DIR/$script" 2>/dev/null; then
       pass "$script passes shellcheck"
     else
@@ -143,6 +147,7 @@ run_build_invocation_details
 run_artifact_verification
 run_source_tarball_verification
 run_checksum_integrity
+run_codesign_requirement_test
 run_upgrade_docs_script_tests
 run_go_tool_tests_extractchecksum
 run_go_tool_tests_updateformula

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -6,6 +6,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# These tests drive build-release.sh with a mock `go` and must never invoke real
+# code signing. `make release-dist` runs this suite as its `test-release`
+# prerequisite while exporting AL_CODESIGN_IDENTITY/AL_REQUIRE_CODESIGN for the
+# actual build, so clear them here to keep the codesign-requirement test
+# deterministic regardless of the caller's environment.
+unset AL_CODESIGN_IDENTITY AL_REQUIRE_CODESIGN
+
 # Colors for output (disabled if not a terminal)
 if [[ -t 1 ]]; then
   RED='\033[0;31m'
@@ -151,6 +158,7 @@ run_codesign_requirement_test
 run_upgrade_docs_script_tests
 run_go_tool_tests_extractchecksum
 run_go_tool_tests_updateformula
+run_go_tool_tests_updateformula_unit
 run_go_tool_tests_gentemplatemanifest
 
 # -----------------------------------------------------------------------------

--- a/scripts/test-release/release_tests.sh
+++ b/scripts/test-release/release_tests.sh
@@ -94,6 +94,9 @@ run_codesign_requirement_test() {
     AL_VERSION="$expected_version" DIST_DIR="$require_dist" AL_REQUIRE_CODESIGN=1 ./scripts/build-release.sh
   ) > "$require_log" 2>&1; then
     fail "AL_REQUIRE_CODESIGN=1 should fail when AL_CODESIGN_IDENTITY is unset"
+    echo "--- Build Log ---"
+    head -n 10 "$require_log"
+    echo "-----------------"
   else
     pass "AL_REQUIRE_CODESIGN=1 fails when AL_CODESIGN_IDENTITY is unset"
   fi

--- a/scripts/test-release/release_tests.sh
+++ b/scripts/test-release/release_tests.sh
@@ -75,6 +75,37 @@ MOCK_GO
   fi
 }
 
+run_codesign_requirement_test() {
+  section "Codesign Requirement Test"
+
+  if [[ ! -d "${mock_bin:-}" ]]; then
+    warn "Skipping codesign requirement test because mock go was not initialized"
+    return
+  fi
+
+  require_dist="$tmp_dir/require-codesign-dist"
+  require_go_log="$tmp_dir/require-codesign-go.log"
+  require_log="$tmp_dir/require-codesign.log"
+
+  if (
+    export PATH="$mock_bin:$PATH"
+    export MOCK_GO_LOG="$require_go_log"
+    cd "$ROOT_DIR"
+    AL_VERSION="$expected_version" DIST_DIR="$require_dist" AL_REQUIRE_CODESIGN=1 ./scripts/build-release.sh
+  ) > "$require_log" 2>&1; then
+    fail "AL_REQUIRE_CODESIGN=1 should fail when AL_CODESIGN_IDENTITY is unset"
+  else
+    pass "AL_REQUIRE_CODESIGN=1 fails when AL_CODESIGN_IDENTITY is unset"
+  fi
+
+  if grep -q "AL_CODESIGN_IDENTITY is required" "$require_log"; then
+    pass "codesign requirement failure explains missing AL_CODESIGN_IDENTITY"
+  else
+    fail "codesign requirement failure did not explain missing AL_CODESIGN_IDENTITY"
+    cat "$require_log"
+  fi
+}
+
 run_build_invocation_details() {
   section "Build Invocation Details"
 

--- a/scripts/test-release/tool_tests.sh
+++ b/scripts/test-release/tool_tests.sh
@@ -124,124 +124,86 @@ run_go_tool_tests_updateformula() {
     if [[ "$update_ok" -ne 1 ]]; then
       warn "Skipping updateformula tests because build failed"
     else
-      # Test 1: Successfully update a valid formula
+      # Test 1: Successfully render the binary formula
       valid_formula="$tmp_dir/valid-formula.rb"
       cat > "$valid_formula" << 'EOF'
 class AgentLayer < Formula
-  desc "Agent Layer CLI"
-  homepage "https://github.com/conn-castle/agent-layer"
   url "https://example.com/old-url.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-  license "MIT"
-
-  def install
-    bin.install "al"
-  end
 end
 EOF
 
-      new_url="https://example.com/new-url.tar.gz"
-      new_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      formula_checksums="$tmp_dir/formula-checksums.txt"
+      cat > "$formula_checksums" << 'EOF'
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  ./al-darwin-arm64
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  al-linux-arm64
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  al-linux-amd64
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  agent-layer-1.2.3.tar.gz
+EOF
 
-      if run_update_formula "$valid_formula" "$new_url" "$new_sha" 2>/dev/null; then
-        # Verify the update
-        if grep -q "url \"$new_url\"" "$valid_formula" && grep -q "sha256 \"$new_sha\"" "$valid_formula"; then
-          pass "updateformula: successfully updates url and sha256"
+      if run_update_formula "$valid_formula" "v1.2.3" "$formula_checksums" 2>/dev/null; then
+        if grep -q 'version "1.2.3"' "$valid_formula" && \
+           grep -q 'al-darwin-arm64", using: :nounzip' "$valid_formula" && \
+           grep -q 'sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' "$valid_formula" && \
+           grep -q 'al-linux-arm64", using: :nounzip' "$valid_formula" && \
+           grep -q 'sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' "$valid_formula" && \
+           grep -q 'al-linux-amd64", using: :nounzip' "$valid_formula" && \
+           grep -q 'sha256 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"' "$valid_formula"; then
+          pass "updateformula: renders binary asset urls and sha256 values"
         else
-          fail "updateformula: file not updated correctly"
+          fail "updateformula: binary formula content is missing expected asset urls or sha256 values"
         fi
       else
-        fail "updateformula: failed on valid formula"
+        fail "updateformula: failed on valid formula render"
       fi
 
-      # Test 2: Verify formatting is preserved (indentation)
-      if grep -q '^  url "' "$valid_formula" && grep -q '^  sha256 "' "$valid_formula"; then
-        pass "updateformula: preserves indentation"
+      # Test 2: Verify the formula keeps required Homebrew shape.
+      if grep -q 'depends_on arch: :arm64' "$valid_formula" && \
+         grep -q 'generate_completions_from_executable(bin/"al", "completion")' "$valid_formula" && \
+         grep -q 'test do' "$valid_formula"; then
+        pass "updateformula: keeps required arch, completion, and test blocks"
       else
-        fail "updateformula: did not preserve indentation"
+        fail "updateformula: missing required arch, completion, or test block"
       fi
 
-      # Test 3: Verify surrounding content is preserved
-      if grep -q 'class AgentLayer < Formula' "$valid_formula" && \
-         grep -q 'def install' "$valid_formula" && \
-         grep -q 'license "MIT"' "$valid_formula"; then
-        pass "updateformula: preserves surrounding content"
+      # Test 3: Verify removed source-build formula features stay removed.
+      if ! grep -q 'depends_on "go"' "$valid_formula" && ! grep -q 'bottle do' "$valid_formula" && ! grep -q 'agent-layer-1.2.3.tar.gz' "$valid_formula"; then
+        pass "updateformula: drops source-build dependency, bottle block, and tarball url"
       else
-        fail "updateformula: did not preserve surrounding content"
+        fail "updateformula: rendered formula still contains source-build-only content"
       fi
 
-      # Test 4: Exit code 1 when multiple url lines exist
-      multi_url_formula="$tmp_dir/multi-url-formula.rb"
-      cat > "$multi_url_formula" << 'EOF'
-class Test < Formula
-  url "https://example.com/one.tar.gz"
-  url "https://example.com/two.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-end
+      # Test 4: Exit code 1 when a required checksum is missing
+      missing_checksum_file="$tmp_dir/missing-checksums.txt"
+      cat > "$missing_checksum_file" << 'EOF'
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  al-darwin-arm64
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  al-linux-arm64
 EOF
 
-      if run_update_formula "$multi_url_formula" "$new_url" "$new_sha" >/dev/null 2>&1; then
-        fail "updateformula: should exit 1 with multiple url lines"
+      if run_update_formula "$valid_formula" "v1.2.3" "$missing_checksum_file" >/dev/null 2>&1; then
+        fail "updateformula: should exit 1 when a required checksum is missing"
       else
-        pass "updateformula: exits 1 with multiple url lines"
+        pass "updateformula: exits 1 when a required checksum is missing"
       fi
 
-      # Test 5: Exit code 1 when multiple sha256 lines exist
-      multi_sha_formula="$tmp_dir/multi-sha-formula.rb"
-      cat > "$multi_sha_formula" << 'EOF'
-class Test < Formula
-  url "https://example.com/test.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-  sha256 "1111111111111111111111111111111111111111111111111111111111111111"
-end
-EOF
-
-      if run_update_formula "$multi_sha_formula" "$new_url" "$new_sha" >/dev/null 2>&1; then
-        fail "updateformula: should exit 1 with multiple sha256 lines"
-      else
-        pass "updateformula: exits 1 with multiple sha256 lines"
-      fi
-
-      # Test 6: Exit code 1 when formula file doesn't exist
-      if run_update_formula "$tmp_dir/no-such-formula.rb" "$new_url" "$new_sha" >/dev/null 2>&1; then
+      # Test 5: Exit code 1 when formula file doesn't exist
+      if run_update_formula "$tmp_dir/no-such-formula.rb" "v1.2.3" "$formula_checksums" >/dev/null 2>&1; then
         fail "updateformula: should exit 1 when formula file missing"
       else
         pass "updateformula: exits 1 when formula file missing"
       fi
 
+      # Test 6: Exit code 1 when checksums file doesn't exist
+      if run_update_formula "$valid_formula" "v1.2.3" "$tmp_dir/no-such-checksums.txt" >/dev/null 2>&1; then
+        fail "updateformula: should exit 1 when checksums file missing"
+      else
+        pass "updateformula: exits 1 when checksums file missing"
+      fi
+
       # Test 7: Exit code 1 when wrong number of arguments
-      if run_update_formula "$valid_formula" "$new_url" >/dev/null 2>&1; then
+      if run_update_formula "$valid_formula" "v1.2.3" >/dev/null 2>&1; then
         fail "updateformula: should exit 1 with wrong argument count"
       else
         pass "updateformula: exits 1 with wrong argument count"
-      fi
-
-      # Test 8: Exit code 1 when no url line exists
-      no_url_formula="$tmp_dir/no-url-formula.rb"
-      cat > "$no_url_formula" << 'EOF'
-class Test < Formula
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-end
-EOF
-
-      if run_update_formula "$no_url_formula" "$new_url" "$new_sha" >/dev/null 2>&1; then
-        fail "updateformula: should exit 1 with no url line"
-      else
-        pass "updateformula: exits 1 with no url line"
-      fi
-
-      # Test 9: Exit code 1 when no sha256 line exists
-      no_sha_formula="$tmp_dir/no-sha-formula.rb"
-      cat > "$no_sha_formula" << 'EOF'
-class Test < Formula
-  url "https://example.com/test.tar.gz"
-end
-EOF
-
-      if run_update_formula "$no_sha_formula" "$new_url" "$new_sha" >/dev/null 2>&1; then
-        fail "updateformula: should exit 1 with no sha256 line"
-      else
-        pass "updateformula: exits 1 with no sha256 line"
       fi
     fi
   fi

--- a/scripts/test-release/tool_tests.sh
+++ b/scripts/test-release/tool_tests.sh
@@ -209,6 +209,19 @@ EOF
   fi
 }
 
+run_go_tool_tests_updateformula_unit() {
+  section "Go Tool Tests: updateformula (unit)"
+
+  # The updateformula package (and its tests) are guarded by the `tools` build
+  # tag, so `go test ./...` (used by make coverage) skips them. Run them
+  # explicitly here so the formula renderer's unit tests actually execute in CI.
+  if (cd "$ROOT_DIR" && go test -tags tools ./internal/tools/updateformula/); then
+    pass "updateformula unit tests passed"
+  else
+    fail "updateformula unit tests failed"
+  fi
+}
+
 run_go_tool_tests_gentemplatemanifest() {
   section "Go Tool Tests: gentemplatemanifest"
 

--- a/scripts/test-release/workflow_tests.sh
+++ b/scripts/test-release/workflow_tests.sh
@@ -16,34 +16,16 @@ run_workflow_consistency_tests() {
     return
   fi
 
-  # The release workflow runs make docs-upgrade-check, which invokes
-  # check-upgrade-ctas.sh, which requires ripgrep (rg). CI installs rg
-  # via apt-get. The release workflow must do the same, otherwise releases
-  # fail on tag push.
-  #
-  # Extract apt-get install package names from both workflows and verify
-  # that every package installed in CI is also installed in the release workflow.
-
-  local ci_packages release_packages
-  ci_packages=$(sed -n 's/.*apt-get install[[:space:]]*//p' "$ci_workflow" | tr -s ' ' '\n' | grep -v '^-' | grep -v '^$' | sort -u || true)
-  release_packages=$(sed -n 's/.*apt-get install[[:space:]]*//p' "$release_workflow" | tr -s ' ' '\n' | grep -v '^-' | grep -v '^$' | sort -u || true)
-
-  if [[ -z "$ci_packages" ]]; then
-    pass "workflow-consistency: CI installs no apt packages (nothing to check)"
-    return
+  if grep -q 'runs-on: macos-latest' "$release_workflow"; then
+    pass "workflow-consistency: build-release runs on macos-latest"
+  else
+    fail "workflow-consistency: build-release must run on macos-latest for Developer ID signing"
   fi
 
-  local missing=""
-  while IFS= read -r pkg; do
-    if ! printf '%s\n' "$release_packages" | grep -qx "$pkg"; then
-      missing="$missing $pkg"
-    fi
-  done <<< "$ci_packages"
-
-  if [[ -z "$missing" ]]; then
-    pass "workflow-consistency: release workflow installs all CI apt packages"
+  if grep -q 'command -v rg' "$release_workflow" && grep -q 'brew install ripgrep' "$release_workflow"; then
+    pass "workflow-consistency: release workflow installs ripgrep via Homebrew when needed"
   else
-    fail "workflow-consistency: release workflow missing apt packages from CI:$missing"
+    fail "workflow-consistency: release workflow must install ripgrep via Homebrew when missing"
   fi
 
   # Stable tag validation must happen in build-release before the release
@@ -61,6 +43,62 @@ run_workflow_consistency_tests() {
     pass "workflow-consistency: stable tag validation runs before publish release"
   else
     fail "workflow-consistency: stable tag validation must run before publish release"
+  fi
+
+  local import_cert_line build_release_line notarize_line upload_line
+  import_cert_line=$(grep -n 'name: Import Developer ID cert' "$release_workflow" | head -n1 | cut -d: -f1 || true)
+  build_release_line=$(grep -n 'name: Build release artifacts' "$release_workflow" | head -n1 | cut -d: -f1 || true)
+  notarize_line=$(grep -n 'name: Notarize darwin binaries' "$release_workflow" | head -n1 | cut -d: -f1 || true)
+  upload_line=$(grep -n 'name: Upload dist artifacts for downstream jobs' "$release_workflow" | head -n1 | cut -d: -f1 || true)
+
+  if [[ -n "$import_cert_line" && -n "$build_release_line" && "$import_cert_line" -lt "$build_release_line" ]]; then
+    pass "workflow-consistency: Developer ID cert imports before release build"
+  else
+    fail "workflow-consistency: Developer ID cert import must run before release build"
+  fi
+
+  if [[ -n "$notarize_line" && -n "$build_release_line" && -n "$upload_line" && "$build_release_line" -lt "$notarize_line" && "$notarize_line" -lt "$upload_line" ]]; then
+    pass "workflow-consistency: notarization runs after build and before artifact upload"
+  else
+    fail "workflow-consistency: notarization must run after build and before artifact upload"
+  fi
+
+  if grep -q 'Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466' "$release_workflow" && \
+     grep -q 'MACOS_CERT_P12_BASE64' "$release_workflow" && \
+     grep -q 'MACOS_CERT_P12_PASSWORD' "$release_workflow"; then
+    pass "workflow-consistency: cert import action is SHA-pinned and wired to MACOS cert secrets"
+  else
+    fail "workflow-consistency: cert import action must be SHA-pinned and use MACOS cert secrets"
+  fi
+
+  if grep -q 'AL_CODESIGN_IDENTITY: "Developer ID Application: Hardware Breakout LLC (DQCZX59J6D)"' "$release_workflow" && \
+     grep -q 'AL_REQUIRE_CODESIGN: "1"' "$release_workflow"; then
+    pass "workflow-consistency: release build requires Developer ID signing"
+  else
+    fail "workflow-consistency: release build must set AL_CODESIGN_IDENTITY and AL_REQUIRE_CODESIGN=1"
+  fi
+
+  if grep -q 'MACOS_NOTARY_API_KEY_ID' "$release_workflow" && \
+     grep -q 'MACOS_NOTARY_API_KEY_ISSUER_ID' "$release_workflow" && \
+     grep -q 'MACOS_NOTARY_API_KEY_P8_BASE64' "$release_workflow" && \
+     grep -q 'scripts/notarize-release.sh' "$release_workflow"; then
+    pass "workflow-consistency: notarization step uses MACOS notary secrets"
+  else
+    fail "workflow-consistency: notarization step must use MACOS notary secrets"
+  fi
+
+  if grep -q '"al-darwin-arm64"' "$release_workflow" && \
+     grep -q '"al-linux-arm64"' "$release_workflow" && \
+     grep -q '"al-linux-amd64"' "$release_workflow"; then
+    pass "workflow-consistency: tap job verifies binary release assets"
+  else
+    fail "workflow-consistency: tap job must verify binary release assets before formula update"
+  fi
+
+  if grep -q 'go run -tags tools ./internal/tools/updateformula "${FORMULA}" "${TAG}" dist/checksums.txt' "$release_workflow"; then
+    pass "workflow-consistency: tap job renders binary formula from tag and checksums"
+  else
+    fail "workflow-consistency: tap job must invoke updateformula with formula, tag, and checksums"
   fi
 
   # Structural integrity: verify files required by the release workflow exist.


### PR DESCRIPTION
## Summary

Makes macOS permission prompts name the actual coding agent instead of `al`, and stops those prompts from recurring on every release.

Two independent streams:

**1. Exec handoff (permission attribution).** The four interactive CLI launch paths (`al claude`, `al codex`, `al copilot`, `al agy`) now replace the `al` process with the agent CLI via `syscall.Exec` instead of spawning it as a child and waiting. After handoff no `al` process exists, so macOS TCC/keychain prompts attribute to the agent binary — identical to running the agent directly — and grants persist across `al` upgrades. This uses the same pattern the codebase already trusts for `al dispatch` version pinning (`internal/dispatch/exec.go`).

**2. Signing, notarization, and Homebrew delivery.** Darwin release binaries are Developer ID signed (hardened runtime, timestamp, identifier `com.conncastle.agent-layer`) and notarized in the release workflow, so Gatekeeper trusts them and grants persist. The Homebrew tap formula switches from build-from-source to downloading the prebuilt (signed on macOS) release binaries for both macOS and Linux.

## Changes

- **Exec seam:** new `internal/clients/exec.go` (`ExecHandoff` wrapping `syscall.Exec`); each of the four launchers (`internal/clients/{claude,codex,copilotcli,antigravity}/launch.go`) gets a package-local `execFunc` test seam and drops `exec.Command`/`cmd.Run`. Arg/env assembly is unchanged (env parity preserved: `syscall.Exec` does full env replacement, matching the old `cmd.Env`).
- **Exit-code passthrough (behavior change):** on success `Launch` never returns, so the agent's exit code becomes `al`'s exit code directly. The old `al` "exited: exit status N" stderr wrapper and exit-1 normalization are gone. GUI launchers (vscode, Antigravity IDE) keep spawn-and-wait.
- **Messages:** removed the four now-unused `Clients<Name>ExitErrorFmt` constants; added shared exec lookup / exec-failure constants in `internal/messages`.
- **Release scripts:** new `scripts/codesign-release.sh` and `scripts/notarize-release.sh`; `scripts/build-release.sh` signs both darwin binaries when `AL_CODESIGN_IDENTITY` is set and fails loud when `AL_REQUIRE_CODESIGN=1` and signing cannot run; `checksums.txt` is still written last (after signing).
- **Release workflow (`.github/workflows/release.yml`):** `build-release` job moved to a macOS runner; imports the Developer ID cert, signs during `make release-dist`, then notarizes. Publish/website/tap jobs unchanged.
- **Homebrew formula:** `internal/tools/updateformula` reworked to render the whole `Formula/agent-layer.rb` as a prebuilt-binary formula (darwin-arm64 + linux arm64/amd64), no `depends_on "go"`, no bottle block. New unit tests (golden rendering + checksum-extraction failures).
- **Tests/docs:** updated `scripts/test-release*`, the `error-propagation.sh` e2e scenario (exit-code passthrough), CHANGELOG, DECISIONS, and the release runbook.

## Verification

Full local verification passed in the implementing session: `make dev` (coverage 95.09%), `make test-race`, `make test-release` (86/86 after this PR's audit removed one self-confirming assertion), `make test-e2e` (834/834). `make ci` runs in parallel with PR CI during ship-pr.

Uncommitted-changes audit before commit: prune-new-tests (0 deleted, all justified), simplify-new-code (2 behavior-preserving simplifications), and a multi-lens review round that surfaced only 2 Low findings, both fixed.

## Notes / rollout

- **One-time re-prompt wave:** after upgrading, agents ask for permissions under their own identities; stale `al` grants linger in Privacy & Security (cosmetic — `tccutil reset <service>` clears). Noted in CHANGELOG/release notes.
- **PR CI does not exercise signing:** the five `MACOS_*` GitHub secrets already exist on `conn-castle/agent-layer`, and the release-workflow changes only take effect on the next tag. The first signed release is validated end-to-end at tag time.
- Local/from-source builds and Linux artifacts stay unsigned (out of scope). Notarization is done without stapling (bare Mach-O binaries can't be stapled; Gatekeeper looks up tickets online).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS release binaries are now signed and notarized.
  * Homebrew installs now use prebuilt release binaries on macOS and Linux.
  * Claude model options now include `fable`.

* **Bug Fixes**
  * CLI launchers now pass through the agent’s exit code directly.
  * Removed the extra wrapper error message for agent startup failures.
  * `al wizard` no longer offers a workflow refresh when files already exist.

* **Notes**
  * Upgrading on macOS may trigger one additional permission prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->