### PR TITLE
Prefetch Antigravity wizard model options

### DIFF
--- a/internal/wizard/catalog.go
+++ b/internal/wizard/catalog.go
@@ -1,6 +1,8 @@
 package wizard
 
 import (
+	"sync"
+
 	"github.com/conn-castle/agent-layer/internal/agentoptions"
 	"github.com/conn-castle/agent-layer/internal/config"
 )
@@ -61,6 +63,34 @@ func ApprovalModeFieldOptions() []config.FieldOption {
 }
 
 var wizardOptionDiscoveryRequestFunc = agentoptions.DefaultDiscoveryRequest
+
+type wizardOptionDiscoveryCache struct {
+	mu                     sync.Mutex
+	antigravityModelValues []string
+	antigravityModelsReady bool
+}
+
+func (c *wizardOptionDiscoveryCache) prefetchAntigravityModels() {
+	req := wizardOptionDiscoveryRequestFunc()
+	go func() {
+		values := agentoptions.Values(AgentAntigravity, agentoptions.KindModel, req)
+		c.mu.Lock()
+		c.antigravityModelValues = values
+		c.antigravityModelsReady = true
+		c.mu.Unlock()
+	}()
+}
+
+func (c *wizardOptionDiscoveryCache) antigravityModelOptions() []string {
+	c.mu.Lock()
+	if c.antigravityModelsReady {
+		values := c.antigravityModelValues
+		c.mu.Unlock()
+		return values
+	}
+	c.mu.Unlock()
+	return agentoptions.Values(AgentAntigravity, agentoptions.KindModel, agentoptions.DiscoveryRequest{})
+}
 
 func modelOptions(agent string) []string {
 	return agentoptions.Values(agent, agentoptions.KindModel, wizardOptionDiscoveryRequestFunc())

--- a/internal/wizard/catalog.go
+++ b/internal/wizard/catalog.go
@@ -65,30 +65,57 @@ func ApprovalModeFieldOptions() []config.FieldOption {
 var wizardOptionDiscoveryRequestFunc = agentoptions.DefaultDiscoveryRequest
 
 type wizardOptionDiscoveryCache struct {
-	mu                     sync.Mutex
-	antigravityModelValues []string
-	antigravityModelsReady bool
+	mu                       sync.Mutex
+	antigravityModelValues   []string
+	antigravityModelsReady   bool
+	antigravityModelsStarted bool
+	antigravityModelsDone    chan struct{}
 }
 
 func (c *wizardOptionDiscoveryCache) prefetchAntigravityModels() {
+	c.mu.Lock()
+	if c.antigravityModelsStarted {
+		c.mu.Unlock()
+		return
+	}
+	c.antigravityModelsStarted = true
+	done := make(chan struct{})
+	c.antigravityModelsDone = done
+	c.mu.Unlock()
+
 	req := wizardOptionDiscoveryRequestFunc()
 	go func() {
 		values := agentoptions.Values(AgentAntigravity, agentoptions.KindModel, req)
 		c.mu.Lock()
 		c.antigravityModelValues = values
 		c.antigravityModelsReady = true
+		close(done)
 		c.mu.Unlock()
 	}()
 }
 
-func (c *wizardOptionDiscoveryCache) antigravityModelOptions() []string {
+func (c *wizardOptionDiscoveryCache) antigravityModelOptions(waitForPrefetch bool) []string {
 	c.mu.Lock()
 	if c.antigravityModelsReady {
-		values := c.antigravityModelValues
+		values := append([]string(nil), c.antigravityModelValues...)
 		c.mu.Unlock()
 		return values
 	}
+	done := c.antigravityModelsDone
+	started := c.antigravityModelsStarted
 	c.mu.Unlock()
+
+	if waitForPrefetch {
+		if started {
+			<-done
+			c.mu.Lock()
+			values := append([]string(nil), c.antigravityModelValues...)
+			c.mu.Unlock()
+			return values
+		}
+		return agentoptions.Values(AgentAntigravity, agentoptions.KindModel, wizardOptionDiscoveryRequestFunc())
+	}
+
 	return agentoptions.Values(AgentAntigravity, agentoptions.KindModel, agentoptions.DiscoveryRequest{})
 }
 

--- a/internal/wizard/option_discovery_test.go
+++ b/internal/wizard/option_discovery_test.go
@@ -1,12 +1,16 @@
 package wizard
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/conn-castle/agent-layer/internal/agentoptions"
+	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
 )
 
@@ -17,13 +21,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestPromptModelsAntigravityUsesLiveSharedOptions(t *testing.T) {
+func TestPromptModelsAntigravityUsesReadyAsyncPrefetch(t *testing.T) {
 	orig := wizardOptionDiscoveryRequestFunc
 	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
 
 	binDir := t.TempDir()
 	agyPath := filepath.Join(binDir, "agy")
-	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'Live Wizard Model\\nFallback Wizard Model\\n'\nfi\n"
+	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'Ready Async Model\\nFallback Wizard Model\\n'\nfi\n"
 	if err := os.WriteFile(agyPath, []byte(script), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
 		t.Fatalf("write agy stub: %v", err)
 	}
@@ -31,7 +35,7 @@ func TestPromptModelsAntigravityUsesLiveSharedOptions(t *testing.T) {
 		return agentoptions.DiscoveryRequest{
 			LookPath: func(name string) (string, error) {
 				if name != "agy" {
-					t.Fatalf("LookPath name = %q, want agy", name)
+					return "", errors.New("unexpected binary lookup")
 				}
 				return agyPath, nil
 			},
@@ -40,6 +44,10 @@ func TestPromptModelsAntigravityUsesLiveSharedOptions(t *testing.T) {
 		}
 	}
 
+	cache := &wizardOptionDiscoveryCache{}
+	cache.prefetchAntigravityModels()
+	waitForAntigravityModelDiscoveryReady(t, cache)
+
 	choices := NewChoices()
 	choices.EnabledAgents[AgentAntigravity] = true
 	ui := &MockUI{
@@ -47,24 +55,177 @@ func TestPromptModelsAntigravityUsesLiveSharedOptions(t *testing.T) {
 			if title != messages.WizardAntigravityModelTitle {
 				t.Fatalf("unexpected select title %q", title)
 			}
-			want := []string{messages.WizardLeaveBlankOption, "Live Wizard Model", "Fallback Wizard Model", messages.WizardCustomOption}
-			if len(options) != len(want) {
+			want := []string{messages.WizardLeaveBlankOption, "Ready Async Model", "Fallback Wizard Model", messages.WizardCustomOption}
+			if !slices.Equal(options, want) {
 				t.Fatalf("options = %v, want %v", options, want)
 			}
-			for i := range want {
-				if options[i] != want[i] {
-					t.Fatalf("options = %v, want %v", options, want)
-				}
-			}
-			*current = "Live Wizard Model"
+			*current = "Ready Async Model"
 			return nil
 		},
 	}
 
-	if err := promptModels(ui, choices); err != nil {
+	if err := promptModels(ui, choices, cache); err != nil {
 		t.Fatalf("promptModels error: %v", err)
 	}
-	if choices.AntigravityModel != "Live Wizard Model" {
-		t.Fatalf("AntigravityModel = %q, want live selection", choices.AntigravityModel)
+	if choices.AntigravityModel != "Ready Async Model" {
+		t.Fatalf("AntigravityModel = %q, want ready async selection", choices.AntigravityModel)
+	}
+}
+
+func TestPromptModelsAntigravityFallsBackWithoutWaitingForPendingAsyncPrefetch(t *testing.T) {
+	orig := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	releaseDiscovery := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseDiscovery()
+
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		return agentoptions.DiscoveryRequest{
+			LookPath: func(name string) (string, error) {
+				if name != "agy" {
+					return "", errors.New("unexpected binary lookup")
+				}
+				startedOnce.Do(func() { close(started) })
+				<-release
+				return "", errors.New("released pending discovery")
+			},
+			Live:    true,
+			Timeout: 30 * time.Second,
+		}
+	}
+
+	cache := &wizardOptionDiscoveryCache{}
+	cache.prefetchAntigravityModels()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async Antigravity model prefetch to start")
+	}
+
+	catalogOptions := config.FieldOptionValues(config.AntigravityModelFieldKey)
+	wantOptions := make([]string, 0, len(catalogOptions)+2)
+	wantOptions = append(wantOptions, messages.WizardLeaveBlankOption)
+	wantOptions = append(wantOptions, catalogOptions...)
+	wantOptions = append(wantOptions, messages.WizardCustomOption)
+
+	choices := NewChoices()
+	choices.EnabledAgents[AgentAntigravity] = true
+	ui := &MockUI{
+		SelectFunc: func(title string, options []string, current *string) error {
+			if title != messages.WizardAntigravityModelTitle {
+				t.Fatalf("unexpected select title %q", title)
+			}
+			if !slices.Equal(options, wantOptions) {
+				t.Fatalf("options = %v, want catalog fallback %v", options, wantOptions)
+			}
+			*current = messages.WizardLeaveBlankOption
+			return nil
+		},
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- promptModels(ui, choices, cache)
+	}()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("promptModels error: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("promptModels blocked waiting for pending Antigravity model prefetch")
+	}
+
+	releaseDiscovery()
+	waitForAntigravityModelDiscoveryReady(t, cache)
+}
+
+func TestPromptWizardFlowPrefetchesAntigravityModelsOnceAcrossModelRevisit(t *testing.T) {
+	orig := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
+
+	var discoveryRequests int
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		discoveryRequests++
+		return agentoptions.DiscoveryRequest{}
+	}
+
+	choices := NewChoices()
+	choices.ApprovalMode = config.ApprovalModeAll
+
+	var modelPrompts int
+	var enableLayerPrompts int
+	ui := &MockUI{
+		SelectFunc: func(title string, options []string, _ *string) error {
+			if title != messages.WizardAntigravityModelTitle {
+				return nil
+			}
+			modelPrompts++
+			wantOptions := append([]string{messages.WizardLeaveBlankOption}, config.FieldOptionValues(config.AntigravityModelFieldKey)...)
+			wantOptions = append(wantOptions, messages.WizardCustomOption)
+			if !slices.Equal(options, wantOptions) {
+				t.Fatalf("options = %v, want catalog fallback %v", options, wantOptions)
+			}
+			return nil
+		},
+		MultiSelectFunc: func(title string, _ []string, selected *[]string) error {
+			switch title {
+			case messages.WizardEnableAgentsTitle:
+				*selected = []string{AgentAntigravity}
+			case messages.WizardEnableDefaultMCPServersTitle:
+				*selected = []string{}
+			}
+			return nil
+		},
+		ConfirmFunc: func(title string, value *bool) error {
+			switch title {
+			case messages.WizardEnableAgentLayerPrompt:
+				enableLayerPrompts++
+				if enableLayerPrompts == 1 {
+					return errWizardBack
+				}
+				*value = false
+			case messages.WizardEnableWarningsPrompt:
+				*value = false
+			}
+			return nil
+		},
+	}
+
+	if err := promptWizardFlow(t.TempDir(), ui, choices); err != nil {
+		t.Fatalf("promptWizardFlow error: %v", err)
+	}
+	if modelPrompts != 2 {
+		t.Fatalf("model prompts = %d, want 2 after back-navigation revisit", modelPrompts)
+	}
+	if enableLayerPrompts != 2 {
+		t.Fatalf("enable-layer prompts = %d, want 2", enableLayerPrompts)
+	}
+	if discoveryRequests != 1 {
+		t.Fatalf("discovery requests = %d, want exactly one flow-owned prefetch", discoveryRequests)
+	}
+}
+
+func waitForAntigravityModelDiscoveryReady(t *testing.T, cache *wizardOptionDiscoveryCache) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		cache.mu.Lock()
+		ready := cache.antigravityModelsReady
+		cache.mu.Unlock()
+		if ready {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for async Antigravity model discovery")
+		case <-tick.C:
+		}
 	}
 }

--- a/internal/wizard/option_discovery_test.go
+++ b/internal/wizard/option_discovery_test.go
@@ -136,12 +136,138 @@ func TestPromptModelsAntigravityFallsBackWithoutWaitingForPendingAsyncPrefetch(t
 		if err != nil {
 			t.Fatalf("promptModels error: %v", err)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("promptModels blocked waiting for pending Antigravity model prefetch")
 	}
 
 	releaseDiscovery()
 	waitForAntigravityModelDiscoveryReady(t, cache)
+}
+
+func TestPromptModelsScriptedAntigravityWaitsForPendingAsyncPrefetch(t *testing.T) {
+	orig := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
+
+	binDir := t.TempDir()
+	agyPath := filepath.Join(binDir, "agy")
+	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'Live Scripted Model\\n'\nfi\n"
+	if err := os.WriteFile(agyPath, []byte(script), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
+		t.Fatalf("write agy stub: %v", err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	releaseDiscovery := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseDiscovery()
+
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		return agentoptions.DiscoveryRequest{
+			LookPath: func(name string) (string, error) {
+				if name != "agy" {
+					return "", errors.New("unexpected binary lookup")
+				}
+				startedOnce.Do(func() { close(started) })
+				<-release
+				return agyPath, nil
+			},
+			Live:    true,
+			Timeout: 30 * time.Second,
+		}
+	}
+
+	cache := &wizardOptionDiscoveryCache{}
+	cache.prefetchAntigravityModels()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async Antigravity model prefetch to start")
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		releaseDiscovery()
+	}()
+
+	choices := NewChoices()
+	choices.EnabledAgents[AgentAntigravity] = true
+	ui := &ScriptedUI{
+		answers: scriptedAnswers{
+			Select: map[string]string{messages.WizardAntigravityModelTitle: "Live Scripted Model"},
+		},
+		used: make(map[string]struct{}),
+	}
+
+	if err := promptModels(ui, choices, cache); err != nil {
+		t.Fatalf("promptModels error: %v", err)
+	}
+	if choices.AntigravityModel != "Live Scripted Model" {
+		t.Fatalf("AntigravityModel = %q, want live scripted selection", choices.AntigravityModel)
+	}
+}
+
+func TestAntigravityModelOptionsReturnsCachedCopy(t *testing.T) {
+	cache := &wizardOptionDiscoveryCache{
+		antigravityModelValues: []string{"Cached Model"},
+		antigravityModelsReady: true,
+	}
+
+	values := cache.antigravityModelOptions(false)
+	values[0] = "Mutated Model"
+
+	again := cache.antigravityModelOptions(false)
+	if !slices.Equal(again, []string{"Cached Model"}) {
+		t.Fatalf("cached values = %v, want immutable cached model", again)
+	}
+}
+
+func TestPrefetchAntigravityModelsStartsOnlyOnce(t *testing.T) {
+	orig := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var requestCalls int
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	releaseDiscovery := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseDiscovery()
+
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		requestCalls++
+		return agentoptions.DiscoveryRequest{
+			LookPath: func(name string) (string, error) {
+				if name != "agy" {
+					return "", errors.New("unexpected binary lookup")
+				}
+				startedOnce.Do(func() { close(started) })
+				<-release
+				return "", errors.New("released pending discovery")
+			},
+			Live:    true,
+			Timeout: 30 * time.Second,
+		}
+	}
+
+	cache := &wizardOptionDiscoveryCache{}
+	cache.prefetchAntigravityModels()
+	cache.prefetchAntigravityModels()
+	if requestCalls != 1 {
+		t.Fatalf("discovery requests = %d, want one idempotent prefetch", requestCalls)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async Antigravity model prefetch to start")
+	}
+
+	releaseDiscovery()
+	waitForAntigravityModelDiscoveryReady(t, cache)
+	cache.prefetchAntigravityModels()
+	if requestCalls != 1 {
+		t.Fatalf("discovery requests after completion = %d, want one idempotent prefetch", requestCalls)
+	}
 }
 
 func TestPromptWizardFlowPrefetchesAntigravityModelsOnceAcrossModelRevisit(t *testing.T) {
@@ -207,6 +333,43 @@ func TestPromptWizardFlowPrefetchesAntigravityModelsOnceAcrossModelRevisit(t *te
 	}
 	if discoveryRequests != 1 {
 		t.Fatalf("discovery requests = %d, want exactly one flow-owned prefetch", discoveryRequests)
+	}
+}
+
+func TestPromptWizardFlowSkipsAntigravityPrefetchWhenAgentDisabled(t *testing.T) {
+	orig := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
+
+	var discoveryRequests int
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		discoveryRequests++
+		return agentoptions.DiscoveryRequest{}
+	}
+
+	choices := NewChoices()
+	choices.ApprovalMode = config.ApprovalModeAll
+	ui := &MockUI{
+		MultiSelectFunc: func(title string, _ []string, selected *[]string) error {
+			switch title {
+			case messages.WizardEnableAgentsTitle, messages.WizardEnableDefaultMCPServersTitle:
+				*selected = []string{}
+			}
+			return nil
+		},
+		ConfirmFunc: func(title string, value *bool) error {
+			switch title {
+			case messages.WizardEnableAgentLayerPrompt, messages.WizardEnableWarningsPrompt:
+				*value = false
+			}
+			return nil
+		},
+	}
+
+	if err := promptWizardFlow(t.TempDir(), ui, choices); err != nil {
+		t.Fatalf("promptWizardFlow error: %v", err)
+	}
+	if discoveryRequests != 0 {
+		t.Fatalf("discovery requests = %d, want none when Antigravity stays disabled", discoveryRequests)
 	}
 }
 

--- a/internal/wizard/run_flow_test.go
+++ b/internal/wizard/run_flow_test.go
@@ -671,7 +671,7 @@ func TestPromptModels_FeatureTogglesPreSelectAndRoundTrip(t *testing.T) {
 		},
 	}
 
-	if err := promptModels(ui, choices); err != nil {
+	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
 		t.Fatalf("promptModels error: %v", err)
 	}
 
@@ -725,7 +725,7 @@ func TestPromptModels_CodexDisabledRendersNoCodexMultiSelect(t *testing.T) {
 		},
 	}
 
-	if err := promptModels(ui, choices); err != nil {
+	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
 		t.Fatalf("promptModels error: %v", err)
 	}
 
@@ -772,7 +772,7 @@ func TestPromptModels_VSCodeOnlyPromptsCodexLocalConfigDir(t *testing.T) {
 		},
 	}
 
-	if err := promptModels(ui, choices); err != nil {
+	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
 		t.Fatalf("promptModels error: %v", err)
 	}
 

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -415,6 +415,8 @@ const (
 
 // promptWizardFlow drives the step-by-step prompt loop.
 func promptWizardFlow(root string, ui UI, choices *Choices) error {
+	optionCache := &wizardOptionDiscoveryCache{}
+	optionCache.prefetchAntigravityModels()
 	// The workflow-bundle prompt is install-only. Once bundle evidence exists on
 	// disk, the wizard does not offer a refresh action; users who want a full
 	// managed workflow update can use `al upgrade`.
@@ -435,7 +437,7 @@ func promptWizardFlow(root string, ui UI, choices *Choices) error {
 		case wizardFlowStepAgents:
 			err = promptEnabledAgents(ui, choices)
 		case wizardFlowStepModels:
-			err = promptModels(ui, choices)
+			err = promptModels(ui, choices, optionCache)
 		case wizardFlowStepEnableLayer:
 			err = promptEnableAgentLayer(ui, choices)
 		case wizardFlowStepGitTracking:
@@ -672,9 +674,9 @@ func confirmWizardExitOnFirstStepEscape(ui UI) (bool, error) {
 	return exit, nil
 }
 
-func promptModels(ui UI, choices *Choices) error {
+func promptModels(ui UI, choices *Choices, optionCache *wizardOptionDiscoveryCache) error {
 	if choices.EnabledAgents[AgentAntigravity] {
-		if err := selectOptionalValue(ui, messages.WizardAntigravityModelTitle, modelOptions(AgentAntigravity), &choices.AntigravityModel); err != nil {
+		if err := selectOptionalValue(ui, messages.WizardAntigravityModelTitle, optionCache.antigravityModelOptions(), &choices.AntigravityModel); err != nil {
 			return err
 		}
 		choices.AntigravityModelTouched = true

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -416,7 +416,9 @@ const (
 // promptWizardFlow drives the step-by-step prompt loop.
 func promptWizardFlow(root string, ui UI, choices *Choices) error {
 	optionCache := &wizardOptionDiscoveryCache{}
-	optionCache.prefetchAntigravityModels()
+	if choices.EnabledAgents[AgentAntigravity] {
+		optionCache.prefetchAntigravityModels()
+	}
 	// The workflow-bundle prompt is install-only. Once bundle evidence exists on
 	// disk, the wizard does not offer a refresh action; users who want a full
 	// managed workflow update can use `al upgrade`.
@@ -436,6 +438,9 @@ func promptWizardFlow(root string, ui UI, choices *Choices) error {
 			err = promptApprovalMode(ui, choices)
 		case wizardFlowStepAgents:
 			err = promptEnabledAgents(ui, choices)
+			if err == nil && choices.EnabledAgents[AgentAntigravity] {
+				optionCache.prefetchAntigravityModels()
+			}
 		case wizardFlowStepModels:
 			err = promptModels(ui, choices, optionCache)
 		case wizardFlowStepEnableLayer:
@@ -676,7 +681,8 @@ func confirmWizardExitOnFirstStepEscape(ui UI) (bool, error) {
 
 func promptModels(ui UI, choices *Choices, optionCache *wizardOptionDiscoveryCache) error {
 	if choices.EnabledAgents[AgentAntigravity] {
-		if err := selectOptionalValue(ui, messages.WizardAntigravityModelTitle, optionCache.antigravityModelOptions(), &choices.AntigravityModel); err != nil {
+		_, scripted := ui.(*ScriptedUI)
+		if err := selectOptionalValue(ui, messages.WizardAntigravityModelTitle, optionCache.antigravityModelOptions(scripted), &choices.AntigravityModel); err != nil {
 			return err
 		}
 		choices.AntigravityModelTouched = true

--- a/internal/wizard/wizard_coverage_test.go
+++ b/internal/wizard/wizard_coverage_test.go
@@ -244,7 +244,7 @@ func TestPromptWizardAndHelpers_ErrorBranches(t *testing.T) {
 			ConfirmFunc: func(string, *bool) error {
 				return errors.New("confirm failed")
 			},
-		}, choices)
+		}, choices, &wizardOptionDiscoveryCache{})
 		if err == nil || !strings.Contains(err.Error(), "confirm failed") {
 			t.Fatalf("expected confirm error, got %v", err)
 		}
@@ -275,7 +275,7 @@ func TestPromptWizardAndHelpers_ErrorBranches(t *testing.T) {
 				}
 				return nil
 			},
-		}, choices)
+		}, choices, &wizardOptionDiscoveryCache{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -312,7 +312,7 @@ func TestPromptWizardAndHelpers_ErrorBranches(t *testing.T) {
 				}
 				return nil
 			},
-		}, choices)
+		}, choices, &wizardOptionDiscoveryCache{})
 		if err == nil || !strings.Contains(err.Error(), "codex features failed") {
 			t.Fatalf("expected codex features error, got %v", err)
 		}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -394,7 +394,7 @@ func TestPromptModels_SetsDisableToggles(t *testing.T) {
 		},
 	}
 
-	if err := promptModels(ui, choices); err != nil {
+	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
 		t.Fatalf("promptModels error: %v", err)
 	}
 
@@ -433,7 +433,7 @@ func TestPromptModels_AntigravityModelOptions(t *testing.T) {
 		},
 	}
 
-	if err := promptModels(ui, choices); err != nil {
+	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
 		t.Fatalf("promptModels error: %v", err)
 	}
 	assert.True(t, sawAntigravityModel)


### PR DESCRIPTION
## Summary
- prefetch Antigravity model discovery when the wizard flow starts
- use ready prefetched values at the model prompt, falling back to static catalog values without blocking
- cover ready, pending, and flow/back-navigation cache behavior

## Verification
- make test
- commit hook fast lane: pre-commit checks, tidy check, golangci-lint, go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wizard model selection now loads Antigravity model options in the background for faster, more responsive prompts.
  * Model choices can use cached results when available, with an immediate fallback if discovery is still running.

* **Bug Fixes**
  * Improved consistency when revisiting wizard steps so Antigravity model discovery is only triggered once per flow.
  * Updated related checks to preserve existing prompt behavior and selected values across navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->