### PR TITLE
Fix completion chime lifecycle repairs

### DIFF
--- a/internal/chime/chime.go
+++ b/internal/chime/chime.go
@@ -58,6 +58,7 @@ func (SystemSoundRunner) Play() error {
 	return startAndReapSound(cmd)
 }
 
+// startAndReapSound starts a sound process and waits for it asynchronously.
 func startAndReapSound(process soundProcess) error {
 	if err := process.Start(); err != nil {
 		return fmt.Errorf("start notification sound: %w", err)
@@ -98,6 +99,7 @@ type antigravityEvent struct {
 
 type nonNullArray []any
 
+// UnmarshalJSON decodes an array while rejecting an explicit JSON null.
 func (a *nonNullArray) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
 		return errors.New("must be an array, not null")
@@ -115,6 +117,7 @@ type optionalNonNullString struct {
 	value   string
 }
 
+// UnmarshalJSON decodes a present string while rejecting an explicit JSON null.
 func (s *optionalNonNullString) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
 		return errors.New("must be a string, not null")

--- a/internal/chime/chime.go
+++ b/internal/chime/chime.go
@@ -39,6 +39,11 @@ func (f SoundRunnerFunc) Play() error { return f() }
 // SystemSoundRunner starts the supported system notification sound asynchronously.
 type SystemSoundRunner struct{}
 
+type soundProcess interface {
+	Start() error
+	Wait() error
+}
+
 // Play selects the operating system sound command, discards its standard
 // streams, and releases it without waiting.
 func (SystemSoundRunner) Play() error {
@@ -50,10 +55,14 @@ func (SystemSoundRunner) Play() error {
 	cmd.Stdin = nil
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
-	if err := cmd.Start(); err != nil {
+	return startAndReapSound(cmd)
+}
+
+func startAndReapSound(process soundProcess) error {
+	if err := process.Start(); err != nil {
 		return fmt.Errorf("start notification sound: %w", err)
 	}
-	go func() { _ = cmd.Wait() }()
+	go func() { _ = process.Wait() }()
 	return nil
 }
 
@@ -75,16 +84,46 @@ func systemSoundCommand(goos string, lookPath func(string) (string, error)) (str
 }
 
 type stopEvent struct {
-	HookEventName   string `json:"hook_event_name"`
-	StopHookActive  *bool  `json:"stop_hook_active"`
-	BackgroundTasks []any  `json:"background_tasks"`
-	SessionCrons    []any  `json:"session_crons"`
+	HookEventName   string       `json:"hook_event_name"`
+	StopHookActive  *bool        `json:"stop_hook_active"`
+	BackgroundTasks nonNullArray `json:"background_tasks"`
+	SessionCrons    nonNullArray `json:"session_crons"`
 }
 
 type antigravityEvent struct {
-	FullyIdle         *bool   `json:"fullyIdle"`
-	TerminationReason *string `json:"terminationReason"`
-	Error             *string `json:"error"`
+	FullyIdle         *bool                 `json:"fullyIdle"`
+	TerminationReason *string               `json:"terminationReason"`
+	Error             optionalNonNullString `json:"error"`
+}
+
+type nonNullArray []any
+
+func (a *nonNullArray) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("must be an array, not null")
+	}
+	var values []any
+	if err := json.Unmarshal(data, &values); err != nil {
+		return err
+	}
+	*a = values
+	return nil
+}
+
+type optionalNonNullString struct {
+	present bool
+	value   string
+}
+
+func (s *optionalNonNullString) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("must be a string, not null")
+	}
+	if err := json.Unmarshal(data, &s.value); err != nil {
+		return err
+	}
+	s.present = true
+	return nil
 }
 
 // Handle validates one provider hook event, optionally starts a sound, and emits
@@ -108,8 +147,15 @@ func Handle(provider string, stdin io.Reader, stdout io.Writer, stderr io.Writer
 }
 
 func decision(provider string, stdin io.Reader) (bool, string, error) {
+	data, err := io.ReadAll(io.LimitReader(stdin, maxHookEventBytes+1))
+	if err != nil {
+		return false, "", fmt.Errorf("agent-layer chime: read %s hook event: %w", provider, err)
+	}
+	if len(data) > maxHookEventBytes {
+		return false, "", fmt.Errorf("agent-layer chime: %s hook event exceeds %d bytes", provider, maxHookEventBytes)
+	}
 	var raw json.RawMessage
-	decoder := json.NewDecoder(io.LimitReader(stdin, maxHookEventBytes))
+	decoder := json.NewDecoder(bytes.NewReader(data))
 	if err := decoder.Decode(&raw); err != nil {
 		return false, "", fmt.Errorf("agent-layer chime: decode %s hook event: %w", provider, err)
 	}
@@ -155,7 +201,7 @@ func decision(provider string, stdin io.Reader) (bool, string, error) {
 		if event.TerminationReason == nil {
 			return false, "", errors.New("agent-layer chime: antigravity terminationReason must be a string")
 		}
-		hasError := event.Error != nil && *event.Error != ""
+		hasError := event.Error.present && event.Error.value != ""
 		return *event.FullyIdle && *event.TerminationReason == "model_stop" && !hasError, antigravityResponse, nil
 	default:
 		return false, "", fmt.Errorf("agent-layer chime: unsupported provider %q", provider)

--- a/internal/chime/chime_test.go
+++ b/internal/chime/chime_test.go
@@ -3,8 +3,10 @@ package chime
 import (
 	"bytes"
 	"errors"
+	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandleProviderFilters(t *testing.T) {
@@ -17,11 +19,9 @@ func TestHandleProviderFilters(t *testing.T) {
 		{"claude continuation", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":true}`, "", false},
 		{"claude background", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[{}]}`, "", false},
 		{"claude cron", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"session_crons":[{}]}`, "", false},
-		{"claude null optional arrays", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":null,"session_crons":null}`, "", true},
 		{"codex accepted", ProviderCodex, `{"hook_event_name":"Stop","stop_hook_active":false,"future":true}`, "{}\n", true},
 		{"codex continuation", ProviderCodex, `{"hook_event_name":"Stop","stop_hook_active":true}`, "{}\n", false},
 		{"antigravity accepted", ProviderAntigravity, `{"fullyIdle":true,"terminationReason":"model_stop"}`, "{\"decision\":\"allow\"}\n", true},
-		{"antigravity null error", ProviderAntigravity, `{"fullyIdle":true,"terminationReason":"model_stop","error":null}`, "{\"decision\":\"allow\"}\n", true},
 		{"antigravity empty error", ProviderAntigravity, `{"fullyIdle":true,"terminationReason":"model_stop","error":""}`, "{\"decision\":\"allow\"}\n", true},
 		{"antigravity busy", ProviderAntigravity, `{"fullyIdle":false,"terminationReason":"model_stop"}`, "{\"decision\":\"allow\"}\n", false},
 		{"antigravity other termination", ProviderAntigravity, `{"fullyIdle":true,"terminationReason":"error"}`, "{\"decision\":\"allow\"}\n", false},
@@ -60,7 +60,8 @@ func TestHandleRejectsMalformedOrIncompleteEvents(t *testing.T) {
 	t.Parallel()
 	tests := []struct{ name, provider, input, errorPart string }{
 		{"malformed", ProviderClaude, `{`, "decode"},
-		{"oversized", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"padding":"` + strings.Repeat("x", maxHookEventBytes) + `"}`, "decode"},
+		{"oversized", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"padding":"` + strings.Repeat("x", maxHookEventBytes) + `"}`, "exceeds"},
+		{"oversized after valid event", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false}` + strings.Repeat(" ", maxHookEventBytes) + `x`, "exceeds"},
 		{"trailing object", ProviderCodex, `{"hook_event_name":"Stop","stop_hook_active":false} {}`, "trailing JSON"},
 		{"trailing garbage", ProviderCodex, `{"hook_event_name":"Stop","stop_hook_active":false} x`, "trailing"},
 		{"non-object", ProviderClaude, `[]`, "JSON object"},
@@ -70,9 +71,12 @@ func TestHandleRejectsMalformedOrIncompleteEvents(t *testing.T) {
 		{"missing stop active", ProviderCodex, `{"hook_event_name":"Stop"}`, "must be a boolean"},
 		{"wrong stop active", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":"false"}`, "invalid claude"},
 		{"wrong background tasks", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":{}}`, "invalid claude"},
+		{"null background tasks", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":null}`, "invalid claude"},
+		{"null session crons", ProviderClaude, `{"hook_event_name":"Stop","stop_hook_active":false,"session_crons":null}`, "invalid claude"},
 		{"missing idle", ProviderAntigravity, `{"terminationReason":"model_stop"}`, "fullyIdle"},
 		{"missing termination", ProviderAntigravity, `{"fullyIdle":true}`, "terminationReason"},
 		{"wrong error", ProviderAntigravity, `{"fullyIdle":true,"terminationReason":"model_stop","error":{}}`, "invalid antigravity"},
+		{"null error", ProviderAntigravity, `{"fullyIdle":true,"terminationReason":"model_stop","error":null}`, "invalid antigravity"},
 		{"unsupported", "other", `{}`, "unsupported provider"},
 	}
 	for _, tc := range tests {
@@ -94,6 +98,22 @@ func TestHandleRejectsMalformedOrIncompleteEvents(t *testing.T) {
 	}
 }
 
+func TestHandleAcceptsExactMaximumInput(t *testing.T) {
+	t.Parallel()
+	input := `{"hook_event_name":"Stop","stop_hook_active":false}`
+	input += strings.Repeat(" ", maxHookEventBytes-len(input))
+	plays := 0
+	if err := Handle(ProviderClaude, strings.NewReader(input), io.Discard, io.Discard, SoundRunnerFunc(func() error {
+		plays++
+		return nil
+	})); err != nil {
+		t.Fatalf("Handle exact-limit input: %v", err)
+	}
+	if plays != 1 {
+		t.Fatalf("sound plays = %d, want 1", plays)
+	}
+}
+
 func TestHandleSoundFailureStillAllowsProvider(t *testing.T) {
 	t.Parallel()
 	var stdout, stderr bytes.Buffer
@@ -109,6 +129,78 @@ func TestHandleSoundFailureStillAllowsProvider(t *testing.T) {
 	if !strings.Contains(stderr.String(), "audio unavailable") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
+}
+
+type failingWriter struct{ err error }
+
+func (w failingWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestHandleReportsProviderResponseWriteFailure(t *testing.T) {
+	t.Parallel()
+	writeErr := errors.New("output closed")
+	err := Handle(
+		ProviderCodex,
+		strings.NewReader(`{"hook_event_name":"Stop","stop_hook_active":true}`),
+		failingWriter{err: writeErr},
+		io.Discard,
+		SoundRunnerFunc(func() error { return nil }),
+	)
+	if !errors.Is(err, writeErr) || !strings.Contains(err.Error(), "write codex hook response") {
+		t.Fatalf("Handle error = %v, want wrapped response write failure", err)
+	}
+}
+
+type fakeSoundProcess struct {
+	startErr    error
+	waitStarted chan struct{}
+	releaseWait chan struct{}
+}
+
+func (p *fakeSoundProcess) Start() error { return p.startErr }
+
+func (p *fakeSoundProcess) Wait() error {
+	close(p.waitStarted)
+	<-p.releaseWait
+	return nil
+}
+
+func TestStartAndReapSoundLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("start failure does not wait", func(t *testing.T) {
+		t.Parallel()
+		process := &fakeSoundProcess{
+			startErr:    errors.New("start denied"),
+			waitStarted: make(chan struct{}),
+			releaseWait: make(chan struct{}),
+		}
+		err := startAndReapSound(process)
+		if err == nil || !strings.Contains(err.Error(), "start denied") {
+			t.Fatalf("startAndReapSound error = %v", err)
+		}
+		select {
+		case <-process.waitStarted:
+			t.Fatal("Wait must not run after Start fails")
+		case <-time.After(20 * time.Millisecond):
+		}
+	})
+
+	t.Run("successful start schedules non-blocking wait", func(t *testing.T) {
+		t.Parallel()
+		process := &fakeSoundProcess{
+			waitStarted: make(chan struct{}),
+			releaseWait: make(chan struct{}),
+		}
+		if err := startAndReapSound(process); err != nil {
+			t.Fatalf("startAndReapSound: %v", err)
+		}
+		select {
+		case <-process.waitStarted:
+		case <-time.After(time.Second):
+			t.Fatal("Wait was not scheduled after Start succeeded")
+		}
+		close(process.releaseWait)
+	})
 }
 
 func TestSystemSoundCommand(t *testing.T) {

--- a/internal/messages/sync.go
+++ b/internal/messages/sync.go
@@ -35,6 +35,7 @@ const (
 	SyncChimeListConflictFmt                        = "%s must be a list to merge the managed notifications chime hook; remove or fix that override, or set notifications.chime = false"
 	SyncChimePathConflictFmt                        = "%s must be a real file inside the repository while cleaning Agent Layer chime hooks"
 	SyncCodexChimeMarkerConflictFmt                 = "%s: Agent Layer-managed Codex chime hook markers are incomplete or ambiguous; remove the marked chime block before running al sync"
+	SyncCodexChimeOwnershipConflictFmt              = "%s contains an augmented or ambiguous Agent Layer chime hook; remove that hook before running al sync"
 	SyncAntigravityChimePluginConflictFmt           = "%s already exists and is not the Agent Layer-managed chime plugin; remove or rename it before running al sync"
 	SyncClaudeStatuslineSourceMissingFmt            = "agents.claude.statusline is true but %s is missing; run `al wizard` to create the source file, run interactive `al upgrade` to review statusline sources, or create the file manually"
 	SyncCodexStatuslineSourceMissingFmt             = "agents.codex.statusline is true but %s is missing; run `al wizard` to create the source file, run interactive `al upgrade` to review statusline sources, or create the file manually"

--- a/internal/sync/antigravity_chime.go
+++ b/internal/sync/antigravity_chime.go
@@ -61,6 +61,8 @@ func writeAntigravityChimePlugin(sys System, root string, project *config.Projec
 	return nil
 }
 
+// rollbackNewAntigravityChimePlugin removes only files proven to be written by
+// the failed invocation, preserving ambiguous filesystem state for resolution.
 func rollbackNewAntigravityChimePlugin(sys System, dir string, written []antigravityChimePluginFile) error {
 	var rollbackErrs []error
 	for i := len(written) - 1; i >= 0; i-- {

--- a/internal/sync/antigravity_chime.go
+++ b/internal/sync/antigravity_chime.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,11 +28,13 @@ func writeAntigravityChimePlugin(sys System, root string, project *config.Projec
 	if err := ensureAntigravityChimePathContained(sys, root, dir); err != nil {
 		return err
 	}
+	created := false
 	info, err := sys.Lstat(dir)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf(messages.InstallFailedStatFmt, dir, err)
 		}
+		created = true
 	} else if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 		return fmt.Errorf(messages.SyncAntigravityChimePluginConflictFmt, dir)
 	} else if err := antigravityChimePluginIsManaged(sys, dir); err != nil {
@@ -39,13 +43,59 @@ func writeAntigravityChimePlugin(sys System, root string, project *config.Projec
 	if err := sys.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf(messages.SyncCreateDirFailedFmt, dir, err)
 	}
+	written := make([]antigravityChimePluginFile, 0, len(antigravityChimePluginFiles()))
 	for _, file := range antigravityChimePluginFiles() {
 		path := filepath.Join(dir, file.name)
 		if err := sys.WriteFileAtomic(path, file.data, 0o644); err != nil {
-			return fmt.Errorf(messages.SyncWriteFileFailedFmt, path, err)
+			writeErr := fmt.Errorf(messages.SyncWriteFileFailedFmt, path, err)
+			if !created {
+				return writeErr
+			}
+			if rollbackErr := rollbackNewAntigravityChimePlugin(sys, dir, append(written, file)); rollbackErr != nil {
+				return errors.Join(writeErr, rollbackErr)
+			}
+			return writeErr
 		}
+		written = append(written, file)
 	}
 	return nil
+}
+
+func rollbackNewAntigravityChimePlugin(sys System, dir string, written []antigravityChimePluginFile) error {
+	var rollbackErrs []error
+	for i := len(written) - 1; i >= 0; i-- {
+		path := filepath.Join(dir, written[i].name)
+		info, err := sys.Lstat(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf(messages.InstallFailedStatFmt, path, err))
+			}
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf(messages.SyncAntigravityChimePluginConflictFmt, path))
+			continue
+		}
+		data, err := sys.ReadFile(path)
+		if err != nil {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf(messages.SyncReadFailedFmt, path, err))
+			continue
+		}
+		if !bytes.Equal(data, written[i].data) {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf(messages.SyncAntigravityChimePluginConflictFmt, path))
+			continue
+		}
+		if err := sys.Remove(path); err != nil && !os.IsNotExist(err) {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf(messages.SyncRemoveFailedFmt, path, err))
+		}
+	}
+	if err := sys.Remove(dir); err != nil && !os.IsNotExist(err) {
+		rollbackErrs = append(rollbackErrs, fmt.Errorf(messages.SyncRemoveFailedFmt, dir, err))
+	}
+	if len(rollbackErrs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("roll back incomplete Antigravity chime plugin: %w", errors.Join(rollbackErrs...))
 }
 
 // cleanAntigravityChimePlugin removes the dedicated Agent Layer-owned
@@ -110,6 +160,19 @@ func antigravityChimePluginIsManaged(sys System, dir string) error {
 	}
 	if len(entries) != len(antigravityChimePluginFiles()) {
 		return fmt.Errorf(messages.SyncAntigravityChimePluginConflictFmt, dir)
+	}
+	for _, file := range antigravityChimePluginFiles() {
+		path := filepath.Join(dir, file.name)
+		info, err := sys.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf(messages.SyncAntigravityChimePluginConflictFmt, dir)
+			}
+			return fmt.Errorf(messages.InstallFailedStatFmt, path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf(messages.SyncAntigravityChimePluginConflictFmt, dir)
+		}
 	}
 	for _, files := range [][]antigravityChimePluginFile{antigravityChimePluginFiles(), legacyAntigravityChimePluginFiles()} {
 		matched := true

--- a/internal/sync/antigravity_test.go
+++ b/internal/sync/antigravity_test.go
@@ -1188,6 +1188,53 @@ func TestWriteAntigravityChimePluginRejectsSymlinkPluginDir(t *testing.T) {
 	}
 }
 
+func TestAntigravityChimePluginRejectsSymlinkedManagedManifests(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"write", "clean"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			dir := antigravityChimePluginDir(root)
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				t.Fatalf("mkdir plugin dir: %v", err)
+			}
+			outside := t.TempDir()
+			for _, file := range antigravityChimePluginFiles() {
+				target := filepath.Join(outside, file.name)
+				if err := os.WriteFile(target, file.data, 0o600); err != nil {
+					t.Fatalf("write outside %s: %v", file.name, err)
+				}
+				if err := os.Symlink(target, filepath.Join(dir, file.name)); err != nil {
+					t.Fatalf("symlink %s: %v", file.name, err)
+				}
+			}
+
+			var err error
+			if action == "write" {
+				enabled := true
+				project := &config.ProjectConfig{Config: config.Config{Notifications: config.NotificationsConfig{Chime: &enabled}}}
+				err = writeAntigravityChimePlugin(RealSystem{}, root, project)
+			} else {
+				err = cleanAntigravityChimePlugin(RealSystem{}, root)
+			}
+			if err == nil || !strings.Contains(err.Error(), "not the Agent Layer-managed chime plugin") {
+				t.Fatalf("%s error = %v, want ownership conflict", action, err)
+			}
+			for _, file := range antigravityChimePluginFiles() {
+				link := filepath.Join(dir, file.name)
+				info, statErr := os.Lstat(link)
+				if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("%s must preserve symlink %s, info=%v err=%v", action, file.name, info, statErr)
+				}
+				target := filepath.Join(outside, file.name)
+				if got := readFileForTest(t, target); got != string(file.data) {
+					t.Fatalf("%s changed outside %s: %q", action, file.name, got)
+				}
+			}
+		})
+	}
+}
+
 func TestWriteAntigravityChimePluginRejectsNonDirectoryPluginPath(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -1327,6 +1374,39 @@ func TestWriteAntigravityChimePluginWriteErrorReportsTarget(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(antigravityChimePluginDir(root), "plugin.json")); !os.IsNotExist(err) {
 		t.Fatalf("failed plugin write should not leave plugin.json, lstat err=%v", err)
+	}
+}
+
+func TestWriteAntigravityChimePluginSecondWriteFailureRollsBackFreshPlugin(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	enabled := true
+	project := &config.ProjectConfig{
+		Config: config.Config{Notifications: config.NotificationsConfig{Chime: &enabled}},
+	}
+	writeErr := errors.New("hooks write denied")
+	sys := &MockSystem{
+		Fallback: RealSystem{},
+		WriteFileAtomicFunc: func(filename string, data []byte, perm os.FileMode) error {
+			if filepath.Base(filename) == "hooks.json" {
+				if err := (RealSystem{}).WriteFileAtomic(filename, data, perm); err != nil {
+					return err
+				}
+				return writeErr
+			}
+			return RealSystem{}.WriteFileAtomic(filename, data, perm)
+		},
+	}
+
+	err := writeAntigravityChimePlugin(sys, root, project)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("writeAntigravityChimePlugin error = %v, want hooks write failure", err)
+	}
+	if _, err := os.Lstat(antigravityChimePluginDir(root)); !os.IsNotExist(err) {
+		t.Fatalf("fresh partial plugin must be rolled back, lstat err=%v", err)
+	}
+	if err := writeAntigravityChimePlugin(RealSystem{}, root, project); err != nil {
+		t.Fatalf("retry after rolled-back write failure: %v", err)
 	}
 }
 

--- a/internal/sync/chime.go
+++ b/internal/sync/chime.go
@@ -145,28 +145,28 @@ func numericEquals(value any, want int) bool {
 // both its parent directory and the file itself are real in-repo filesystem
 // entries. Missing paths are reported as not existing so cleanup remains
 // idempotent for disabled providers.
-func existingChimeCleanupTarget(sys System, root string, dirName string, fileName string) (string, bool, error) {
+func existingChimeCleanupTarget(sys System, root string, dirName string, fileName string) (string, os.FileMode, bool, error) {
 	dir := filepath.Join(root, dirName)
 	path := filepath.Join(dir, fileName)
 	dirInfo, err := sys.Lstat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return path, false, nil
+			return path, 0, false, nil
 		}
-		return path, false, fmt.Errorf(messages.InstallFailedStatFmt, dir, err)
+		return path, 0, false, fmt.Errorf(messages.InstallFailedStatFmt, dir, err)
 	}
 	if dirInfo.Mode()&os.ModeSymlink != 0 || !dirInfo.IsDir() {
-		return path, false, fmt.Errorf(messages.SyncChimePathConflictFmt, dir)
+		return path, 0, false, fmt.Errorf(messages.SyncChimePathConflictFmt, dir)
 	}
 	fileInfo, err := sys.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return path, false, nil
+			return path, 0, false, nil
 		}
-		return path, false, fmt.Errorf(messages.InstallFailedStatFmt, path, err)
+		return path, 0, false, fmt.Errorf(messages.InstallFailedStatFmt, path, err)
 	}
 	if fileInfo.Mode()&os.ModeSymlink != 0 || !fileInfo.Mode().IsRegular() {
-		return path, false, fmt.Errorf(messages.SyncChimePathConflictFmt, path)
+		return path, 0, false, fmt.Errorf(messages.SyncChimePathConflictFmt, path)
 	}
-	return path, true, nil
+	return path, fileInfo.Mode().Perm(), true, nil
 }

--- a/internal/sync/claude_chime.go
+++ b/internal/sync/claude_chime.go
@@ -66,7 +66,7 @@ func appendClaudeChimeStopHook(existing any) []any {
 // .claude/settings.json. It is used when both Claude surfaces are disabled, so
 // the normal settings regeneration path will not run.
 func cleanClaudeChimeHook(sys System, root string) error {
-	path, exists, err := existingChimeCleanupTarget(sys, root, ".claude", "settings.json")
+	path, mode, exists, err := existingChimeCleanupTarget(sys, root, ".claude", "settings.json")
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func cleanClaudeChimeHook(sys System, root string) error {
 		return fmt.Errorf(messages.SyncMarshalClaudeSettingsFailedFmt, err)
 	}
 	out = append(out, '\n')
-	if err := sys.WriteFileAtomic(path, out, 0o644); err != nil {
+	if err := sys.WriteFileAtomic(path, out, mode); err != nil {
 		return fmt.Errorf(messages.SyncWriteFileFailedFmt, path, err)
 	}
 	return nil

--- a/internal/sync/claude_test.go
+++ b/internal/sync/claude_test.go
@@ -1094,6 +1094,13 @@ func TestCleanClaudeChimeHookRemovesOnlyManagedHandler(t *testing.T) {
 			t.Fatalf("expected %q preserved, got:\n%s", want, updated)
 		}
 	}
+	info, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat cleaned settings: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("cleaned settings mode = %04o, want preserved 0600", got)
+	}
 }
 
 func TestCleanClaudeChimeHookRejectsSymlinkSettingsDir(t *testing.T) {

--- a/internal/sync/codex_config_merge.go
+++ b/internal/sync/codex_config_merge.go
@@ -451,6 +451,8 @@ func (e *codexTomlEditor) removeCodexChimeHook(path string) (bool, error) {
 	return changed, nil
 }
 
+// rejectAmbiguousCodexChimeHook reports remaining exact chime commands that
+// cannot be proven to belong to an Agent Layer-managed hook region.
 func (e *codexTomlEditor) rejectAmbiguousCodexChimeHook(path string) error {
 	content := e.render()
 	if !strings.Contains(content, "al hook chime codex") &&

--- a/internal/sync/codex_config_merge.go
+++ b/internal/sync/codex_config_merge.go
@@ -454,11 +454,10 @@ func (e *codexTomlEditor) removeCodexChimeHook(path string) (bool, error) {
 // rejectAmbiguousCodexChimeHook reports remaining exact chime commands that
 // cannot be proven to belong to an Agent Layer-managed hook region.
 func (e *codexTomlEditor) rejectAmbiguousCodexChimeHook(path string) error {
-	content := e.render()
-	if !strings.Contains(content, "al hook chime codex") &&
-		!strings.Contains(content, "/usr/bin/afplay /System/Library/Sounds/Blow.aiff") {
+	if !e.containsActiveCodexChimeCommand() {
 		return nil
 	}
+	content := e.render()
 	var parsed map[string]any
 	if err := toml.Unmarshal([]byte(content), &parsed); err != nil {
 		return fmt.Errorf(messages.SyncCodexExistingConfigInvalidFmt, path, err)
@@ -471,6 +470,29 @@ func (e *codexTomlEditor) rejectAmbiguousCodexChimeHook(path string) error {
 		return fmt.Errorf(messages.SyncCodexChimeOwnershipConflictFmt, path)
 	}
 	return nil
+}
+
+// containsActiveCodexChimeCommand finds an uncommented command assignment
+// whose complete string value is an Agent Layer-managed Codex chime command.
+func (e *codexTomlEditor) containsActiveCodexChimeCommand() bool {
+	commands := managedChimeCommandVariants(agentLayerCodexChimeCommand)
+	found := false
+	tomlpatch.WalkLinesOutsideMultiline(e.lines, func(_ int, line string, state tomlpatch.StringState) tomlpatch.LineWalkResult {
+		_, literal, ok := tomlpatch.ParseKeyValueWithState(line, chimeHandlerCommandKey, state)
+		if !ok {
+			return tomlpatch.LineWalkResult{}
+		}
+		command, err := strconv.Unquote(literal)
+		if err != nil {
+			return tomlpatch.LineWalkResult{}
+		}
+		if _, ok := commands[command]; ok {
+			found = true
+			return tomlpatch.LineWalkResult{Stop: true}
+		}
+		return tomlpatch.LineWalkResult{}
+	})
+	return found
 }
 
 func (e *codexTomlEditor) managedCodexChimeRegions(path string) ([]lineRange, error) {

--- a/internal/sync/codex_config_merge.go
+++ b/internal/sync/codex_config_merge.go
@@ -153,7 +153,7 @@ func mergeCodexConfig(path string, existing string, managed codexManagedConfig) 
 // .codex/config.toml. It is used when Codex is disabled, so the normal Codex
 // config merge path will not run.
 func cleanCodexChimeHook(sys System, root string) error {
-	path, exists, err := existingChimeCleanupTarget(sys, root, ".codex", "config.toml")
+	path, mode, exists, err := existingChimeCleanupTarget(sys, root, ".codex", "config.toml")
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func cleanCodexChimeHook(sys System, root string) error {
 	if err := toml.Unmarshal([]byte(out), &renderCheck); err != nil {
 		return fmt.Errorf("merged Codex config is invalid TOML: %w", err)
 	}
-	if err := sys.WriteFileAtomic(path, []byte(out), 0o600); err != nil {
+	if err := sys.WriteFileAtomic(path, []byte(out), mode); err != nil {
 		return fmt.Errorf(messages.SyncWriteFileFailedFmt, path, err)
 	}
 	return nil
@@ -445,7 +445,30 @@ func (e *codexTomlEditor) removeCodexChimeHook(path string) (bool, error) {
 		e.removeRanges(unmarked)
 		changed = true
 	}
+	if err := e.rejectAmbiguousCodexChimeHook(path); err != nil {
+		return false, err
+	}
 	return changed, nil
+}
+
+func (e *codexTomlEditor) rejectAmbiguousCodexChimeHook(path string) error {
+	content := e.render()
+	if !strings.Contains(content, "al hook chime codex") &&
+		!strings.Contains(content, "/usr/bin/afplay /System/Library/Sounds/Blow.aiff") {
+		return nil
+	}
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(content), &parsed); err != nil {
+		return fmt.Errorf(messages.SyncCodexExistingConfigInvalidFmt, path, err)
+	}
+	hooks, ok := parsed[hooksKey]
+	if !ok {
+		return nil
+	}
+	if containsExactChimeCommand(hooks, managedChimeCommandVariants(agentLayerCodexChimeCommand)) {
+		return fmt.Errorf(messages.SyncCodexChimeOwnershipConflictFmt, path)
+	}
+	return nil
 }
 
 func (e *codexTomlEditor) managedCodexChimeRegions(path string) ([]lineRange, error) {

--- a/internal/sync/codex_config_merge_test.go
+++ b/internal/sync/codex_config_merge_test.go
@@ -693,6 +693,10 @@ command = "echo user"
 timeout = 2
 
 `+codexChimeBlockForTest())
+	configPath := filepath.Join(root, ".codex", "config.toml")
+	if err := os.Chmod(configPath, 0o400); err != nil {
+		t.Fatalf("chmod existing config: %v", err)
+	}
 
 	if err := cleanCodexChimeHook(RealSystem{}, root); err != nil {
 		t.Fatalf("cleanCodexChimeHook: %v", err)
@@ -705,6 +709,57 @@ timeout = 2
 		t.Fatalf("expected user Stop hook preserved, got:\n%s", merged)
 	}
 	assertValidTOML(t, merged)
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat cleaned config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o400 {
+		t.Fatalf("cleaned config mode = %04o, want preserved 0400", got)
+	}
+}
+
+func TestCodexChimeRejectsAugmentedMatchingHookWithoutMutation(t *testing.T) {
+	t.Parallel()
+	augmented := codexPartialHeader + fmt.Sprintf(`
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = %q
+timeout = 5
+description = "user-owned"
+`, agentLayerCodexChimeCommand)
+
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("write enabled=%t", enabled), func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeExistingCodexConfig(t, root, augmented)
+			project := &config.ProjectConfig{
+				Config: config.Config{Notifications: config.NotificationsConfig{Chime: &enabled}},
+				Env:    map[string]string{},
+			}
+			err := writeCodexConfig(RealSystem{}, root, project)
+			if err == nil || !strings.Contains(err.Error(), "augmented or ambiguous") {
+				t.Fatalf("writeCodexConfig error = %v, want ownership ambiguity", err)
+			}
+			if got := readCodexConfig(t, root); got != augmented {
+				t.Fatalf("ambiguous config must remain unchanged, got:\n%s", got)
+			}
+		})
+	}
+
+	t.Run("disabled-provider cleanup", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeExistingCodexConfig(t, root, augmented)
+		err := cleanCodexChimeHook(RealSystem{}, root)
+		if err == nil || !strings.Contains(err.Error(), "augmented or ambiguous") {
+			t.Fatalf("cleanCodexChimeHook error = %v, want ownership ambiguity", err)
+		}
+		if got := readCodexConfig(t, root); got != augmented {
+			t.Fatalf("ambiguous config must remain unchanged, got:\n%s", got)
+		}
+	})
 }
 
 func TestCleanCodexChimeHookRejectsSymlinkConfigDir(t *testing.T) {

--- a/internal/sync/codex_config_merge_test.go
+++ b/internal/sync/codex_config_merge_test.go
@@ -807,23 +807,32 @@ func TestCleanCodexChimeHookRejectsSymlinkConfigFile(t *testing.T) {
 	}
 }
 
-func TestCleanCodexChimeHookIgnoresMalformedConfigWithoutChime(t *testing.T) {
+func TestCleanCodexChimeHookIgnoresMalformedConfigWithoutActiveChime(t *testing.T) {
 	t.Parallel()
-	root := t.TempDir()
-	configPath := filepath.Join(root, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
-		t.Fatalf("mkdir .codex: %v", err)
+	testCases := map[string]string{
+		"no chime":        `model = [`,
+		"commented chime": "# command = \"al hook chime codex\"\nmodel = [",
+		"string chime":    "note = \"al hook chime codex\"\nmodel = [",
 	}
-	content := `model = [`
-	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	for name, content := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			configPath := filepath.Join(root, ".codex", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+				t.Fatalf("mkdir .codex: %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
 
-	if err := cleanCodexChimeHook(RealSystem{}, root); err != nil {
-		t.Fatalf("cleanCodexChimeHook should ignore malformed no-chime config: %v", err)
-	}
-	if got := readFileForTest(t, configPath); got != content {
-		t.Fatalf("expected malformed no-chime config untouched, got:\n%s", got)
+			if err := cleanCodexChimeHook(RealSystem{}, root); err != nil {
+				t.Fatalf("cleanCodexChimeHook should ignore malformed config without an active chime hook: %v", err)
+			}
+			if got := readFileForTest(t, configPath); got != content {
+				t.Fatalf("expected malformed config untouched, got:\n%s", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Repair seven completion-chime lifecycle findings across hook parsing, sound execution, and provider configuration cleanup.
- Preserve strict provider-event validation, user-owned configuration, and reliable enable/disable recovery.

## Changes

- Reject oversized or schema-invalid hook events and cover asynchronous sound process reaping.
- Make Antigravity plugin writes rollback-safe and reject symlinked managed manifests.
- Preserve configuration permissions during cleanup and reject ambiguous Codex chime ownership.

## Verification

- `make ci` — passed on `4eddfa6c3a89610ad31012f3f8a14c18bc7665f3`.

## Notes

- The implementation report records focused, full-suite, lint, race, coverage, formatting, and installed Antigravity validator evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of provider hook events, including oversized or malformed payloads.
  * Prevented unsafe changes when managed plugin files are symlinks or configurations are ambiguous.
  * Added rollback for partially failed plugin installations.
  * Preserved existing file permissions during cleanup and updates.
  * Improved system notification sound process handling and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->