### PR TITLE
Refactor install prompt routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,15 @@ Notes:
 
 ---
 
-## Best practice guides
+## Documentation sets
 
+Universal best practices:
 - [Skill Design](https://agent-layer.dev/skill-design) (canonical source: `docs/SKILL-DESIGN.md`)
 - [CLI Skill Design](https://agent-layer.dev/cli-skill-design) (canonical source: `docs/CLI-SKILL-DESIGN.md`)
 - [Instruction Design](https://agent-layer.dev/instruction-design) (canonical source: `docs/INSTRUCTION-DESIGN.md`)
+
+Agent Layer approach:
+- [Skills approach](https://agent-layer.dev/docs/skills-approach) (canonical source: `site/docs/skills-approach.mdx`)
 
 ---
 

--- a/docs/CLI-SKILL-DESIGN.md
+++ b/docs/CLI-SKILL-DESIGN.md
@@ -2,15 +2,15 @@
 
 This document is the CLI-specific companion to `docs/SKILL-DESIGN.md`. It does
 not replace the general skill-authoring guide. Use this document when creating
-or reviewing Agent Layer skills that teach agents how to use an installed
-command line interface.
+or reviewing skills that teach agents how to use an installed command line
+interface.
 
 Research and standards in this guide were verified on 2026-05-26. The guide
 separates:
 
 - specification and client behavior
 - evidence-backed guidance for agent performance
-- Agent Layer heuristics for maintainable CLI skills
+- authoring heuristics for maintainable CLI skills
 
 The central rule is simple: **a CLI skill is a router and operating contract,
 not a copied manual**. The skill description routes the agent to the tool; the
@@ -30,9 +30,9 @@ installed CLI's help output supplies the current command reference.
 - Context-performance research: long-context degradation, lost-in-the-middle,
   instruction density, constraint composition, and context engineering.
 
-When this guide says "must", it is an Agent Layer authoring rule. When it says
-"should", it is the default recommendation unless a local product constraint
-requires a different design.
+When this guide says "must", it names a requirement for the CLI-skill authoring
+model described here. When it says "should", it is the default recommendation
+unless a local product constraint requires a different design.
 
 ---
 
@@ -109,15 +109,15 @@ The description should not include:
 
 Length budget:
 
-- 512 characters is the hard maximum for Agent Layer-authored skill
-  descriptions, even though the cross-client Agent Skills specification permits
-  up to 1,024 characters.
-- Prefer 200-260 characters for CLI skills. This range is a repo-local budget,
-  not an external standard: Codex's unknown-context fallback is 8,000
-  characters for the whole initial skill list, including names, descriptions,
-  and paths. A 25-30 skill catalog only has about 260-320 characters per skill
-  before names, paths, and formatting, so descriptions need to stay below that
-  to leave routing headroom.
+- The cross-client Agent Skills specification permits descriptions up to 1,024
+  characters. This guide recommends a more conservative 512-character internal
+  budget.
+- Prefer 200-260 characters for CLI skills. This range is an authoring
+  heuristic, not an external standard: Codex's unknown-context fallback is
+  8,000 characters for the whole initial skill list, including names,
+  descriptions, and paths. A 25-30 skill catalog only has about 260-320
+  characters per skill before names, paths, and formatting, so descriptions
+  need to stay below that to leave routing headroom.
 - Descriptions over 300 characters need a concrete routing reason. Use that
   space only for trigger boundaries, not extra examples or workflow steps.
 
@@ -479,7 +479,8 @@ routing, safety, and workflow rules; installed CLI help provides command syntax.
 
 ## Required Artifacts
 
-- Put agent-only scratch files under `.agent-layer/tmp/`.
+- Put agent-only scratch files under the project's documented scratch or
+  artifact directory.
 - Report every artifact path created.
 
 ## Global Constraints

--- a/docs/INSTRUCTION-DESIGN.md
+++ b/docs/INSTRUCTION-DESIGN.md
@@ -1,13 +1,13 @@
 # Instruction Design Guide
 
-This document is the canonical instruction-authoring guide for repo-local
-instruction sources such as `.agent-layer/instructions/*.md`.
+This document is the canonical instruction-authoring guide for always-loaded
+agent instruction sources.
 
 Research and sources in this guide were verified on 2026-03-16. The guide
 intentionally separates:
 - evidence-backed design principles
 - practical authoring guidance
-- repo heuristics used to keep instructions maintainable
+- authoring heuristics used to keep instructions maintainable
 
 Participant-terminology sources were checked on 2026-07-04.
 
@@ -26,7 +26,7 @@ apply them to different authoring surfaces.
   ComplexBench.
 
 When this guide gives a numeric limit, it is either a published finding or
-explicitly labeled as a local heuristic.
+explicitly labeled as an authoring heuristic.
 
 ---
 
@@ -191,7 +191,8 @@ wastes the model's attention budget on redundant content.
 - Anthropic [ref 1]: "Find the smallest set of high-signal tokens."
 
 **Authoring guidance:**
-- If a rule appears in `00_rules.md`, do not restate it in `01_base.md`.
+- If a rule appears in one always-loaded instruction file, do not restate it in
+  another always-loaded instruction file.
 - If a behavior is fully specified in a skill file, do not re-specify it in
   the base instruction files.
 - When two instruction files need to reference the same concept, have one
@@ -315,7 +316,7 @@ in practice.
 | Overly detailed prompts vs simple | 4.0% vs 10.0% Task Success | [ref 10] |
 | Minimal agent (~100 lines) | >74% SWE-bench Verified | [ref 11] |
 
-**Repo heuristics (local, not universal):**
+**Authoring heuristics (local examples, not universal standards):**
 - Each instruction file should aim for the minimum content needed to prevent
   observed failure modes.
 - If an instruction file exceeds 50 lines, audit it for duplication,

--- a/docs/SKILL-DESIGN.md
+++ b/docs/SKILL-DESIGN.md
@@ -1,7 +1,7 @@
 # Skill Design Guide
 
-This document is the canonical skill-authoring guide for repo-local skill
-sources such as `.agent-layer/skills/<name>/SKILL.md`.
+This document is the canonical skill-authoring guide for portable agent skill
+sources such as `skills/<name>/SKILL.md`.
 
 This guide is the skill-authoring counterpart to `docs/INSTRUCTION-DESIGN.md`,
 which covers instruction-file authoring. The two documents share several
@@ -13,16 +13,16 @@ For skills that route agents to installed command line tools, use
 
 Research and standards in this guide were re-verified on 2026-04-18. The guide
 intentionally separates:
-- specification or product requirements
+- specification or client requirements
 - evidence-backed authoring guidance
-- repo heuristics used to keep skills maintainable
+- authoring heuristics used to keep skills maintainable
 
 Participant-terminology sources were checked on 2026-07-04.
 
 ## Evidence model
 
 - Standards and platform behavior: Agent Skills specification, OpenAI Codex
-  skills docs, and agent-layer's own validator/README.
+  skills docs, and client validation behavior.
 - Official prompting guidance: Anthropic and OpenAI agent/prompting docs.
 - Empirical studies: long-context, instruction-following, constraint-
   composition, and context-rot papers.
@@ -30,24 +30,24 @@ Participant-terminology sources were checked on 2026-07-04.
   skills.
 
 When this guide gives a numeric limit, it is either a published limit or
-explicitly labeled as a local heuristic.
+explicitly labeled as an authoring heuristic.
 
 ---
 
-## Specification and product requirements
+## Specification and client requirements
 
 ### Canonical source format
 
-- Author skills in directory format: `.agent-layer/skills/<name>/SKILL.md`
-  [ref 1].
+- Author portable skills in directory format: `skills/<name>/SKILL.md`, or the
+  equivalent directory format required by the target client [ref 1].
 - Required frontmatter fields: `name`, `description` [ref 1].
 - Optional frontmatter fields: `license`, `compatibility`, `metadata`,
   `allowed-tools` [ref 1].
-- `name` must match the directory name and pass agent-layer validation.
+- `name` must match the directory name and pass the target client's validation.
 - `description` must explain both what the skill does and when it should
   trigger. The Agent Skills specification permits up to 1,024 characters
-  [ref 1], but Agent Layer-authored skills use a stricter hard maximum of 512
-  characters.
+  [ref 1]. This guide recommends a more conservative 512-character internal
+  budget so descriptions stay useful in large catalogs.
 - `name` must be 1-64 characters, lowercase alphanumeric and hyphens only, no
   leading/trailing/consecutive hyphens [ref 1].
 
@@ -63,9 +63,9 @@ explicitly labeled as a local heuristic.
   the context window is unknown; Codex shortens descriptions first when many
   skills are installed [ref 3]. The 8,000-character fallback is independent of
   large model context windows.
-- `al doctor` warns when all skill names plus descriptions (the always-loaded
-  catalog metadata) exceed an estimated ~4,000-token budget.
-- `al doctor` warns when a skill source exceeds 500 lines.
+- Validation tooling should warn when all skill names plus descriptions (the
+  always-loaded catalog metadata) exceed the product's catalog budget.
+- Validation tooling should warn when a skill source exceeds 500 lines.
 - Treat 500 lines as a warning threshold, not a design target.
 
 ### Experimental surfaces
@@ -74,11 +74,11 @@ explicitly labeled as a local heuristic.
 - `compatibility` should only be used for real environment requirements such as
   tools, network access, or intended runtime.
 
-### Current agent-layer implementation
+### Portability expectation
 
-- Agent Layer syncs skills natively to each client's skill directory with full
-  subdirectory support (`scripts/`, `references/`, `assets/`).
-- Companion files are available to agents alongside `SKILL.md` during execution.
+- Clients differ in how they project and load skill directories.
+- Companion files may be available to agents alongside `SKILL.md` during
+  execution.
 - Skills should still be understandable from `SKILL.md` alone for maximum
   portability across clients.
 
@@ -111,10 +111,10 @@ trigger conditions [ref 8]. This maps directly to skill activation: the
 Authoring guidance:
 - Write the `description` for routing, not marketing. State the job, likely
   trigger phrases, and nearby non-goals.
-- Keep descriptions concise enough to survive catalog truncation. The hard
-  maximum is 512 characters, and most descriptions should fit well below that;
-  if a description approaches the limit, move examples, setup, and workflow
-  detail into the body.
+- Keep descriptions concise enough to survive catalog truncation. This guide
+  recommends a 512-character internal budget, and most descriptions should fit
+  well below that; if a description approaches the budget, move examples, setup,
+  and workflow detail into the body.
 - Every description should answer two questions: **what** the skill does and
   **when** it should fire. Descriptions that answer only "what" leak into
   neighboring territory; descriptions that answer only "when" fail to help the
@@ -137,8 +137,8 @@ Authoring guidance:
 | --- | --- | --- |
 | `Helps with documents` | No domain, no trigger, no negative | `Create, edit, and analyze .docx files. Use for tracked changes, comments, formatting, or text extraction. Do not use for PDFs or plain text.` |
 | `API helper` | Fires on anything API-shaped | `Use when writing code that calls an external model API. Covers authentication, request construction, and streaming responses.` |
-| `Fix code quality` | Overlaps with every quality skill | `Assess code complexity, remove dead code, simplify complex functions. Scoped to uncommitted changes when they exist, otherwise full codebase. Use audit-tests for test suite health; use boost-coverage to add missing tests.` |
-| `Review things` | Router cannot disambiguate review-scope vs review-plan | `Review explicit files, directories, diffs, or uncommitted changes and produce a findings report. Use review-plan instead when the target is a plan/task/context artifact set.` |
+| `Fix code quality` | Overlaps with every quality skill | `Assess code complexity, remove dead code, and simplify complex functions. Use a test-audit skill for test-suite health; use a coverage skill to add missing behavior coverage.` |
+| `Review things` | Router cannot disambiguate code review vs plan review | `Review explicit files, directories, diffs, or uncommitted changes and produce a findings report. Use plan-review instead when the target is a design or implementation plan.` |
 
 Philipp Schmid reports "50% improvements just by improving the description"
 [ref 19] — refining a vague description is often the highest-leverage change
@@ -177,9 +177,9 @@ Authoring guidance:
   decision rules.
 - Avoid mode-switching sections like `if mode X` / `if mode Y` unless the
   branches are tiny and inseparable.
-- Prefer separate skills for separate targets, such as `review-plan` versus
-  `review-scope`.
-- Local heuristic: if a skill needs the same branching explanation more than
+- Prefer separate skills for separate targets, such as plan review versus code
+  review.
+- Authoring heuristic: if a skill needs the same branching explanation more than
   once, it is a strong candidate for splitting.
 - When two skills share structural similarity (e.g., both use an audit loop),
   accept the duplication until there are at least three real consumers of the
@@ -234,7 +234,7 @@ Authoring guidance:
 - Every token in `SKILL.md` should change the model's behavior. If removing a
   sentence would not change what the model does, the sentence should not be
   there.
-- Repo heuristic: most healthy skills should stay roughly in the 150-300 line
+- Authoring heuristic: most healthy skills should stay roughly in the 150-300 line
   range; cross 300 only with a clear reason. The validator warning at 500 lines
   is the hard backstop.
 
@@ -423,8 +423,8 @@ actions [ref 3].
 Authoring guidance:
 - Name the exact ambiguity trigger that requires user input.
 - Keep the normal path autonomous.
-- Prefer concrete checkpoint rules such as `ask before creating a missing
-  memory file` or `ask before applying destructive deletes`.
+- Prefer concrete checkpoint rules such as `ask before creating a required
+  missing artifact` or `ask before applying destructive deletes`.
 - Avoid generic instructions like `ask when uncertain`.
 - Limit the number of distinct checkpoint conditions. Each one is an
   instruction the model must carry, competing for attention with the workflow.
@@ -499,8 +499,8 @@ Authoring guidance:
 
 OpenAI's skills docs explicitly warn that skills can influence planning, tool
 usage, and command execution, and should be treated as privileged
-instructions/code [ref 3]. This matters even for repo-local skills: the skill
-author is defining what the agent is allowed to believe is the intended
+instructions/code [ref 3]. This matters even for locally installed skills: the
+skill author is defining what the agent is allowed to believe is the intended
 workflow.
 
 **Evidence — context is trusted by default:**
@@ -558,8 +558,8 @@ Authoring guidance:
 - When a skill delegates to sub-agents, expect summaries (1,000-2,000 tokens)
   rather than full transcripts.
 - Prefer file-based artifacts over in-context accumulation for multi-step
-  workflows. Write intermediate results to `.agent-layer/tmp/` and reference
-  them by path.
+  workflows. Write intermediate results to a documented scratch or artifact
+  directory and reference them by path.
 - Be aware that a 300-line skill loaded into a 200K-token context is a small
   fraction of the window, but a 300-line skill loaded after 180K tokens of
   prior conversation is competing for the model's remaining attention.
@@ -626,7 +626,7 @@ Authoring guidance:
 
 ---
 
-## Recommended section order for agent-layer skills
+## Recommended section order for agent skills
 
 | Section | Purpose | Why it belongs there |
 | --- | --- | --- |
@@ -705,22 +705,21 @@ Before considering a skill done, verify that:
 
 ---
 
-## Repo heuristics that are intentionally not universal
+## Implementation-specific conventions
 
-These are local preferences for this repository, not claims about the wider
-ecosystem:
+These examples are intentionally not universal. Product-specific skill systems
+may adopt conventions like these, but they should be documented outside the
+portable best-practice guide when they are normative for one product:
 - Aim for skills that are comfortably below the 500-line validator warning;
-  150-300 lines is the healthy default range here.
+  150-300 lines is a reasonable default range for many workflow skills.
 - Prefer separate skills over wrapper/base-skill patterns until there are at
   least three real consumers of the shared structure.
-- Use repo-local artifact naming under
-  `.agent-layer/tmp/<skill-name>.<run-id>.<type>.md` when the workflow produces
-  reviewable intermediate files.
+- Use a documented artifact naming pattern when the workflow produces reviewable
+  intermediate files.
 - Favor stable section names (`Defaults`, `Global constraints`,
   `Human checkpoints`, `Guardrails`, `Final handoff`) so reviewers can compare
   skills quickly.
-- Accept structural duplication between skills with similar audit-loop shapes
-  (e.g., `audit-and-fix-uncommitted-changes` and `improve-codebase`) rather
+- Accept structural duplication between skills with similar loop shapes rather
   than extracting a shared abstraction prematurely.
 
 ---

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -264,27 +264,14 @@ func validatePrompter(prompter Prompter, overwrite bool) error {
 	if !overwrite {
 		return nil
 	}
-	if prompter == nil {
-		return fmt.Errorf(messages.InstallOverwritePromptRequired)
-	}
-	if validator, ok := prompter.(promptValidator); ok {
-		if !validator.hasOverwriteAll() {
-			return fmt.Errorf(messages.InstallOverwritePromptRequired)
-		}
-		if !validator.hasOverwriteAllMemory() {
-			return fmt.Errorf(messages.InstallOverwritePromptRequired)
-		}
-		if !validator.hasOverwrite() {
-			return fmt.Errorf(messages.InstallOverwritePromptRequired)
-		}
-		if !validator.hasDeleteUnknownAll() {
-			return fmt.Errorf(messages.InstallDeleteUnknownPromptRequired)
-		}
-		if !validator.hasDeleteUnknown() {
-			return fmt.Errorf(messages.InstallDeleteUnknownPromptRequired)
-		}
-	}
-	return nil
+	return newPromptRouter(prompter).validateRequiredOverwrite()
+}
+
+// promptRouter returns a prompt router bound to the installer's prompter. The
+// router is stateless and cheap to build, so it is constructed per call rather
+// than cached; this keeps it correct for tests that reassign inst.prompter.
+func (inst *installer) promptRouter() *promptRouter {
+	return newPromptRouter(inst.prompter)
 }
 
 func (inst upgradeOrchestrator) ensureBaseDirs() error {

--- a/internal/install/install_overwrite.go
+++ b/internal/install/install_overwrite.go
@@ -10,17 +10,14 @@ import (
 	"github.com/conn-castle/agent-layer/internal/messages"
 )
 
-type unifiedOverwritePrompter interface {
-	OverwriteAllUnified(managed []DiffPreview, memory []DiffPreview) (bool, bool, error)
-}
-
 // shouldOverwrite decides whether to overwrite the given path.
 // It returns true to overwrite, false to keep existing content, or an error.
 func (inst *installer) shouldOverwrite(path string) (bool, error) {
 	if !inst.overwrite {
 		return false, nil
 	}
-	if inst.hasUnifiedOverwritePrompter() && (!inst.overwriteAllDecided || !inst.overwriteMemoryAllDecided) {
+	router := inst.promptRouter()
+	if router.hasUnifiedOverwrite() && (!inst.overwriteAllDecided || !inst.overwriteMemoryAllDecided) {
 		if err := inst.resolveUnifiedOverwriteAllDecisions(); err != nil {
 			return false, err
 		}
@@ -55,33 +52,19 @@ func (inst *installer) shouldOverwrite(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return inst.prompter.Overwrite(preview)
-}
-
-func (inst *installer) hasUnifiedOverwritePrompter() bool {
-	if inst.prompter == nil {
-		return false
+	resp, err := router.route(promptRequest{kind: promptKindOverwrite, preview: preview})
+	if err != nil {
+		return false, err
 	}
-	unified, ok := inst.prompter.(unifiedOverwritePrompter)
-	if !ok || unified == nil {
-		return false
-	}
-	validator, ok := inst.prompter.(promptValidator)
-	if !ok {
-		return false
-	}
-	return validator.hasOverwriteAllUnified()
+	return resp.approved, nil
 }
 
 func (inst *installer) resolveUnifiedOverwriteAllDecisions() error {
 	if inst.overwriteAllDecided && inst.overwriteMemoryAllDecided {
 		return nil
 	}
-	if inst.prompter == nil {
-		return fmt.Errorf(messages.InstallOverwritePromptRequired)
-	}
-	unified, ok := inst.prompter.(unifiedOverwritePrompter)
-	if !ok {
+	router := inst.promptRouter()
+	if !router.hasUnifiedOverwrite() {
 		return fmt.Errorf(messages.InstallOverwritePromptRequired)
 	}
 
@@ -113,12 +96,16 @@ func (inst *installer) resolveUnifiedOverwriteAllDecisions() error {
 		return nil
 	}
 
-	overwriteManaged, overwriteMemory, err := unified.OverwriteAllUnified(managedPreviews, memoryPreviews)
+	resp, err := router.route(promptRequest{
+		kind:           promptKindOverwriteAllUnified,
+		previews:       managedPreviews,
+		memoryPreviews: memoryPreviews,
+	})
 	if err != nil {
 		return err
 	}
-	inst.overwriteAll = overwriteManaged
-	inst.overwriteMemoryAll = overwriteMemory
+	inst.overwriteAll = resp.approved
+	inst.overwriteMemoryAll = resp.approvedMemory
 	inst.overwriteAllDecided = true
 	inst.overwriteMemoryAllDecided = true
 	return nil
@@ -126,66 +113,77 @@ func (inst *installer) resolveUnifiedOverwriteAllDecisions() error {
 
 // shouldOverwriteAllManaged resolves the "overwrite all managed files" decision.
 func (inst *installer) shouldOverwriteAllManaged() (bool, error) {
-	if inst.overwriteAllDecided {
-		return inst.overwriteAll, nil
-	}
-	if inst.hasUnifiedOverwritePrompter() {
-		if err := inst.resolveUnifiedOverwriteAllDecisions(); err != nil {
-			return false, err
-		}
-		return inst.overwriteAll, nil
-	}
-	if inst.prompter == nil {
-		return false, fmt.Errorf(messages.InstallOverwritePromptRequired)
-	}
-	diffs, err := inst.templates().listManagedLabeledDiffs()
-	if err != nil {
-		return false, err
-	}
-	previews, index, err := inst.buildManagedDiffPreviews(diffs)
-	if err != nil {
-		return false, err
-	}
-	inst.managedDiffPreviews = index
-	overwriteAll, err := inst.prompter.OverwriteAll(previews)
-	if err != nil {
-		return false, err
-	}
-	inst.overwriteAll = overwriteAll
-	inst.overwriteAllDecided = true
-	return overwriteAll, nil
+	return inst.resolveOverwriteAllDecision(
+		&inst.overwriteAllDecided,
+		&inst.overwriteAll,
+		promptKindOverwriteAll,
+		func() ([]DiffPreview, error) {
+			diffs, err := inst.templates().listManagedLabeledDiffs()
+			if err != nil {
+				return nil, err
+			}
+			previews, index, err := inst.buildManagedDiffPreviews(diffs)
+			if err != nil {
+				return nil, err
+			}
+			inst.managedDiffPreviews = index
+			return previews, nil
+		},
+	)
 }
 
 // shouldOverwriteAllMemory resolves the "overwrite all memory files" decision.
 func (inst *installer) shouldOverwriteAllMemory() (bool, error) {
-	if inst.overwriteMemoryAllDecided {
-		return inst.overwriteMemoryAll, nil
+	return inst.resolveOverwriteAllDecision(
+		&inst.overwriteMemoryAllDecided,
+		&inst.overwriteMemoryAll,
+		promptKindOverwriteAllMemory,
+		func() ([]DiffPreview, error) {
+			diffs, err := inst.templates().listMemoryLabeledDiffs()
+			if err != nil {
+				return nil, err
+			}
+			previews, index, err := inst.buildMemoryDiffPreviews(diffs)
+			if err != nil {
+				return nil, err
+			}
+			inst.memoryDiffPreviews = index
+			return previews, nil
+		},
+	)
+}
+
+func (inst *installer) resolveOverwriteAllDecision(
+	decided *bool,
+	decision *bool,
+	kind promptKind,
+	buildPreviews func() ([]DiffPreview, error),
+) (bool, error) {
+	if *decided {
+		return *decision, nil
 	}
-	if inst.hasUnifiedOverwritePrompter() {
+	router := inst.promptRouter()
+	if router.hasUnifiedOverwrite() {
 		if err := inst.resolveUnifiedOverwriteAllDecisions(); err != nil {
 			return false, err
 		}
-		return inst.overwriteMemoryAll, nil
+		return *decision, nil
 	}
 	if inst.prompter == nil {
 		return false, fmt.Errorf(messages.InstallOverwritePromptRequired)
 	}
-	diffs, err := inst.templates().listMemoryLabeledDiffs()
+
+	previews, err := buildPreviews()
 	if err != nil {
 		return false, err
 	}
-	previews, index, err := inst.buildMemoryDiffPreviews(diffs)
+	resp, err := router.route(promptRequest{kind: kind, previews: previews})
 	if err != nil {
 		return false, err
 	}
-	inst.memoryDiffPreviews = index
-	overwriteAll, err := inst.prompter.OverwriteAllMemory(previews)
-	if err != nil {
-		return false, err
-	}
-	inst.overwriteMemoryAll = overwriteAll
-	inst.overwriteMemoryAllDecided = true
-	return overwriteAll, nil
+	*decision = resp.approved
+	*decided = true
+	return resp.approved, nil
 }
 
 // isMemoryPath reports whether the path is under docs/agent-layer.

--- a/internal/install/install_overwrite_test.go
+++ b/internal/install/install_overwrite_test.go
@@ -248,28 +248,28 @@ func TestShouldOverwrite_MissingPrompter(t *testing.T) {
 func TestHasUnifiedOverwritePrompter(t *testing.T) {
 	t.Run("nil prompter", func(t *testing.T) {
 		inst := &installer{prompter: nil}
-		if inst.hasUnifiedOverwritePrompter() {
+		if inst.promptRouter().hasUnifiedOverwrite() {
 			t.Fatalf("expected false for nil prompter")
 		}
 	})
 
 	t.Run("prompter without unified callback", func(t *testing.T) {
 		inst := &installer{prompter: plainPrompter{}}
-		if inst.hasUnifiedOverwritePrompter() {
+		if inst.promptRouter().hasUnifiedOverwrite() {
 			t.Fatalf("expected false for prompter without unified support")
 		}
 	})
 
 	t.Run("unified prompter without validator", func(t *testing.T) {
 		inst := &installer{prompter: unifiedOnlyPrompter{}}
-		if inst.hasUnifiedOverwritePrompter() {
+		if inst.promptRouter().hasUnifiedOverwrite() {
 			t.Fatalf("expected false for unified prompter without validator")
 		}
 	})
 
 	t.Run("validator exists but unified callback disabled", func(t *testing.T) {
 		inst := &installer{prompter: PromptFuncs{}}
-		if inst.hasUnifiedOverwritePrompter() {
+		if inst.promptRouter().hasUnifiedOverwrite() {
 			t.Fatalf("expected false when unified callback is not configured")
 		}
 	})
@@ -282,7 +282,7 @@ func TestHasUnifiedOverwritePrompter(t *testing.T) {
 				},
 			},
 		}
-		if !inst.hasUnifiedOverwritePrompter() {
+		if !inst.promptRouter().hasUnifiedOverwrite() {
 			t.Fatalf("expected true when unified callback is configured")
 		}
 	})

--- a/internal/install/install_unknowns.go
+++ b/internal/install/install_unknowns.go
@@ -109,21 +109,22 @@ func (inst *installer) handleNonTmpUnknowns(tmpUnknowns, otherUnknowns []string)
 	if len(otherUnknowns) == 0 {
 		return nil
 	}
+	router := inst.promptRouter()
 	rel := inst.collapsedRelativePathList(tmpUnknowns, otherUnknowns)
-	deleteAll, err := inst.prompter.DeleteUnknownAll(rel)
+	deleteAll, err := router.route(promptRequest{kind: promptKindDeleteUnknownAll, paths: rel})
 	if err != nil {
 		return err
 	}
-	if deleteAll {
+	if deleteAll.approved {
 		return inst.deleteUnknowns(otherUnknowns)
 	}
 	for _, path := range otherUnknowns {
 		relPath := inst.relativePath(path)
-		deletePath, err := inst.prompter.DeleteUnknown(relPath)
+		deletePath, err := router.route(promptRequest{kind: promptKindDeleteUnknown, path: relPath})
 		if err != nil {
 			return err
 		}
-		if deletePath {
+		if deletePath.approved {
 			if err := inst.sys.RemoveAll(path); err != nil {
 				return fmt.Errorf(messages.InstallDeleteUnknownFailedFmt, relPath, err)
 			}
@@ -135,30 +136,21 @@ func (inst *installer) handleNonTmpUnknowns(tmpUnknowns, otherUnknowns []string)
 // handleTmpUnknowns asks one grouped yes/no question for every unknown path
 // under `.agent-layer/tmp/`. Tmp deletion is destructive (it can wipe
 // in-progress agent run artifacts) so it requires an affirmative grouped
-// answer; if the prompter does not implement tmpUnknownsPrompter (or has the
-// method defined but not wired in a PromptFuncs), tmp paths are left
-// untouched rather than falling back to per-file prompts. This guarantees no
-// code path can delete tmp content without going through the dedicated
-// destructive-action confirmation in the grouped prompt.
+// answer; when the router reports the grouped tmp capability as unavailable
+// (see newPromptRouter) the routed prompt returns "not approved" and tmp paths
+// are left untouched rather than falling back to per-file prompts. This
+// guarantees no code path can delete tmp content without going through the
+// dedicated destructive-action confirmation in the grouped prompt.
 func (inst *installer) handleTmpUnknowns(tmpUnknowns []string) error {
 	if len(tmpUnknowns) == 0 {
 		return nil
 	}
-	grouped, ok := inst.prompter.(tmpUnknownsPrompter)
-	if ok {
-		if validator, vok := inst.prompter.(promptValidator); vok && !validator.hasDeleteUnknownTmpAll() {
-			ok = false
-		}
-	}
-	if !ok {
-		return nil
-	}
 	rel := inst.relativePathList(tmpUnknowns)
-	deleteTmp, err := grouped.DeleteUnknownTmpAll(rel)
+	deleteTmp, err := inst.promptRouter().route(promptRequest{kind: promptKindDeleteUnknownTmpAll, paths: rel})
 	if err != nil {
 		return err
 	}
-	if !deleteTmp {
+	if !deleteTmp.approved {
 		return nil
 	}
 	return inst.deleteUnknowns(tmpUnknowns)

--- a/internal/install/prompter.go
+++ b/internal/install/prompter.go
@@ -235,6 +235,10 @@ func (p PromptFuncs) hasDeleteUnknownTmpAll() bool {
 	return p.DeleteUnknownTmpAllFunc != nil
 }
 
+func (p PromptFuncs) hasStatuslineSource() bool {
+	return p.StatuslineSourcePreviewFunc != nil
+}
+
 // unifiedOverwritePrompter is an optional interface a Prompter can implement to
 // resolve the managed and memory overwrite-all decisions in a single pass. The
 // router only selects it when the prompter also implements promptValidator and
@@ -243,6 +247,10 @@ func (p PromptFuncs) hasDeleteUnknownTmpAll() bool {
 // and memory overwrite-all prompts.
 type unifiedOverwritePrompter interface {
 	OverwriteAllUnified(managed []DiffPreview, memory []DiffPreview) (bool, bool, error)
+}
+
+type statuslineSourceValidator interface {
+	hasStatuslineSource() bool
 }
 
 // promptKind identifies which prompt category a promptRequest represents.
@@ -338,7 +346,13 @@ func newPromptRouter(prompter Prompter) *promptRouter {
 		}
 	}
 	if statusline, ok := prompter.(statuslineSourcePrompter); ok {
-		r.statusline = statusline
+		wired := true
+		if validator, vok := prompter.(statuslineSourceValidator); vok && !validator.hasStatuslineSource() {
+			wired = false
+		}
+		if wired {
+			r.statusline = statusline
+		}
 	}
 	if configDefault, ok := prompter.(configSetDefaultPrompter); ok {
 		r.configDefault = configDefault

--- a/internal/install/prompter.go
+++ b/internal/install/prompter.go
@@ -118,11 +118,12 @@ func (p PromptFuncs) DeleteUnknown(path string) (bool, error) {
 // DeleteUnknownTmpAll prompts the user to confirm deleting all unknown paths
 // under .agent-layer/tmp/ as a group. Returns an error when no
 // DeleteUnknownTmpAllFunc is configured, mirroring the no-silent-fallback
-// behavior of the other prompt callbacks. Per-file fallback for callers that
-// construct a PromptFuncs without wiring DeleteUnknownTmpAllFunc — and for
-// legacy Prompter implementations that don't implement tmpUnknownsPrompter at
-// all — is provided in handleTmpUnknowns, which probes promptValidator before
-// invoking this method.
+// behavior of the other prompt callbacks. The grouped-vs-untouched fallback for
+// callers that construct a PromptFuncs without wiring DeleteUnknownTmpAllFunc —
+// and for legacy Prompter implementations that don't implement
+// tmpUnknownsPrompter at all — is owned by the promptRouter, which probes
+// promptValidator (see newPromptRouter) and leaves tmp paths untouched rather
+// than invoking this method.
 func (p PromptFuncs) DeleteUnknownTmpAll(paths []string) (bool, error) {
 	if p.DeleteUnknownTmpAllFunc == nil {
 		return false, fmt.Errorf(messages.InstallDeleteUnknownPromptRequired)
@@ -133,7 +134,8 @@ func (p PromptFuncs) DeleteUnknownTmpAll(paths []string) (bool, error) {
 // configSetDefaultPrompter is an optional interface that a Prompter can
 // implement to interactively confirm or customize config_set_default
 // migration values. When the Prompter does not implement this interface (or
-// returns nil), the migration uses the manifest value directly.
+// PromptFuncs has no callback wired), the migration uses the manifest value
+// directly.
 type configSetDefaultPrompter interface {
 	ConfigSetDefault(key string, manifestValue any, rationale string, field *config.FieldDef) (any, error)
 }
@@ -199,8 +201,8 @@ type promptValidator interface {
 // hasDeleteUnknownTmpAll() == true. The second step exists because PromptFuncs
 // always satisfies this interface (the method is defined on the struct), so
 // callers that build a PromptFuncs without wiring DeleteUnknownTmpAllFunc
-// would otherwise hit the "prompt required" error instead of falling back to
-// the per-file DeleteUnknown loop. handleTmpUnknowns performs both probes.
+// would otherwise hit the "prompt required" error instead of leaving tmp paths
+// untouched. newPromptRouter performs both probes.
 type tmpUnknownsPrompter interface {
 	DeleteUnknownTmpAll(paths []string) (bool, error)
 }
@@ -231,4 +233,213 @@ func (p PromptFuncs) hasDeleteUnknown() bool {
 
 func (p PromptFuncs) hasDeleteUnknownTmpAll() bool {
 	return p.DeleteUnknownTmpAllFunc != nil
+}
+
+// unifiedOverwritePrompter is an optional interface a Prompter can implement to
+// resolve the managed and memory overwrite-all decisions in a single pass. The
+// router only selects it when the prompter also implements promptValidator and
+// reports the unified callback as wired (see newPromptRouter); a prompter that
+// implements this interface without promptValidator keeps the separate managed
+// and memory overwrite-all prompts.
+type unifiedOverwritePrompter interface {
+	OverwriteAllUnified(managed []DiffPreview, memory []DiffPreview) (bool, bool, error)
+}
+
+// promptKind identifies which prompt category a promptRequest represents.
+type promptKind int
+
+const (
+	promptKindOverwriteAll promptKind = iota
+	promptKindOverwriteAllMemory
+	promptKindOverwriteAllUnified
+	promptKindOverwrite
+	promptKindStatuslineSource
+	promptKindDeleteUnknownAll
+	promptKindDeleteUnknown
+	promptKindDeleteUnknownTmpAll
+	promptKindConfigSetDefault
+	promptKindConfirmSkillsMigration
+)
+
+// promptRequest carries the data a single prompt category needs. Only the
+// fields relevant to kind are populated by the caller.
+type promptRequest struct {
+	kind promptKind
+
+	previews       []DiffPreview // overwrite-all managed batch (also unified managed batch)
+	memoryPreviews []DiffPreview // unified memory batch
+	preview        DiffPreview   // single overwrite / statusline source
+
+	paths []string // delete-unknown-all / delete-unknown-tmp-all
+	path  string   // single delete-unknown
+
+	configKey     string
+	manifestValue any
+	rationale     string
+	field         *config.FieldDef
+
+	flatSkills []string
+	conflicts  []SkillsMigrationConflict
+}
+
+// promptResponse carries a prompt outcome. Which fields are meaningful depends
+// on the request kind: approved is the primary yes/no decision, approvedMemory
+// is the second unified overwrite-all decision, and value is the resolved
+// config default.
+type promptResponse struct {
+	approved       bool
+	approvedMemory bool
+	value          any
+}
+
+// promptRouter is the single place install/upgrade prompt decisions flow
+// through. It wraps a Prompter, resolves the optional prompt capabilities once
+// under the fixed capability policy, and applies the fallback for each optional
+// prompt category so callers no longer repeat optional-interface probing.
+type promptRouter struct {
+	prompter      Prompter
+	unified       unifiedOverwritePrompter
+	tmpUnknowns   tmpUnknownsPrompter
+	statusline    statuslineSourcePrompter
+	configDefault configSetDefaultPrompter
+	skills        skillsMigrationPrompter
+}
+
+// newPromptRouter resolves prompter's optional prompt capabilities under the
+// current capability policy. It accepts a nil prompter so validation can run
+// before an installer exists.
+func newPromptRouter(prompter Prompter) *promptRouter {
+	r := &promptRouter{prompter: prompter}
+	if prompter == nil {
+		return r
+	}
+	// Unified overwrite requires the unified interface AND a promptValidator
+	// that reports the unified callback as wired. A prompter that implements
+	// the interface but not promptValidator does NOT get unified overwrite,
+	// preserving the separate managed and memory overwrite-all prompts.
+	if unified, ok := prompter.(unifiedOverwritePrompter); ok && unified != nil {
+		if validator, vok := prompter.(promptValidator); vok && validator.hasOverwriteAllUnified() {
+			r.unified = unified
+		}
+	}
+	// Tmp grouped deletion requires the tmp interface and, when the prompter
+	// also implements promptValidator, the tmp callback reported as wired. A
+	// prompter without promptValidator keeps the capability (legacy Prompter
+	// implementations). PromptFuncs always satisfies the interface, so the
+	// validator probe distinguishes a wired callback from a zero value; when it
+	// is unwired, tmp paths are left untouched rather than routed elsewhere.
+	if grouped, ok := prompter.(tmpUnknownsPrompter); ok {
+		wired := true
+		if validator, vok := prompter.(promptValidator); vok && !validator.hasDeleteUnknownTmpAll() {
+			wired = false
+		}
+		if wired {
+			r.tmpUnknowns = grouped
+		}
+	}
+	if statusline, ok := prompter.(statuslineSourcePrompter); ok {
+		r.statusline = statusline
+	}
+	if configDefault, ok := prompter.(configSetDefaultPrompter); ok {
+		r.configDefault = configDefault
+	}
+	if skills, ok := prompter.(skillsMigrationPrompter); ok {
+		r.skills = skills
+	}
+	return r
+}
+
+// hasUnifiedOverwrite reports whether the wrapped prompter resolves the managed
+// and memory overwrite-all decisions in one unified pass.
+func (r *promptRouter) hasUnifiedOverwrite() bool { return r.unified != nil }
+
+// hasStatuslineSource reports whether the wrapped prompter can prompt for a
+// user-owned statusline source replacement. Callers gate the (file-reading)
+// diff-preview build on this when the prompter lacks the optional interface.
+func (r *promptRouter) hasStatuslineSource() bool { return r.statusline != nil }
+
+// validateRequiredOverwrite enforces that a Prompter used in overwrite mode
+// wires the required core overwrite and delete callbacks before any overwrite
+// work begins. It preserves the historical early-error messages.
+func (r *promptRouter) validateRequiredOverwrite() error {
+	if r.prompter == nil {
+		return fmt.Errorf(messages.InstallOverwritePromptRequired)
+	}
+	validator, ok := r.prompter.(promptValidator)
+	if !ok {
+		return nil
+	}
+	if !validator.hasOverwriteAll() {
+		return fmt.Errorf(messages.InstallOverwritePromptRequired)
+	}
+	if !validator.hasOverwriteAllMemory() {
+		return fmt.Errorf(messages.InstallOverwritePromptRequired)
+	}
+	if !validator.hasOverwrite() {
+		return fmt.Errorf(messages.InstallOverwritePromptRequired)
+	}
+	if !validator.hasDeleteUnknownAll() {
+		return fmt.Errorf(messages.InstallDeleteUnknownPromptRequired)
+	}
+	if !validator.hasDeleteUnknown() {
+		return fmt.Errorf(messages.InstallDeleteUnknownPromptRequired)
+	}
+	return nil
+}
+
+// route dispatches a prompt request to the wrapped prompter, applying the fixed
+// fallback policy for the optional prompt categories. It is the single entry
+// point for every install/upgrade prompt decision.
+func (r *promptRouter) route(req promptRequest) (promptResponse, error) {
+	switch req.kind {
+	case promptKindOverwriteAll:
+		approved, err := r.prompter.OverwriteAll(req.previews)
+		return promptResponse{approved: approved}, err
+	case promptKindOverwriteAllMemory:
+		approved, err := r.prompter.OverwriteAllMemory(req.previews)
+		return promptResponse{approved: approved}, err
+	case promptKindOverwriteAllUnified:
+		managed, memory, err := r.unified.OverwriteAllUnified(req.previews, req.memoryPreviews)
+		return promptResponse{approved: managed, approvedMemory: memory}, err
+	case promptKindOverwrite:
+		approved, err := r.prompter.Overwrite(req.preview)
+		return promptResponse{approved: approved}, err
+	case promptKindStatuslineSource:
+		// Missing statusline prompt keeps an existing customized source.
+		if r.statusline == nil {
+			return promptResponse{}, nil
+		}
+		approved, err := r.statusline.StatuslineSource(req.preview)
+		return promptResponse{approved: approved}, err
+	case promptKindDeleteUnknownAll:
+		approved, err := r.prompter.DeleteUnknownAll(req.paths)
+		return promptResponse{approved: approved}, err
+	case promptKindDeleteUnknown:
+		approved, err := r.prompter.DeleteUnknown(req.path)
+		return promptResponse{approved: approved}, err
+	case promptKindDeleteUnknownTmpAll:
+		// Missing grouped tmp prompt leaves tmp paths untouched; tmp deletion
+		// only ever happens through this dedicated destructive confirmation.
+		if r.tmpUnknowns == nil {
+			return promptResponse{}, nil
+		}
+		approved, err := r.tmpUnknowns.DeleteUnknownTmpAll(req.paths)
+		return promptResponse{approved: approved}, err
+	case promptKindConfigSetDefault:
+		// Missing config-default prompt uses the migration manifest value.
+		if r.configDefault == nil {
+			return promptResponse{value: req.manifestValue}, nil
+		}
+		value, err := r.configDefault.ConfigSetDefault(req.configKey, req.manifestValue, req.rationale, req.field)
+		return promptResponse{value: value}, err
+	case promptKindConfirmSkillsMigration:
+		// Missing skills-migration prompt proceeds (headless default).
+		if r.skills == nil {
+			return promptResponse{approved: true}, nil
+		}
+		approved, err := r.skills.ConfirmSkillsMigration(req.flatSkills, req.conflicts)
+		return promptResponse{approved: approved}, err
+	default:
+		return promptResponse{}, fmt.Errorf("install: unknown prompt kind %d", req.kind)
+	}
 }

--- a/internal/install/prompter_router_test.go
+++ b/internal/install/prompter_router_test.go
@@ -93,10 +93,22 @@ func TestPromptRouter_DeleteUnknownTmpAll_LegacyWithoutValidatorRoutes(t *testin
 
 func TestPromptRouter_StatuslineSource_FallbackNeverOverwrites(t *testing.T) {
 	// A prompter that does not implement the statusline capability must never
-	// authorize overwriting a customized statusline source.
+	// authorize overwriting a customized statusline source. A zero PromptFuncs
+	// also has the method set, but the router must not advertise the capability
+	// unless the callback is wired; callers use that gate to avoid building the
+	// statusline diff preview.
 	router := newPromptRouter(plainPrompter{})
 	if router.hasStatuslineSource() {
 		t.Fatal("plain prompter must not advertise the statusline capability")
+	}
+	if newPromptRouter(PromptFuncs{}).hasStatuslineSource() {
+		t.Fatal("PromptFuncs without a wired statusline callback must not advertise the capability")
+	}
+	wired := newPromptRouter(PromptFuncs{
+		StatuslineSourcePreviewFunc: func(DiffPreview) (bool, error) { return true, nil },
+	})
+	if !wired.hasStatuslineSource() {
+		t.Fatal("PromptFuncs with a wired statusline callback must advertise the capability")
 	}
 	resp, err := router.route(promptRequest{kind: promptKindStatuslineSource})
 	if err != nil {

--- a/internal/install/prompter_router_test.go
+++ b/internal/install/prompter_router_test.go
@@ -1,0 +1,194 @@
+package install
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/config"
+	"github.com/conn-castle/agent-layer/internal/messages"
+)
+
+// tmpOnlyNoValidatorPrompter satisfies the base Prompter and the optional
+// grouped tmp deletion capability, but NOT promptValidator. It models a legacy
+// Prompter implementation that predates the promptValidator probe: under the
+// tmp capability rule such a prompter still gets grouped tmp deletion (the
+// validator step is skipped when absent). This is the distinct half of the tmp
+// rule that differs from the unified-overwrite rule.
+type tmpOnlyNoValidatorPrompter struct {
+	plainPrompter
+	called *bool
+	answer bool
+}
+
+func (p tmpOnlyNoValidatorPrompter) DeleteUnknownTmpAll([]string) (bool, error) {
+	if p.called != nil {
+		*p.called = true
+	}
+	return p.answer, nil
+}
+
+func TestPromptRouter_UnifiedOverwrite_RequiresValidator(t *testing.T) {
+	// Unified overwrite must be selected ONLY when the prompter implements both
+	// the unified interface and promptValidator (reporting the callback wired).
+	// A prompter that implements the interface but not promptValidator keeps the
+	// separate managed/memory prompts — treating it as unified would change the
+	// prompt flow.
+	if newPromptRouter(unifiedOnlyPrompter{}).hasUnifiedOverwrite() {
+		t.Fatal("unified interface without promptValidator must not select unified overwrite")
+	}
+	if newPromptRouter(PromptFuncs{}).hasUnifiedOverwrite() {
+		t.Fatal("PromptFuncs without a wired unified callback must not select unified overwrite")
+	}
+
+	router := newPromptRouter(PromptFuncs{
+		OverwriteAllUnifiedPreviewFunc: func([]DiffPreview, []DiffPreview) (bool, bool, error) {
+			return true, false, nil
+		},
+	})
+	if !router.hasUnifiedOverwrite() {
+		t.Fatal("PromptFuncs with a wired unified callback must select unified overwrite")
+	}
+	resp, err := router.route(promptRequest{kind: promptKindOverwriteAllUnified})
+	if err != nil {
+		t.Fatalf("route unified: %v", err)
+	}
+	if !resp.approved || resp.approvedMemory {
+		t.Fatalf("unified route must surface both decisions: managed=%v memory=%v", resp.approved, resp.approvedMemory)
+	}
+}
+
+func TestPromptRouter_DeleteUnknownTmpAll_UnavailableLeavesUntouched(t *testing.T) {
+	// A PromptFuncs without DeleteUnknownTmpAllFunc must not delete tmp: the
+	// router reports the grouped capability as unavailable and route returns
+	// "not approved" without invoking any callback. Tmp deletion is destructive
+	// and only ever allowed through an affirmative grouped answer.
+	router := newPromptRouter(PromptFuncs{
+		DeleteUnknownTmpAllFunc: nil,
+	})
+	resp, err := router.route(promptRequest{kind: promptKindDeleteUnknownTmpAll, paths: []string{".agent-layer/tmp/x"}})
+	if err != nil {
+		t.Fatalf("route tmp: %v", err)
+	}
+	if resp.approved {
+		t.Fatal("tmp deletion must not be approved when the grouped callback is unwired")
+	}
+}
+
+func TestPromptRouter_DeleteUnknownTmpAll_LegacyWithoutValidatorRoutes(t *testing.T) {
+	// The tmp rule differs from the unified rule: a tmp-capable prompter that
+	// does NOT implement promptValidator still gets grouped tmp deletion.
+	called := false
+	router := newPromptRouter(tmpOnlyNoValidatorPrompter{called: &called, answer: true})
+	resp, err := router.route(promptRequest{kind: promptKindDeleteUnknownTmpAll, paths: []string{".agent-layer/tmp/x"}})
+	if err != nil {
+		t.Fatalf("route tmp: %v", err)
+	}
+	if !called {
+		t.Fatal("grouped tmp callback must be invoked for a legacy tmp-capable prompter without promptValidator")
+	}
+	if !resp.approved {
+		t.Fatal("expected the grouped tmp answer to be surfaced")
+	}
+}
+
+func TestPromptRouter_StatuslineSource_FallbackNeverOverwrites(t *testing.T) {
+	// A prompter that does not implement the statusline capability must never
+	// authorize overwriting a customized statusline source.
+	router := newPromptRouter(plainPrompter{})
+	if router.hasStatuslineSource() {
+		t.Fatal("plain prompter must not advertise the statusline capability")
+	}
+	resp, err := router.route(promptRequest{kind: promptKindStatuslineSource})
+	if err != nil {
+		t.Fatalf("route statusline: %v", err)
+	}
+	if resp.approved {
+		t.Fatal("missing statusline prompt must keep the existing source (not approved)")
+	}
+}
+
+func TestPromptRouter_ConfigSetDefault_FallbackUsesManifestValue(t *testing.T) {
+	// When the prompter cannot confirm a config default, the migration manifest
+	// value must be used verbatim.
+	router := newPromptRouter(plainPrompter{})
+	resp, err := router.route(promptRequest{kind: promptKindConfigSetDefault, manifestValue: "manifest"})
+	if err != nil {
+		t.Fatalf("route config default: %v", err)
+	}
+	if resp.value != "manifest" {
+		t.Fatalf("expected manifest value fallback, got %v", resp.value)
+	}
+}
+
+func TestPromptRouter_ConfigSetDefault_WiredReturnsPromptedValue(t *testing.T) {
+	router := newPromptRouter(PromptFuncs{
+		ConfigSetDefaultFunc: func(string, any, string, *config.FieldDef) (any, error) {
+			return "chosen", nil
+		},
+	})
+	resp, err := router.route(promptRequest{kind: promptKindConfigSetDefault, manifestValue: "manifest"})
+	if err != nil {
+		t.Fatalf("route config default: %v", err)
+	}
+	if resp.value != "chosen" {
+		t.Fatalf("expected wired prompt value, got %v", resp.value)
+	}
+}
+
+func TestPromptRouter_ConfirmSkillsMigration_FallbackProceeds(t *testing.T) {
+	// A prompter without the skills-migration capability proceeds automatically
+	// (headless default) once preflight has passed.
+	router := newPromptRouter(plainPrompter{})
+	resp, err := router.route(promptRequest{kind: promptKindConfirmSkillsMigration})
+	if err != nil {
+		t.Fatalf("route skills migration: %v", err)
+	}
+	if !resp.approved {
+		t.Fatal("missing skills-migration prompt must proceed (approved)")
+	}
+
+	declined := newPromptRouter(PromptFuncs{
+		ConfirmSkillsMigrationFunc: func([]string, []SkillsMigrationConflict) (bool, error) {
+			return false, nil
+		},
+	})
+	resp, err = declined.route(promptRequest{kind: promptKindConfirmSkillsMigration})
+	if err != nil {
+		t.Fatalf("route skills migration declined: %v", err)
+	}
+	if resp.approved {
+		t.Fatal("a wired skills-migration prompt that declines must not be approved")
+	}
+}
+
+func TestPromptRouter_ValidateRequiredOverwrite(t *testing.T) {
+	if err := newPromptRouter(nil).validateRequiredOverwrite(); err == nil ||
+		!strings.Contains(err.Error(), messages.InstallOverwritePromptRequired) {
+		t.Fatalf("nil prompter must be rejected in overwrite mode, got %v", err)
+	}
+	// A non-PromptFuncs Prompter (no promptValidator) is trusted to implement
+	// the required methods and must pass validation.
+	if err := newPromptRouter(plainPrompter{}).validateRequiredOverwrite(); err != nil {
+		t.Fatalf("plain Prompter without promptValidator must pass validation, got %v", err)
+	}
+	// A PromptFuncs missing required callbacks must fail with the delete error
+	// once the overwrite callbacks are satisfied.
+	partial := PromptFuncs{
+		OverwriteAllPreviewFunc:       func([]DiffPreview) (bool, error) { return false, nil },
+		OverwriteAllMemoryPreviewFunc: func([]DiffPreview) (bool, error) { return false, nil },
+		OverwritePreviewFunc:          func(DiffPreview) (bool, error) { return false, nil },
+	}
+	if err := newPromptRouter(partial).validateRequiredOverwrite(); err == nil ||
+		!strings.Contains(err.Error(), messages.InstallDeleteUnknownPromptRequired) {
+		t.Fatalf("missing delete callbacks must be rejected, got %v", err)
+	}
+}
+
+func TestPromptRouter_UnknownKind_ReturnsError(t *testing.T) {
+	// The router must reject an unrecognized prompt kind rather than silently
+	// returning a zero decision that a caller could act on.
+	_, err := newPromptRouter(PromptFuncs{}).route(promptRequest{kind: promptKind(-1)})
+	if err == nil {
+		t.Fatal("expected an error for an unknown prompt kind")
+	}
+}

--- a/internal/install/prompter_router_test.go
+++ b/internal/install/prompter_router_test.go
@@ -117,6 +117,13 @@ func TestPromptRouter_StatuslineSource_FallbackNeverOverwrites(t *testing.T) {
 	if resp.approved {
 		t.Fatal("missing statusline prompt must keep the existing source (not approved)")
 	}
+	resp, err = newPromptRouter(PromptFuncs{}).route(promptRequest{kind: promptKindStatuslineSource})
+	if err != nil {
+		t.Fatalf("route zero-value PromptFuncs statusline: %v", err)
+	}
+	if resp.approved {
+		t.Fatal("zero-value PromptFuncs statusline prompt must keep the existing source (not approved)")
+	}
 }
 
 func TestPromptRouter_ConfigSetDefault_FallbackUsesManifestValue(t *testing.T) {
@@ -129,6 +136,13 @@ func TestPromptRouter_ConfigSetDefault_FallbackUsesManifestValue(t *testing.T) {
 	}
 	if resp.value != "manifest" {
 		t.Fatalf("expected manifest value fallback, got %v", resp.value)
+	}
+	resp, err = newPromptRouter(PromptFuncs{}).route(promptRequest{kind: promptKindConfigSetDefault, manifestValue: "manifest"})
+	if err != nil {
+		t.Fatalf("route zero-value PromptFuncs config default: %v", err)
+	}
+	if resp.value != "manifest" {
+		t.Fatalf("zero-value PromptFuncs expected manifest value fallback, got %v", resp.value)
 	}
 }
 
@@ -157,6 +171,13 @@ func TestPromptRouter_ConfirmSkillsMigration_FallbackProceeds(t *testing.T) {
 	}
 	if !resp.approved {
 		t.Fatal("missing skills-migration prompt must proceed (approved)")
+	}
+	resp, err = newPromptRouter(PromptFuncs{}).route(promptRequest{kind: promptKindConfirmSkillsMigration})
+	if err != nil {
+		t.Fatalf("route zero-value PromptFuncs skills migration: %v", err)
+	}
+	if !resp.approved {
+		t.Fatal("zero-value PromptFuncs skills-migration prompt must proceed (approved)")
 	}
 
 	declined := newPromptRouter(PromptFuncs{

--- a/internal/install/statusline_sources.go
+++ b/internal/install/statusline_sources.go
@@ -96,15 +96,17 @@ func (inst *installer) writeStatuslineSource(source StatuslineSourceTemplate) er
 		return nil
 	}
 	overwrite := false
-	if prompt, ok := inst.prompter.(statuslineSourcePrompter); ok {
+	router := inst.promptRouter()
+	if router.hasStatuslineSource() {
 		preview, previewErr := inst.buildStatuslineSourceDiffPreview(source)
 		if previewErr != nil {
 			return previewErr
 		}
-		overwrite, err = prompt.StatuslineSource(preview)
-		if err != nil {
-			return err
+		resp, routeErr := router.route(promptRequest{kind: promptKindStatuslineSource, preview: preview})
+		if routeErr != nil {
+			return routeErr
 		}
+		overwrite = resp.approved
 	}
 	if !overwrite {
 		return nil

--- a/internal/install/upgrade_migrations.go
+++ b/internal/install/upgrade_migrations.go
@@ -795,17 +795,21 @@ func (inst *installer) executeConfigSetDefaultMigration(op upgradeMigrationOpera
 	if unmarshalErr := json.Unmarshal(rawValue, &decoded); unmarshalErr != nil {
 		return false, fmt.Errorf("decode default value for key %s: %w", keyPath, unmarshalErr)
 	}
-	if prompter, ok := inst.prompter.(configSetDefaultPrompter); ok {
-		var fieldPtr *config.FieldDef
-		if f, found := config.LookupField(keyPath); found {
-			fieldPtr = &f
-		}
-		prompted, promptErr := prompter.ConfigSetDefault(keyPath, decoded, op.Rationale, fieldPtr)
-		if promptErr != nil {
-			return false, fmt.Errorf("prompt for config key %s: %w", keyPath, promptErr)
-		}
-		decoded = prompted
+	var fieldPtr *config.FieldDef
+	if f, found := config.LookupField(keyPath); found {
+		fieldPtr = &f
 	}
+	resp, promptErr := inst.promptRouter().route(promptRequest{
+		kind:          promptKindConfigSetDefault,
+		configKey:     keyPath,
+		manifestValue: decoded,
+		rationale:     op.Rationale,
+		field:         fieldPtr,
+	})
+	if promptErr != nil {
+		return false, fmt.Errorf("prompt for config key %s: %w", keyPath, promptErr)
+	}
+	decoded = resp.value
 	if setErr := setNestedConfigValue(cfg, parts, decoded, true); setErr != nil {
 		return false, setErr
 	}

--- a/internal/install/upgrade_migrations_skills.go
+++ b/internal/install/upgrade_migrations_skills.go
@@ -125,14 +125,16 @@ func (inst *installer) preflightAndConfirmSkillsMigration() error {
 	}
 
 	// Prompt for confirmation (before any mutations happen).
-	if prompter, ok := inst.prompter.(skillsMigrationPrompter); ok {
-		proceed, promptErr := prompter.ConfirmSkillsMigration(flatSkills, conflicts)
-		if promptErr != nil {
-			return fmt.Errorf(messages.InstallSkillsMigrationPromptErrFmt, promptErr)
-		}
-		if !proceed {
-			return fmt.Errorf(messages.InstallSkillsMigrationDeclinedErr)
-		}
+	resp, promptErr := inst.promptRouter().route(promptRequest{
+		kind:       promptKindConfirmSkillsMigration,
+		flatSkills: flatSkills,
+		conflicts:  conflicts,
+	})
+	if promptErr != nil {
+		return fmt.Errorf(messages.InstallSkillsMigrationPromptErrFmt, promptErr)
+	}
+	if !resp.approved {
+		return fmt.Errorf(messages.InstallSkillsMigrationDeclinedErr)
 	}
 
 	inst.skillsMigrationConfirmed = true
@@ -174,14 +176,16 @@ func (inst *installer) executeMigrateSkillsFormat(relSkillsDir string) (bool, er
 		if len(conflicts) > 0 {
 			return false, fmt.Errorf(messages.InstallSkillsMigrationBlockedErrFmt, len(conflicts))
 		}
-		if prompter, ok := inst.prompter.(skillsMigrationPrompter); ok {
-			proceed, promptErr := prompter.ConfirmSkillsMigration(flatSkills, conflicts)
-			if promptErr != nil {
-				return false, fmt.Errorf(messages.InstallSkillsMigrationPromptErrFmt, promptErr)
-			}
-			if !proceed {
-				return false, fmt.Errorf(messages.InstallSkillsMigrationDeclinedErr)
-			}
+		resp, promptErr := inst.promptRouter().route(promptRequest{
+			kind:       promptKindConfirmSkillsMigration,
+			flatSkills: flatSkills,
+			conflicts:  conflicts,
+		})
+		if promptErr != nil {
+			return false, fmt.Errorf(messages.InstallSkillsMigrationPromptErrFmt, promptErr)
+		}
+		if !resp.approved {
+			return false, fmt.Errorf(messages.InstallSkillsMigrationDeclinedErr)
 		}
 	}
 

--- a/site/docs/overview.mdx
+++ b/site/docs/overview.mdx
@@ -10,7 +10,7 @@ Agent Layer is a small CLI that keeps AI-assisted development consistent across 
 
 The payoff is fewer surprises: the same repo behaves the same whether you launch Antigravity, Claude, Codex, Copilot CLI, or VS Code. No copying configuration between clients. No gradual drift. Just one place to review and refine how your agents work.
 
-Start with [Getting started](./getting-started), then use [Concepts](./concepts) and [Reference](./reference) as you customize. Use [Best Practices](/best-practices) when you are writing skills, CLI skills, or always-loaded instructions. [Troubleshooting](./troubleshooting) is a fast path when something breaks.
+Start with [Getting started](./getting-started), then use [Concepts](./concepts) and [Reference](./reference) as you customize. Use [Best Practices](/best-practices) when you are writing skills, CLI skills, or always-loaded instructions, and [Skills approach](./skills-approach) for Agent Layer's own skill model. [Troubleshooting](./troubleshooting) is a fast path when something breaks.
 For upgrade policy, compatibility guarantees, and migration rules, use [Upgrades](./upgrades).
 
 ## What you get
@@ -34,9 +34,10 @@ For upgrade policy, compatibility guarantees, and migration rules, use [Upgrades
 2. [Concepts](./concepts) - learn the mental model and safety boundaries
 3. [Reference](./reference) - config, environment variables, and CLI behavior
 4. [Skills](./skills) - built-in workflows for planning, debugging, shipping, and more
-5. [Best Practices](/best-practices) - skill, CLI skill, and instruction design guides
-6. [Troubleshooting](./troubleshooting) - common errors and fixes
-7. [Upgrades](./upgrades) - upgrade event model, compatibility guarantees, and migration rules
+5. [Skills approach](./skills-approach) - Agent Layer's skill ethos and target root-skill model
+6. [Best Practices](/best-practices) - universal skill, CLI skill, and instruction design guides
+7. [Troubleshooting](./troubleshooting) - common errors and fixes
+8. [Upgrades](./upgrades) - upgrade event model, compatibility guarantees, and migration rules
 
 ## Documentation map
 
@@ -56,9 +57,14 @@ Authoritative configuration, environment variables, and CLI behavior. Includes: 
 
 Built-in workflow skills that give agents structured processes for common tasks. Includes: [The built-in skill library](./skills#built-in-skill-library), [Skill categories](./skills#built-in-skill-library), [Anatomy of a skill](./skills#skill-structure), and [Writing your own skills](./skills#writing-your-own-skills).
 
+### [Skills approach](./skills-approach)
+
+Agent Layer's skill ethos, target root modules, workflow boundaries, and mapping
+from conceptual names to current bundled skill names.
+
 ### [Best Practices](/best-practices)
 
-Research-backed public guides for designing [agent skills](/skill-design), [CLI-focused skills](/cli-skill-design), and [always-loaded instructions](/instruction-design).
+Research-backed, product-neutral guides for designing [agent skills](/skill-design), [CLI-focused skills](/cli-skill-design), and [always-loaded instructions](/instruction-design).
 
 ### [Troubleshooting](./troubleshooting)
 

--- a/site/docs/skills-approach.mdx
+++ b/site/docs/skills-approach.mdx
@@ -1,0 +1,119 @@
+---
+title: Skills approach
+description: Agent Layer's skill ethos, conceptual root skill model, and mapping to the current bundled skills.
+sidebar_position: 5
+---
+
+Agent Layer skills are meant to be deterministic, reusable workflow modules
+with stable input and output contracts. A root skill should do one kind of work
+well, produce a predictable handoff, and avoid owning orchestration loops that
+belong in higher-level workflows.
+
+For the evidence behind this shape, use the universal best-practice guides:
+[Skill Design](/skill-design), [CLI Skill Design](/cli-skill-design), and
+[Instruction Design](/instruction-design). This page is Agent Layer-specific:
+it describes the ethos and target model for the bundled skill system.
+
+## Design ethos
+
+**Deterministic modules, not improvisation.** A skill should make the same
+contract available every time: accepted inputs, required artifacts, stop
+conditions, verification expectations, and final handoff shape. The agent still
+uses judgment inside the task, but the module boundary should be stable.
+
+**Root skills own one step.** Planning, review, implementation, fixing, and
+verification are different jobs. Keeping them separate improves activation,
+reviewability, and reuse.
+
+**Root skills are hermetic.** A root skill must not call, route to, or depend
+on another skill, and its body should not reference other skills as next steps,
+alternatives, or implementation dependencies. Cross-skill composition belongs
+only in workflow skills. A root skill may reference Agent Layer system sources
+of truth, such as `COMMANDS.md`, only when that source is necessary to execute
+its own contract.
+
+**Workflows own loops.** Iteration, delegation, retry policy, multi-agent
+coordination, and phase-to-phase orchestration belong in workflow skills. Root
+skills should be callable by many workflows without smuggling in a full
+lifecycle.
+
+**Evidence over assertion.** Skills should push agents toward observable
+evidence: read the code, inspect the diff, run documented checks, write or use
+real artifacts, and state what was verified.
+
+**Checkpoints for real decisions.** Human checkpoints should be narrow and
+explicit: architecture tradeoffs, destructive operations, external writes,
+scope changes, or missing required input. The normal path should be
+autonomous.
+
+## Target root skill model
+
+These names are the conceptual target root modules. They are not all current
+bundled skill names yet.
+
+| Target root module | Stable contract | Current implementation mapping |
+| --- | --- | --- |
+| `write-plan` | Turn a requested change into implementation-ready plan, task list, and context artifacts. | `plan-work` |
+| `review-plan` | Review plan artifacts before implementation and report blocking gaps, weak assumptions, and missing verification. | `review-plan` |
+| `implement-plan` | Execute an approved plan against the codebase and verify the result. | `implement-plan` |
+| `review-code` | Review explicit files, diffs, directories, or uncommitted changes and produce prioritized findings. | `review-scope` |
+| `fix-code` | Triage accepted findings or open issues, implement root-cause fixes, and record what changed or remains deferred. | `resolve-findings`; issue-led repair currently lives in the broader `fix-issues` workflow |
+| `verify-work` | Compare completed work against the plan or request and report completeness, regressions, missing checks, and scope drift. | `verify-against-plan` |
+
+The current names are the truth for invocation today. The target names describe
+the desired stable module boundaries as the skill library evolves.
+
+## Workflow skills
+
+Workflow skills compose root skills and own loops. They decide sequencing,
+delegation, retry behavior, and when to move between phases.
+
+Current examples:
+
+- `complete-current-phase` orchestrates roadmap work through planning,
+  implementation, verification, auditing, and cleanup.
+- `ship-pr` owns the pull request lifecycle, including audit, commit, push,
+  CI monitoring, reviewer feedback, and final status checks.
+- `improve-codebase` decomposes broad quality work into reviewable chunks,
+  runs review and fix loops, and delegates to narrower skills when useful.
+- `fix-issues` works through `ISSUES.md` by batching, planning, implementing,
+  auditing, and keeping the ledger current.
+
+Because workflows own orchestration, root skills should stay boring and
+portable. A workflow can call `review-code` several times with different
+scopes; `review-code` should not decide the whole project lifecycle.
+
+## Contract expectations
+
+A root skill should define:
+
+- Inputs it accepts, including file paths, artifacts, issue identifiers, or
+  plain-language scope.
+- Output artifact or report shape, so another skill or workflow can consume it.
+- Any required system source of truth, with a reason the root skill cannot do
+  its own job without it.
+- Stop conditions for missing required input, incompatible state, or user
+  decisions.
+- Verification expectations appropriate to its job.
+- Final handoff fields that are stable enough for follow-up automation.
+
+A root skill should avoid:
+
+- Hidden mode switches that change the main output contract.
+- Calling or naming other skills as part of its own procedure.
+- Product-wide orchestration loops.
+- Broad "ask when uncertain" fallbacks.
+- Duplicating evidence and best-practice rationale already maintained in the
+  universal guides.
+
+## Relationship to universal guides
+
+The universal guides are the evidence base. This page is the Agent Layer design
+choice built on top of that evidence.
+
+- Use [Skill Design](/skill-design) for portable guidance on routing,
+  progressive disclosure, section ordering, evaluation, and context budget.
+- Use [CLI Skill Design](/cli-skill-design) when a skill routes agents to an
+  installed command-line tool.
+- Use [Instruction Design](/instruction-design) to keep always-loaded
+  instructions separate from workflow-specific skill behavior.

--- a/site/docs/skills.mdx
+++ b/site/docs/skills.mdx
@@ -41,7 +41,7 @@ You do not pay the context cost of every skill on every request.
 
 ### Skill structure
 
-The recommended section order is informed by research on how language models process instructions (primacy and recency effects). Critical rules go early; guardrails go at the end. For the full research basis, see [Skill Design Guide](/skill-design). For skills that route agents to installed command-line tools, use the [CLI Skill Design Guide](/cli-skill-design).
+The recommended section order is informed by research on how language models process instructions (primacy and recency effects). Critical rules go early; guardrails go at the end. For the full research basis, see [Skill Design Guide](/skill-design). For skills that route agents to installed command-line tools, use the [CLI Skill Design Guide](/cli-skill-design). For Agent Layer's root-skill model and current-to-target skill mapping, see [Skills approach](./skills-approach).
 
 1. **Opening contract** — one sentence stating what the skill does
 2. **Defaults** — what happens with no inputs
@@ -58,7 +58,7 @@ The recommended section order is informed by research on how language models pro
 
 The skill standard defines the format. Agent Layer builds on it with:
 
-- **A built-in library of 24 skills** covering planning, implementation, review, debugging, PR lifecycle, auditing, and codebase improvement — available after `al init` with no setup.
+- **A workflow-bundle library of 28 skills** covering planning, implementation, review, debugging, PR lifecycle, auditing, and codebase improvement — available when the workflow bundle is installed through the wizard and refreshed through upgrade flows for repos that already have it.
 - **Client projection** — Skills are authored once under `.agent-layer/skills/` and projected during `al sync` to `.agents/skills/` for shared-skill clients and `.claude/skills/` for Claude Code.
 - **Memory integration** — Skills read from and write to project memory files (`ISSUES.md`, `BACKLOG.md`, `ROADMAP.md`, `DECISIONS.md`, `COMMANDS.md`, `CONTEXT.md`), keeping project context durable across sessions.
 - **Artifact conventions** — Skills produce structured output files under `.agent-layer/tmp/` using a standard naming convention (`<skill-name>.<run-id>.<type>.md`). Planning workflows produce a trio of artifacts — a plan, a task list, and a context file — so that any agent can pick up the work cold without re-discovering what the planner already found.
@@ -100,7 +100,7 @@ Skills accept flexible inputs: plain-language descriptions, file paths, constrai
 
 ## Built-in skill library
 
-Agent Layer ships 24 skills. They are organized here by how you typically use them.
+The Agent Layer workflow bundle includes 28 skills. They are organized here by how you typically use them. Agent Layer also ships optional CLI catalog skills for installed tools; those are listed separately below.
 
 ### Orchestrator skills
 
@@ -109,6 +109,8 @@ These are the top-level workflows you invoke directly. They delegate to supporti
 | Skill | What it does |
 | --- | --- |
 | `complete-current-phase` | Drives a roadmap phase through planning, implementation, verification, auditing, and cleanup loops until the phase is complete. The primary orchestrator for roadmap execution. |
+| `full-workflow` | Orchestrates a feature workflow from questions and spec alignment through planning, multi-agent plan review, implementation, and PR shipping. |
+| `auto-skill-loop` | Runs an explicitly authorized autonomous loop for `fix-issues` or `improve-codebase`, dispatching workers, preserving blocked work, and shipping ready PRs until interrupted or exhausted. |
 | `ship-pr` | Full PR lifecycle: audits uncommitted changes, commits, pushes, creates the PR, monitors CI (fixing failures), waits for review comments, addresses every one, and confirms CI passes. Delegates to `audit-and-fix-uncommitted-changes`, `fix-ci`, and `address-pr-comments`. |
 | `improve-codebase` | Deep autonomous codebase audit: decomposes the repo into reviewable chunks, runs parallel multi-lens reviews, fixes findings iteratively, and delegates to complementary skills. |
 | `fix-issues` | Works through `ISSUES.md`: organizes open issues into coherent batches, plans, implements, audits, and keeps the issue ledger current. |
@@ -134,6 +136,7 @@ These are used by orchestrators or available for fine-grained control when you n
 | --- | --- |
 | `review-scope` | Reviews files, directories, diffs, or uncommitted changes. Produces a findings report covering correctness, gaps, risks, architecture, tests, docs, performance, and maintainability. |
 | `review-plan` | Pre-execution review of a plan and its artifacts. Identifies scope gaps, sequencing problems, missing context, and weak verification before code is written. |
+| `multi-agent-plan-review` | Reviews and repairs a plan/task/context artifact set with dispatched review agents until the plan is implementation-ready. |
 | `verify-against-plan` | Post-implementation completeness check. Compares what was actually built against what the plan promised, reporting gaps, regressions, missing tests or docs, and scope drift. |
 | `resolve-findings` | Triages review findings, verifies each independently, implements accepted fixes, and records why findings were rejected, deferred, or resolved. |
 
@@ -162,12 +165,26 @@ These are used by orchestrators or available for fine-grained control when you n
 | `audit-documentation` | Audits documentation for static accuracy and cross-document consistency against the repository. Optionally applies fixes for accepted findings. |
 | `audit-tests` | Test suite health audit: discovers conventions, classifies tests by tier, identifies redundancy, quality gaps, and coverage gaps — without modifying tests. |
 | `audit-memory` | Audits agent memory files for structure compliance, staleness, misplacement, and consistency. |
+| `interface-audit` | Audits product interfaces as component boundaries, scores complexity and debt, and produces interface cleanup recommendations without implementing changes. |
 
 **Task management**
 
 | Skill | What it does |
 | --- | --- |
 | `finish-task` | Task closeout: checks plan alignment, updates project memory files, runs verification, and summarizes outcomes after implementation is complete. |
+
+### Optional CLI catalog skills
+
+These skills are installed only when selected through the CLI catalog. They route
+agents to installed local tools and require the corresponding command to be
+available on `PATH`.
+
+| Skill | What it does |
+| --- | --- |
+| `agent-dispatch` | Uses `al dispatch` only when the user names an external dispatch target or another skill explicitly requires dispatch. |
+| `find-docs` | Uses Context7 for current API and library documentation when local docs or CLI help are insufficient. |
+| `playwright-cli` | Uses `playwright-cli` for browser automation, screenshots, user interface inspection, and Playwright test work. |
+| `tavily-web` | Uses Tavily CLI for web search, URL extraction, site mapping, and cited research. |
 
 ## Writing your own skills
 
@@ -194,14 +211,10 @@ Run `al sync` to project the new skill into all enabled clients.
 
 For the complete research-backed authoring guide — including empirical studies on instruction-following, context length effects, and constraint composition — see [Skill Design Guide](/skill-design). For command-line tool workflows, use [CLI Skill Design Guide](/cli-skill-design) so live `--help` stays the source of truth for syntax.
 
-## Design philosophy
+## Skills approach
 
-The built-in skills reflect several deliberate choices:
-
-**Investigation before action** — Skills like `debug-issue` refuse to guess. They require reproduction, evidence, and a failing test before any fix. This mirrors how experienced developers work.
-
-**Autonomous by default, checkpoints for real ambiguity** — Skills run autonomously through their normal workflow. Human checkpoints trigger only for genuine ambiguity — scope decisions, breaking changes, or competing approaches. Vague escalation like "ask when uncertain" is deliberately avoided.
-
-**Composition over monoliths** — Skills delegate to each other. `ship-pr` delegates to `audit-and-fix-uncommitted-changes`, `fix-ci`, and `address-pr-comments`. `complete-current-phase` orchestrates planning, implementation, and verification. This keeps each skill focused while enabling complex workflows.
-
-**Evidence-backed structure** — The skill format is informed by research on how language models process instructions. Critical rules go early (primacy effect), guardrails go at the end (recency effect), and lean bodies minimize reasoning degradation from context length. See [Skill Design Guide](/skill-design) for the research basis.
+The built-in skills follow an Agent Layer-specific model: deterministic root
+skills with stable input/output contracts, composed by workflow skills that own
+loops and orchestration. See [Skills approach](./skills-approach) for the
+canonical ethos, target root modules, and mapping to the current bundled skill
+names.

--- a/site/docs/troubleshooting.mdx
+++ b/site/docs/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: Fix common install, configuration, and MCP server issues.
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 Use this page when installs fail, configs do not validate, or MCP servers do not connect. Most issues are configuration or PATH-related, so start with a quick triage before diving deeper. The goal is to get you back to a predictable state without guessing.

--- a/site/docs/upgrade-checklist.mdx
+++ b/site/docs/upgrade-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrade checklist
 description: One-page upgrade checklist for interactive teams and CI.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 Use this page when you want a repeatable, low-risk upgrade runbook.

--- a/site/docs/upgrades.mdx
+++ b/site/docs/upgrades.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrades
 description: Upgrade contract, compatibility guarantees, migration rules, and platform support.
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 This page is the canonical upgrade contract for Agent Layer.

--- a/site/pages/best-practices.mdx
+++ b/site/pages/best-practices.mdx
@@ -20,8 +20,8 @@ contract.
 
 The guides below are evidence-backed and citation-heavy. They do not define
 Agent Layer-specific skill names, memory files, artifact paths, or bundled
-workflow doctrine. For Agent Layer's own skill ethos and current-to-target skill
-mapping, see [Skills approach](/docs/skills-approach).
+workflow doctrine. For Agent Layer's own skill library and workflow model, see
+[Skills](/docs/skills).
 
 ## Guides
 

--- a/site/pages/best-practices.mdx
+++ b/site/pages/best-practices.mdx
@@ -1,6 +1,6 @@
 ---
-title: Agent Best Practices for Skills, CLI Skills, and Instructions
-description: Research-backed Agent Layer guides for designing skills, CLI-focused skills, and always-loaded instructions for AI coding agents.
+title: Universal Best Practices for Skills, CLI Skills, and Instructions
+description: Research-backed, product-neutral guides for designing skills, CLI-focused skills, and always-loaded instructions for AI coding agents.
 keywords:
   - AI coding agents
   - agent skills
@@ -11,11 +11,17 @@ keywords:
 image: /img/branding/logo.svg
 ---
 
-# Best Practices
+# Universal Best Practices
 
-Agent Layer keeps three authoring surfaces separate because they solve different
-problems. Skills define reusable workflows, CLI skills route agents to installed
-commands, and instructions define the always-loaded contract.
+These product-neutral guides keep three authoring surfaces separate because
+they solve different problems. Skills define reusable workflows, CLI skills
+route agents to installed commands, and instructions define the always-loaded
+contract.
+
+The guides below are evidence-backed and citation-heavy. They do not define
+Agent Layer-specific skill names, memory files, artifact paths, or bundled
+workflow doctrine. For Agent Layer's own skill ethos and current-to-target skill
+mapping, see [Skills approach](/docs/skills-approach).
 
 ## Guides
 


### PR DESCRIPTION
## Summary
- consolidate install and upgrade prompt capability checks behind a prompt router
- add router-focused tests for overwrite, tmp deletion, statusline, config defaults, and skills migration fallbacks
- split product-neutral best-practice docs from Agent Layer-specific skills approach docs

## Verification
- pre-commit hooks: tidy check, golangci-lint, go test ./...
- go test ./internal/install -count=1
- make docs-cta-check
- audit pre-pass: make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Skills approach” documentation page and linked it from the main docs navigation.
  * Expanded the skills documentation to better reflect the current bundled skill set and recommended workflow.

* **Documentation**
  * Reorganized best-practices content into clearer documentation sets.
  * Updated several guides with clearer wording, structure, and navigation order.

* **Bug Fixes**
  * Improved prompting and confirmation flows during install and upgrade steps for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->