### PR TITLE
Add GPT-5.6 Codex model options

### DIFF
--- a/docs/agent-layer/BACKLOG.md
+++ b/docs/agent-layer/BACKLOG.md
@@ -28,6 +28,12 @@ Unscheduled user-visible features and tasks (distinct from issues; not refactors
 
 <!-- ENTRIES START -->
 
+- Backlog 2026-07-09 copilot-cli-gpt-5.6-models: Advertise GPT-5.6 models for GitHub Copilot CLI
+    Priority: Medium. Area: providers / copilot-cli / dispatch / wizard
+    Description: Add Sol, Terra, and Luna to the separate Copilot CLI model suggestion catalog after verifying the exact provider-native identifiers, so wizard and dispatch users do not need custom values.
+    Acceptance criteria: Provider-specific CLI evidence confirms the identifiers; the shared Copilot CLI catalog, exact catalog test, wizard, and dispatch suggestions expose all three models while preserving custom values.
+    Notes: GitHub's 2026-07-09 changelog confirms gradual Copilot CLI availability; deferred from PR #135 because that reviewed plan is scoped to the Codex provider catalog.
+
 - Backlog 2026-06-30 shared-live-options: Use shared live option providers for wizard and dispatch choices
     Priority: Medium. Area: providers / dispatch / wizard
     Description: Replace hard-coded model/reasoning suggestions with provider-backed discovery where a client exposes an authoritative source: Codex model and reasoning suggestions from `codex debug models`, Claude reasoning-effort choices from CLI help where available, and Antigravity models from `agy models`.

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,6 +27,11 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
+- Issue 2026-07-09 precommit-nested-git-index-inheritance: Nested Git test mutates the outer commit index under pre-commit
+    Priority: Medium. Area: internal/sync/claude_statusline_runtime_test.go (`runGit`) / pre-commit `go-test` hook
+    Description: When `make test` runs inside `git commit`'s pre-commit hook, the statusline test's temporary-repository Git commands inherit the outer `GIT_INDEX_FILE`; `git add tracked.txt` contaminates the real index and the nested commit re-enters pre-commit without a config, failing the outer commit.
+    Next step: Scrub repository-local Git environment variables from `runGit` before invoking Git in the temporary repository, and add a regression that supplies an external `GIT_INDEX_FILE` without mutating it.
+
 - Issue 2026-07-02 launcher-exec-capture-test-harness-duplication: Exec-capture test harness duplicated across four launcher packages
     Priority: Low. Area: internal/clients/{claude,codex,copilotcli,antigravity}/launch_test.go
     Description: `execCall`/`captureExec`/`forbidExec`/`assertExecCalled` (all over the identical `func(string, []string, []string) error` execFunc seam) are copied near-verbatim into each launcher's launch_test.go, ~50 lines per package. Flagged as CodeRabbit nitpicks on PR #130. Not a defect — the tests pass and cover behavior — but a maintainability trap: a change to the mock's behavior must be made in four places.

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -48,6 +48,24 @@ func TestBuildOptionsJSONShapeAndRandomExclusion(t *testing.T) {
 	if want := config.FieldOptionValues(config.ClaudeModelFieldKey); !slices.Equal(claude.Model.Suggestions, want) {
 		t.Fatalf("claude model suggestions = %v, want shared catalog %v", claude.Model.Suggestions, want)
 	}
+	var codex TargetOption
+	for _, target := range options.Targets {
+		if target.Agent == AgentCodex {
+			codex = target
+		}
+	}
+	if !codex.Model.OverrideSupported || !codex.Model.AllowCustom {
+		t.Fatalf("unexpected codex model metadata: %#v", codex.Model)
+	}
+	if want := config.FieldOptionValues(config.CodexModelFieldKey); !slices.Equal(codex.Model.Suggestions, want) {
+		t.Fatalf("codex model suggestions = %v, want shared catalog %v", codex.Model.Suggestions, want)
+	}
+	if !codex.ReasoningEffort.OverrideSupported || !codex.ReasoningEffort.AllowCustom {
+		t.Fatalf("unexpected codex reasoning effort metadata: %#v", codex.ReasoningEffort)
+	}
+	if want := config.FieldOptionValues(config.CodexReasoningEffortFieldKey); !slices.Equal(codex.ReasoningEffort.Suggestions, want) {
+		t.Fatalf("codex reasoning effort suggestions = %v, want shared catalog %v", codex.ReasoningEffort.Suggestions, want)
+	}
 	var agy TargetOption
 	for _, target := range options.Targets {
 		if target.Agent == AgentAntigravity {

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -70,9 +70,18 @@ var (
 		"opusplan",
 	)
 	claudeReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max")
-	codexModelOptions            = fieldOptions("gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini")
-	codexReasoningEffortOptions  = fieldOptions("low", "medium", "high", "xhigh")
-	copilotCLIModelOptions       = fieldOptions("claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5", "gpt-5.4", "gpt-5.3-codex", "gemini-3-pro")
+	codexModelOptions            = fieldOptions(
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+		"gpt-5.6-luna",
+		"gpt-5.4",
+		"gpt-5.3-codex-spark",
+		"gpt-5.3-codex",
+		"gpt-5.2",
+		"gpt-5.2-mini",
+	)
+	codexReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max", "ultra")
+	copilotCLIModelOptions      = fieldOptions("claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5", "gpt-5.4", "gpt-5.3-codex", "gemini-3-pro")
 )
 
 // fields is the canonical ordered registry of all config fields with constrained values.

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -203,7 +203,16 @@ func TestFieldOptionValues_ClaudeReasoningCatalog(t *testing.T) {
 
 func TestFieldOptionValues_CodexModelCatalog(t *testing.T) {
 	values := FieldOptionValues(CodexModelFieldKey)
-	want := []string{"gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-mini"}
+	want := []string{
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+		"gpt-5.6-luna",
+		"gpt-5.4",
+		"gpt-5.3-codex-spark",
+		"gpt-5.3-codex",
+		"gpt-5.2",
+		"gpt-5.2-mini",
+	}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}
@@ -216,7 +225,7 @@ func TestFieldOptionValues_CodexModelCatalog(t *testing.T) {
 
 func TestFieldOptionValues_CodexReasoningCatalog(t *testing.T) {
 	values := FieldOptionValues(CodexReasoningEffortFieldKey)
-	want := []string{"low", "medium", "high", "xhigh"}
+	want := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}

--- a/internal/wizard/option_discovery_test.go
+++ b/internal/wizard/option_discovery_test.go
@@ -242,6 +242,46 @@ func TestClaudeModelOptionsUsesSharedFieldCatalog(t *testing.T) {
 	}
 }
 
+func TestPromptModelsCodexUsesSharedFieldCatalogs(t *testing.T) {
+	choices := NewChoices()
+	choices.EnabledAgents[AgentCodex] = true
+
+	prompted := make(map[string]bool)
+	ui := &MockUI{
+		SelectFunc: func(title string, options []string, _ *string) error {
+			var catalog []string
+			switch title {
+			case messages.WizardCodexModelTitle:
+				catalog = config.FieldOptionValues(config.CodexModelFieldKey)
+			case messages.WizardCodexReasoningEffortTitle:
+				catalog = config.FieldOptionValues(config.CodexReasoningEffortFieldKey)
+			default:
+				t.Fatalf("unexpected select title %q", title)
+			}
+			want := make([]string, 0, len(catalog)+2)
+			want = append(want, messages.WizardLeaveBlankOption)
+			want = append(want, catalog...)
+			want = append(want, messages.WizardCustomOption)
+			if !slices.Equal(options, want) {
+				t.Fatalf("%s options = %v, want shared catalog choices %v", title, options, want)
+			}
+			prompted[title] = true
+			return nil
+		},
+		ConfirmFunc:     func(string, *bool) error { return nil },
+		MultiSelectFunc: func(string, []string, *[]string) error { return nil },
+	}
+
+	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
+		t.Fatalf("promptModels error: %v", err)
+	}
+	for _, title := range []string{messages.WizardCodexModelTitle, messages.WizardCodexReasoningEffortTitle} {
+		if !prompted[title] {
+			t.Fatalf("expected Codex prompt %q", title)
+		}
+	}
+}
+
 func TestPrefetchAntigravityModelsStartsOnlyOnce(t *testing.T) {
 	orig := wizardOptionDiscoveryRequestFunc
 	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna to the shared Codex model catalog
- add max and ultra reasoning-effort suggestions
- verify wizard and dispatch propagation from the canonical catalog
- track the pre-existing nested-Git pre-commit index contamination discovered while committing

## Testing

- make test
- go test ./internal/config ./internal/agentoptions ./internal/wizard ./internal/agentdispatch
- go build ./...
- go test ./...
- affected-package go vet
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional Codex GPT-5.6 model options.
  * Added “ultra” as a selectable Codex reasoning-effort option.
  * Updated Codex setup prompts to use the shared option catalogs and support custom values.
* **Documentation**
  * Updated agent-layer docs with a known issue about nested Git commands in pre-commit hooks affecting `GIT_INDEX_FILE`.
  * Added a backlog item for advertising GPT-5.6 models for Copilot CLI.
* **Tests**
  * Expanded coverage to validate Codex option catalogs and prompt/dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->