### PR TITLE
fix: share agent option catalogs

### DIFF
--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -45,6 +45,9 @@ func TestBuildOptionsJSONShapeAndRandomExclusion(t *testing.T) {
 	if !claude.Model.OverrideSupported || len(claude.Model.Suggestions) == 0 || !claude.Model.AllowCustom {
 		t.Fatalf("unexpected claude model metadata: %#v", claude.Model)
 	}
+	if want := config.FieldOptionValues(config.ClaudeModelFieldKey); !slices.Equal(claude.Model.Suggestions, want) {
+		t.Fatalf("claude model suggestions = %v, want shared catalog %v", claude.Model.Suggestions, want)
+	}
 	var agy TargetOption
 	for _, target := range options.Targets {
 		if target.Agent == AgentAntigravity {

--- a/internal/agentoptions/options.go
+++ b/internal/agentoptions/options.go
@@ -55,13 +55,13 @@ var providers = map[string]map[Kind]fieldProvider{
 	},
 	"claude": {
 		KindModel: {
-			key: "agents.claude.model",
+			key: config.ClaudeModelFieldKey,
 			configured: func(cfg config.Config) string {
 				return cfg.Agents.Claude.Model
 			},
 		},
 		KindReasoningEffort: {
-			key: "agents.claude.reasoning_effort",
+			key: config.ClaudeReasoningEffortFieldKey,
 			configured: func(cfg config.Config) string {
 				return cfg.Agents.Claude.ReasoningEffort
 			},
@@ -69,13 +69,13 @@ var providers = map[string]map[Kind]fieldProvider{
 	},
 	"codex": {
 		KindModel: {
-			key: "agents.codex.model",
+			key: config.CodexModelFieldKey,
 			configured: func(cfg config.Config) string {
 				return cfg.Agents.Codex.Model
 			},
 		},
 		KindReasoningEffort: {
-			key: "agents.codex.reasoning_effort",
+			key: config.CodexReasoningEffortFieldKey,
 			configured: func(cfg config.Config) string {
 				return cfg.Agents.Codex.ReasoningEffort
 			},
@@ -83,7 +83,7 @@ var providers = map[string]map[Kind]fieldProvider{
 	},
 	"copilot_cli": {
 		KindModel: {
-			key: "agents.copilot_cli.model",
+			key: config.CopilotCLIModelFieldKey,
 			configured: func(cfg config.Config) string {
 				return cfg.Agents.CopilotCLI.Model
 			},

--- a/internal/agentoptions/options_test.go
+++ b/internal/agentoptions/options_test.go
@@ -57,6 +57,30 @@ func TestValuesFallsBackToCatalogWhenLiveDisabled(t *testing.T) {
 	}
 }
 
+func TestValuesUsesSharedStaticFieldCatalog(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent string
+		kind  Kind
+		key   string
+	}{
+		{name: "claude model", agent: "claude", kind: KindModel, key: config.ClaudeModelFieldKey},
+		{name: "claude reasoning", agent: "claude", kind: KindReasoningEffort, key: config.ClaudeReasoningEffortFieldKey},
+		{name: "codex model", agent: "codex", kind: KindModel, key: config.CodexModelFieldKey},
+		{name: "codex reasoning", agent: "codex", kind: KindReasoningEffort, key: config.CodexReasoningEffortFieldKey},
+		{name: "copilot cli model", agent: "copilot_cli", kind: KindModel, key: config.CopilotCLIModelFieldKey},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Values(tt.agent, tt.kind, DiscoveryRequest{Live: true})
+			want := config.FieldOptionValues(tt.key)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("values = %v, want shared catalog %v", got, want)
+			}
+		})
+	}
+}
+
 func TestConfiguredValueTrimsKnownAgentFields(t *testing.T) {
 	cfg := config.Config{
 		Agents: config.AgentsConfig{

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -71,7 +71,7 @@ var (
 	)
 	claudeReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max")
 	codexModelOptions            = fieldOptions("gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini")
-	codexReasoningEffortOptions  = fieldOptions("minimal", "low", "medium", "high", "xhigh")
+	codexReasoningEffortOptions  = fieldOptions("low", "medium", "high", "xhigh")
 	copilotCLIModelOptions       = fieldOptions("claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5", "gpt-5.4", "gpt-5.3-codex", "gemini-3-pro")
 )
 

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -31,10 +31,46 @@ type FieldDef struct {
 	AllowCustom bool // when true, enum fields also accept freetext values
 }
 
-// AntigravityModelFieldKey is the canonical config path for agy's model display
-// string. Sync projects this typed Agent Layer setting into Antigravity's
-// generated settings.json.
-const AntigravityModelFieldKey = "agents.antigravity.model"
+const (
+	// AntigravityModelFieldKey is the canonical config path for agy's model display
+	// string. Sync projects this typed Agent Layer setting into Antigravity's
+	// generated settings.json.
+	AntigravityModelFieldKey = "agents.antigravity.model"
+	// ClaudeModelFieldKey is the canonical config path for Claude Code model aliases.
+	ClaudeModelFieldKey = "agents.claude.model"
+	// ClaudeReasoningEffortFieldKey is the canonical config path for Claude Code effort.
+	ClaudeReasoningEffortFieldKey = "agents.claude.reasoning_effort"
+	// CodexModelFieldKey is the canonical config path for Codex model selection.
+	CodexModelFieldKey = "agents.codex.model"
+	// CodexReasoningEffortFieldKey is the canonical config path for Codex reasoning effort.
+	CodexReasoningEffortFieldKey = "agents.codex.reasoning_effort"
+	// CopilotCLIModelFieldKey is the canonical config path for Copilot CLI model selection.
+	CopilotCLIModelFieldKey = "agents.copilot_cli.model"
+)
+
+var (
+	antigravityModelOptions = fieldOptions(
+		"Gemini 3.5 Flash (Medium)",
+		"Gemini 3.5 Flash (High)",
+		"Gemini 3.5 Flash (Low)",
+		"Gemini 3.1 Pro (Low)",
+		"Gemini 3.1 Pro (High)",
+		"Claude Sonnet 4.6 (Thinking)",
+		"Claude Opus 4.6 (Thinking)",
+		"GPT-OSS 120B (Medium)",
+	)
+	claudeModelOptions = fieldOptions(
+		"default",
+		"sonnet",
+		"opus",
+		"haiku",
+		"fable",
+	)
+	claudeReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max")
+	codexModelOptions            = fieldOptions("gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini")
+	codexReasoningEffortOptions  = fieldOptions("low", "medium", "high", "xhigh")
+	copilotCLIModelOptions       = fieldOptions("claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5", "gpt-5.4", "gpt-5.3-codex", "gemini-3-pro")
+)
 
 // fields is the canonical ordered registry of all config fields with constrained values.
 // Order matches the wizard UI flow (approval → agents → models).
@@ -58,16 +94,7 @@ var fields = []FieldDef{
 		Key:         AntigravityModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options: []FieldOption{
-			{Value: "Gemini 3.5 Flash (Medium)"},
-			{Value: "Gemini 3.5 Flash (High)"},
-			{Value: "Gemini 3.5 Flash (Low)"},
-			{Value: "Gemini 3.1 Pro (Low)"},
-			{Value: "Gemini 3.1 Pro (High)"},
-			{Value: "Claude Sonnet 4.6 (Thinking)"},
-			{Value: "Claude Opus 4.6 (Thinking)"},
-			{Value: "GPT-OSS 120B (Medium)"},
-		},
+		Options:     antigravityModelOptions,
 	},
 	{
 		Key:     "agents.antigravity.dispatch.default_agent",
@@ -76,31 +103,16 @@ var fields = []FieldDef{
 	},
 	{Key: "agents.claude.enabled", Type: FieldBool, Required: true},
 	{
-		Key:         "agents.claude.model",
+		Key:         ClaudeModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options: []FieldOption{
-			{Value: "default"},
-			{Value: "fable"},
-			{Value: "sonnet"},
-			{Value: "opus"},
-			{Value: "haiku"},
-			{Value: "sonnet[1m]"},
-			{Value: "opus[1m]"},
-			{Value: "opusplan"},
-		},
+		Options:     claudeModelOptions,
 	},
 	{
-		Key:         "agents.claude.reasoning_effort",
+		Key:         ClaudeReasoningEffortFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options: []FieldOption{
-			{Value: "low"},
-			{Value: "medium"},
-			{Value: "high"},
-			{Value: "xhigh"},
-			{Value: "max"},
-		},
+		Options:     claudeReasoningEffortOptions,
 	},
 	{
 		Key:     "agents.claude.dispatch.default_agent",
@@ -113,28 +125,16 @@ var fields = []FieldDef{
 	{Key: "agents.claude_vscode.enabled", Type: FieldBool, Required: true},
 	{Key: "agents.codex.enabled", Type: FieldBool, Required: true},
 	{
-		Key:         "agents.codex.model",
+		Key:         CodexModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options: []FieldOption{
-			{Value: "gpt-5.4"},
-			{Value: "gpt-5.3-codex-spark"},
-			{Value: "gpt-5.3-codex"},
-			{Value: "gpt-5.2"},
-			{Value: "gpt-5.2-mini"},
-		},
+		Options:     codexModelOptions,
 	},
 	{
-		Key:         "agents.codex.reasoning_effort",
+		Key:         CodexReasoningEffortFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options: []FieldOption{
-			{Value: "minimal"},
-			{Value: "low"},
-			{Value: "medium"},
-			{Value: "high"},
-			{Value: "xhigh"},
-		},
+		Options:     codexReasoningEffortOptions,
 	},
 	{
 		Key:     "agents.codex.dispatch.default_agent",
@@ -148,18 +148,19 @@ var fields = []FieldDef{
 	{Key: "agents.vscode.enabled", Type: FieldBool, Required: true},
 	{Key: "agents.copilot_cli.enabled", Type: FieldBool, Required: true},
 	{
-		Key:         "agents.copilot_cli.model",
+		Key:         CopilotCLIModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options: []FieldOption{
-			{Value: "claude-opus-4.6"},
-			{Value: "claude-sonnet-4.6"},
-			{Value: "claude-haiku-4.5"},
-			{Value: "gpt-5.4"},
-			{Value: "gpt-5.3-codex"},
-			{Value: "gemini-3-pro"},
-		},
+		Options:     copilotCLIModelOptions,
 	},
+}
+
+func fieldOptions(values ...string) []FieldOption {
+	options := make([]FieldOption, len(values))
+	for i, value := range values {
+		options[i] = FieldOption{Value: value}
+	}
+	return options
 }
 
 func dispatchDefaultAgentOptions() []FieldOption {

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -65,10 +65,13 @@ var (
 		"opus",
 		"haiku",
 		"fable",
+		"sonnet[1m]",
+		"opus[1m]",
+		"opusplan",
 	)
 	claudeReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max")
 	codexModelOptions            = fieldOptions("gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini")
-	codexReasoningEffortOptions  = fieldOptions("low", "medium", "high", "xhigh")
+	codexReasoningEffortOptions  = fieldOptions("minimal", "low", "medium", "high", "xhigh")
 	copilotCLIModelOptions       = fieldOptions("claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5", "gpt-5.4", "gpt-5.3-codex", "gemini-3-pro")
 )
 

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -155,7 +155,7 @@ func TestLookupField_DispatchMaxDepth(t *testing.T) {
 
 func TestFieldOptionValues_ClaudeModelCatalog(t *testing.T) {
 	values := FieldOptionValues(ClaudeModelFieldKey)
-	want := []string{"default", "sonnet", "opus", "haiku", "fable"}
+	want := []string{"default", "sonnet", "opus", "haiku", "fable", "sonnet[1m]", "opus[1m]", "opusplan"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}
@@ -204,6 +204,19 @@ func TestFieldOptionValues_ClaudeReasoningCatalog(t *testing.T) {
 func TestFieldOptionValues_CodexModelCatalog(t *testing.T) {
 	values := FieldOptionValues(CodexModelFieldKey)
 	want := []string{"gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini"}
+	if len(values) != len(want) {
+		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
+	}
+	for i, expected := range want {
+		if values[i] != expected {
+			t.Fatalf("value at index %d = %q, want %q", i, values[i], expected)
+		}
+	}
+}
+
+func TestFieldOptionValues_CodexReasoningCatalog(t *testing.T) {
+	values := FieldOptionValues(CodexReasoningEffortFieldKey)
+	want := []string{"minimal", "low", "medium", "high", "xhigh"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -68,7 +68,7 @@ func TestLookupField_NotificationsChimeOptionalBool(t *testing.T) {
 }
 
 func TestLookupField_EnumWithCustom(t *testing.T) {
-	f, ok := LookupField("agents.claude.model")
+	f, ok := LookupField(ClaudeModelFieldKey)
 	if !ok {
 		t.Fatal("expected agents.claude.model to be in catalog")
 	}
@@ -154,8 +154,8 @@ func TestLookupField_DispatchMaxDepth(t *testing.T) {
 }
 
 func TestFieldOptionValues_ClaudeModelCatalog(t *testing.T) {
-	values := FieldOptionValues("agents.claude.model")
-	want := []string{"default", "fable", "sonnet", "opus", "haiku", "sonnet[1m]", "opus[1m]", "opusplan"}
+	values := FieldOptionValues(ClaudeModelFieldKey)
+	want := []string{"default", "sonnet", "opus", "haiku", "fable"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}
@@ -189,7 +189,7 @@ func TestFieldOptionValues_AntigravityModelCatalog(t *testing.T) {
 }
 
 func TestFieldOptionValues_ClaudeReasoningCatalog(t *testing.T) {
-	values := FieldOptionValues("agents.claude.reasoning_effort")
+	values := FieldOptionValues(ClaudeReasoningEffortFieldKey)
 	want := []string{"low", "medium", "high", "xhigh", "max"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
@@ -202,7 +202,7 @@ func TestFieldOptionValues_ClaudeReasoningCatalog(t *testing.T) {
 }
 
 func TestFieldOptionValues_CodexModelCatalog(t *testing.T) {
-	values := FieldOptionValues("agents.codex.model")
+	values := FieldOptionValues(CodexModelFieldKey)
 	want := []string{"gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
@@ -237,7 +237,7 @@ func TestFieldOptionValues_DispatchDefaultAgentCatalog(t *testing.T) {
 }
 
 func TestFieldOptionValues_CopilotCliModelCatalog(t *testing.T) {
-	values := FieldOptionValues("agents.copilot_cli.model")
+	values := FieldOptionValues(CopilotCLIModelFieldKey)
 	want := []string{"claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5", "gpt-5.4", "gpt-5.3-codex", "gemini-3-pro"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -216,7 +216,7 @@ func TestFieldOptionValues_CodexModelCatalog(t *testing.T) {
 
 func TestFieldOptionValues_CodexReasoningCatalog(t *testing.T) {
 	values := FieldOptionValues(CodexReasoningEffortFieldKey)
-	want := []string{"minimal", "low", "medium", "high", "xhigh"}
+	want := []string{"low", "medium", "high", "xhigh"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}

--- a/internal/templates/instructions/03_tools.md
+++ b/internal/templates/instructions/03_tools.md
@@ -7,7 +7,7 @@ effects.
 
 ## Time-sensitive verification (knowledge cutoff)
 - **Don't rely on training for anything that can change:** Treat internal knowledge as a hint, not a source. Verify with a retrieval tool before acting whenever the answer could have shifted — versions, prices, policies, schedules, specs, library/API surfaces, CLI flags, package availability, deprecations, error messages and their known fixes. Don't rely on memory for version-dependent details.
-- **Failed attempts trigger an immediate lookup:** When an approach you tried fails, search for the exact symptom plus the relevant tech before iterating. Don't loop on guesses — known causes and solutions usually exist, and finding them is faster than re-deriving them.
+- **Failed fixes trigger research:** When a fix attempt does not resolve an error or failure mode, stop guessing before trying another approach. Research up-to-date online information, compare plausible fixes, and implement the best-supported root-cause fix.
 - When you verify: include an as-of date, prefer primary/official sources, and cross-check independently when high impact.
 - If verification is impossible, state what could not be verified and why, describe the risk, and ask for confirmation before proceeding.
 

--- a/internal/templates/skills-catalog/agent-dispatch/SKILL.md
+++ b/internal/templates/skills-catalog/agent-dispatch/SKILL.md
@@ -50,11 +50,15 @@ work the current agent can perform directly with local shell commands.
 1. Inspect `al dispatch --help`.
 2. Follow live help to inspect target metadata before a real run.
 3. Choose the smallest target path that matches the user's intent.
-4. Verify any requested skill exists in the current project's Agent Layer skill
+4. Before starting a real dispatch, choose an execution mode that will not kill
+   the command while the target agent is still working. Use a persistent or
+   long-running shell/tool session, and avoid command wrappers or tool settings
+   that enforce a hard timeout.
+5. Verify any requested skill exists in the current project's Agent Layer skill
    source, or let `al dispatch` validation fail clearly. Do not invent a skill name.
-5. Send the focused prompt to one target. Omit unrelated conversation
+6. Send the focused prompt to one target. Omit unrelated conversation
    history and information that could bias the target.
-6. If a prompt file is needed, write it under `.agent-layer/tmp/`.
+7. If a prompt file is needed, write it under `.agent-layer/tmp/`.
 
 ## Guardrails
 
@@ -64,10 +68,11 @@ work the current agent can perform directly with local shell commands.
 - Do not use `al dispatch` to bypass the caller's restrictions, approvals, or
   sandbox expectations.
 - After starting a dispatch, let the running `al dispatch` command finish.
-  Do not wrap it in a command timeout or use a tool-level timeout intended to
-  stop it early; dispatch is allowed to run as long as the target needs. Use
-  progress and the final result from that process; do not poll, inspect, or read
-  dispatch artifacts with separate commands while it is active.
+  If the host tool separates output wait/yield duration from process lifetime,
+  only the output wait/yield duration may be bounded; keep the same dispatch
+  session alive until the original process exits. Use progress and the final
+  result from that process, and do not inspect dispatch artifacts with separate
+  commands while it is active.
 - Do not retry failed target launches by guessing flags, targets, models, or
   reasoning-effort values. Re-check help and options, then report the mismatch
   if it remains unresolved.

--- a/internal/templates/skills/resolve-findings/SKILL.md
+++ b/internal/templates/skills/resolve-findings/SKILL.md
@@ -67,6 +67,7 @@ Recommended roles:
 - Required: ask before editing only when the user explicitly limited the run to triage or report review.
 - Required: ask when no valid review report can be found and explicit report selection is needed.
 - Required: ask when an accepted fix would require materially broader scope or a real behavior change beyond the reviewed target.
+- Required: ask when an accepted finding has multiple valid fixes and the choice would affect user-facing behavior, architecture, ownership boundaries, data semantics, migration strategy, long-term platform policy, or materially larger scope.
 - When a checkpoint involves a genuine tradeoff between substantive alternatives, present at least two options with brief pros and cons, state which you recommend and why, and let the human decide.
 - Stay autonomous during verdicting and in-scope fixes when the request includes fixes.
 
@@ -114,6 +115,7 @@ Choose exactly one verdict for the accepted finding set:
 If the verdict is `revise`, update the plan or task list and repeat Phase 2.
 If the verdict is `escalate`, ask the smallest question that unblocks a trustworthy fix set.
 If the verdict is `rewrite-because-out-of-scope`, rewrite the accepted set to the largest still-in-scope subset, defer the rest explicitly, and repeat Phase 2.
+Do not treat an accepted finding as settling the implementation approach when the approach itself contains a substantive product or architecture decision.
 
 ### Phase 4: Implement accepted findings (Fixer)
 

--- a/internal/warnings/policy.go
+++ b/internal/warnings/policy.go
@@ -82,7 +82,7 @@ func CheckPolicy(project *config.ProjectConfig) []Warning {
 
 func claudeReasoningEffortUnknownWarning(effort string) *Warning {
 	trimmed := strings.TrimSpace(effort)
-	known := config.FieldOptionValues("agents.claude.reasoning_effort")
+	known := config.FieldOptionValues(config.ClaudeReasoningEffortFieldKey)
 	if trimmed == "" || slices.Contains(known, trimmed) {
 		return nil
 	}

--- a/internal/wizard/option_discovery_test.go
+++ b/internal/wizard/option_discovery_test.go
@@ -222,6 +222,26 @@ func TestAntigravityModelOptionsReturnsCachedCopy(t *testing.T) {
 	}
 }
 
+func TestClaudeModelOptionsUsesSharedFieldCatalog(t *testing.T) {
+	orig := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		return agentoptions.DiscoveryRequest{
+			Live: true,
+			LookPath: func(string) (string, error) {
+				t.Fatal("Claude model options must not run live discovery without an authoritative CLI source")
+				return "", errors.New("unexpected lookup")
+			},
+		}
+	}
+
+	got := modelOptions(AgentClaude)
+	want := config.FieldOptionValues(config.ClaudeModelFieldKey)
+	if !slices.Equal(got, want) {
+		t.Fatalf("Claude model options = %v, want shared catalog %v", got, want)
+	}
+}
+
 func TestPrefetchAntigravityModelsStartsOnlyOnce(t *testing.T) {
 	orig := wizardOptionDiscoveryRequestFunc
 	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })


### PR DESCRIPTION
## Summary
- centralize agent model and reasoning option catalogs behind canonical config field keys
- route agent options, wizard options, and warnings through the shared catalog
- tighten workflow template guidance for failed fixes and dispatch runtime handling

## Verification
- pre-commit hooks during commit passed: whitespace, merge-conflict checks, gofmt/goimports, go mod tidy check, golangci-lint, and Go tests