### PR TITLE
fix(precommit): match Go files in go-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         name: gofmt + goimports
         entry: make fmt
         language: system
-        files: \\.go$
+        files: \.go$
         pass_filenames: false
       - id: go-mod-tidy-check
         name: go mod tidy check


### PR DESCRIPTION
## Summary

- Correct the `go-format` pre-commit selector so ordinary Go paths match it.
- Ensure `gofmt` and `goimports` run at commit time for Go-file changes.

## Changes

- Change the hook's `files` pattern from `\\.go$` to `\.go$`.

## Verification

- `pre-commit run go-format --files internal/testutil/testutil.go` — passed on the delivery commit.
- `make ci` — passed, including 902 end-to-end scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting checks to correctly identify Go source files during pre-commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->