### PR TITLE
fix: harden Agent Dispatch provider lifecycle

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,6 +27,18 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
+- Issue 2026-07-15 dispatch-run-record-write-mutates-before-publish: Failed record writes can poison subsequent terminalization
+    Priority: High. Area: internal/agentdispatch/state.go writeRunRecord
+    Description: writeRunRecord increments the caller-owned Revision and replaces UpdatedAt before writeJSONAtomic succeeds; after an I/O failure, the in-memory record no longer matches durable state, so a subsequent failure write can be rejected as concurrent and leave the record nonterminal.
+    Next step: Mutate a copy, publish it atomically, and update the caller-owned record only after the durable write succeeds; add an injected write-failure regression covering the terminal failure path.
+    Notes: Deferred because durable state/history repairs were explicitly excluded from PR #151 merge-readiness scope.
+
+- Issue 2026-07-15 dispatch-random-override-filter-policy: Random selection can choose a provider that rejects a requested override
+    Priority: Medium. Area: internal/agentdispatch random resolution and fresh preflight
+    Description: Random eligibility considers enabled, installed, compatible, and caller facts, while requested model and reasoning support are validated only after a target is chosen; dispatch can therefore fail on the chosen provider even when another eligible pool member supports the override.
+    Next step: Decide whether random pools should be filtered by requested override support or preserve provider-only eligibility and fail after selection, then encode the chosen public policy in focused selection tests.
+    Notes: Deferred because filtering semantics are a public-policy choice outside PR #151's classified production repairs.
+
 - Issue 2026-07-15 dispatch-provider-sigterm-no-escalation: Provider shutdown can hang after cancellation or internal failure
     Priority: High. Area: internal/agentdispatch runner and runtime helpers
     Description: Dispatch sends SIGTERM after caller signals, cancellation, reducer failure, or capture failure, but a provider or descendant that ignores SIGTERM can keep the pipes and Wait blocked indefinitely while the owned process group remains alive.

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,6 +27,18 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
+- Issue 2026-07-15 dispatch-provider-sigterm-no-escalation: Provider shutdown can hang after cancellation or internal failure
+    Priority: High. Area: internal/agentdispatch runner and runtime helpers
+    Description: Dispatch sends SIGTERM after caller signals, cancellation, reducer failure, or capture failure, but a provider or descendant that ignores SIGTERM can keep the pipes and Wait blocked indefinitely while the owned process group remains alive.
+    Next step: Choose whether shutdown escalates to SIGKILL after a fixed grace period or remains indefinitely graceful/user-driven, then encode the policy in one process-group terminator.
+    Notes: Requires a user-owned cancellation/cleanup policy; do not weaken process identity or group ownership checks.
+
+- Issue 2026-07-15 dispatch-antigravity-log-runtime-unbounded: Antigravity log can exceed the capture budget while the provider runs
+    Priority: High. Area: internal/agentdispatch provider execution and Antigravity diagnostics
+    Description: stdout/stderr/events are write-bounded, but agy writes its log directly for up to 24 hours; the runner checks size only after exit, so a faulty provider can consume unbounded disk and the rejected oversized artifact remains over the 64 MiB retained-data contract.
+    Next step: Choose a supported bounded-write mechanism for the provider-owned log (for example a validated FIFO capture) without adding polling or constraining unrelated provider file writes.
+    Notes: Post-exit truncation does not prevent runtime disk exhaustion; shell-level file-size limits affect unrelated provider outputs.
+
 - Issue 2026-07-13 corrupt-run-record-blocks-delete-cancel: A corrupt run record leaves its mapping undeletable and uncancellable
     Priority: Low. Area: internal/agentdispatch/operations.go (Delete, Cancel) + state.go retention
     Description: Delete and Cancel deliberately fail loud on a corrupt referenced run record (tested behavior consistent with the retention stance of never hiding corrupt evidence), so the only recovery is manual removal of the run directory; history already skips-and-warns, but the mapping stays blocked and retention never expires nonterminal corrupt records.

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -36,7 +36,7 @@ func Run(opts RunOptions) error {
 	if err != nil {
 		return err
 	}
-	target, version, prompt, err := prepareFresh(project, resolved.Target, opts)
+	target, version, prompt, err := prepareFresh(project, resolved, opts)
 	if err != nil {
 		return err
 	}
@@ -322,24 +322,38 @@ func executeDispatch(request dispatchExecution) error {
 				request.Run.Record.ProviderLogPath = ""
 			}
 		}
-		now := time.Now().UTC()
-		request.Run.Record.State = dispatchStateCompleted
-		if result.NotResumable {
-			request.Run.Record.RecoveryState = recoveryNotResumable
-		} else {
-			request.Run.Record.RecoveryState = recoveryResumeRequired
-		}
-		request.Run.Record.CompletedAt = &now
-		request.Run.Record.ProviderSessionID = session.ProviderSessionID
-		if err := writeRunRecord(request.Run.Dir, &request.Run.Record); err != nil {
-			return err
-		}
-		if err := releaseConversation(request.Root, session.Name, request.Run.Record.ID); err != nil {
-			return err
-		}
-		return replayAnswer(request.Run.Record.AnswerPath, request.Stdout)
+		return completeDispatchSuccess(request, result, session)
 	}
 	return finishDispatchFailure(request, exitError(ExitTargetFailure, "dispatch retry exhausted"))
+}
+
+func completeDispatchSuccess(request dispatchExecution, result executionResult, session Session) error {
+	if err := writeBytesAtomic(request.Run.Record.AnswerPath, []byte(result.Answer), 0o600); err != nil {
+		return finishDispatchFailure(request, wrapExitError(ExitConfig, "publish dispatch terminal answer", err))
+	}
+	now := time.Now().UTC()
+	request.Run.Record.State = dispatchStateCompleted
+	if result.NotResumable {
+		request.Run.Record.RecoveryState = recoveryNotResumable
+	} else {
+		request.Run.Record.RecoveryState = recoveryResumeRequired
+	}
+	request.Run.Record.CompletedAt = &now
+	request.Run.Record.ProviderSessionID = session.ProviderSessionID
+	if err := writeRunRecord(request.Run.Dir, &request.Run.Record); err != nil {
+		cause := err
+		if removeErr := os.Remove(request.Run.Record.AnswerPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			cause = wrapExitError(ExitConfig, "retract dispatch answer after terminal record failure", errors.Join(err, removeErr))
+		}
+		return finishDispatchFailure(request, cause)
+	}
+	if err := releaseConversation(request.Root, session.Name, request.Run.Record.ID); err != nil {
+		// The completed run record is authoritative and claimConversation can
+		// replace a stale claim that points at a terminal run. Surface cleanup
+		// failure without turning a completed provider turn into a failed child.
+		_, _ = fmt.Fprintf(request.Stderr, "warning: dispatch run %s completed but active claim cleanup failed: %v\n", request.Run.Record.ID, err)
+	}
+	return replayAnswer(request.Run.Record.AnswerPath, request.Stdout)
 }
 
 func finishDispatchFailure(request dispatchExecution, cause error) error {
@@ -442,7 +456,8 @@ func checkDispatchDepth(cfg config.Config, depth int) error {
 	return nil
 }
 
-func prepareFresh(project *config.ProjectConfig, target targetMeta, opts RunOptions) (targetMeta, string, []byte, error) {
+func prepareFresh(project *config.ProjectConfig, resolved resolution, opts RunOptions) (targetMeta, string, []byte, error) {
+	target := resolved.Target
 	if strings.TrimSpace(opts.Model) != "" && !agentoptions.Supports(target.Name, agentoptions.KindModel) {
 		return targetMeta{}, "", nil, exitError(ExitUsage, fmt.Sprintf("%s does not support --model", target.Name))
 	}
@@ -452,17 +467,20 @@ func prepareFresh(project *config.ProjectConfig, target targetMeta, opts RunOpti
 	if !targetEnabled(project.Config, target.Name) {
 		return targetMeta{}, "", nil, exitError(ExitConfig, fmt.Sprintf("`al dispatch` target %s is disabled in config", target.Name))
 	}
-	lookPath := opts.LookPath
-	if lookPath == nil {
-		lookPath = exec.LookPath
-	}
-	path, err := lookPath(target.Binary)
-	if err != nil {
-		return targetMeta{}, "", nil, exitError(ExitUnavailable, fmt.Sprintf("`al dispatch` target %s requires `%s` on PATH", target.Name, target.Binary))
-	}
-	target, version, err := compatibleTargetVersionCached(project.Root, path, target, opts.VersionLookup)
-	if err != nil {
-		return targetMeta{}, "", nil, err
+	version := resolved.Version
+	if version == "" {
+		lookPath := opts.LookPath
+		if lookPath == nil {
+			lookPath = exec.LookPath
+		}
+		path, err := lookPath(target.Binary)
+		if err != nil {
+			return targetMeta{}, "", nil, exitError(ExitUnavailable, fmt.Sprintf("`al dispatch` target %s requires `%s` on PATH", target.Name, target.Binary))
+		}
+		target, version, err = compatibleTargetVersionCached(project.Root, path, target, opts.VersionLookup)
+		if err != nil {
+			return targetMeta{}, "", nil, err
+		}
 	}
 	promptText, err := ResolvePrompt(opts.PromptArgs, opts.Stdin, opts.ReadStdin)
 	if err != nil {

--- a/internal/agentdispatch/dispatch_behavior_test.go
+++ b/internal/agentdispatch/dispatch_behavior_test.go
@@ -241,6 +241,23 @@ func TestRandomEligibilitySkipsIncompatibleProvidersBeforeChoice(t *testing.T) {
 	}
 }
 
+func TestRandomDiscoveryPreservesUnsupportedVersionFacts(t *testing.T) {
+	cfg := dispatchTestConfig(AgentCodex)
+	target, ok := lookupTarget(AgentCodex)
+	if !ok {
+		t.Fatal("codex target missing")
+	}
+	wantReason := "unsupported provider version; install " + supportedProviderVersions[AgentCodex]
+	for _, installed := range []string{"0.0.1", "not-semver"} {
+		facts := discoverTarget(cfg, target, "", false, alwaysFound, rawTargetVersionDiscovery(func(string, string) (string, error) {
+			return installed, nil
+		}))
+		if facts.RandomEligible || facts.InstalledVersion != installed || facts.Fresh.Reason != wantReason || facts.RandomExclusionReason != wantReason {
+			t.Fatalf("random discovery for version %q lost compatibility facts: %#v", installed, facts)
+		}
+	}
+}
+
 func TestBuildOptionsResolvesEachProviderBinaryOnce(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	lookups := map[string]int{}

--- a/internal/agentdispatch/dispatch_behavior_test.go
+++ b/internal/agentdispatch/dispatch_behavior_test.go
@@ -183,7 +183,8 @@ func TestNewerProviderVersionDispatchWarnsOnStderrOnly(t *testing.T) {
 
 func TestTargetResolutionEnforcesEligibility(t *testing.T) {
 	cfg := dispatchTestConfig(AgentCodex, AgentClaude)
-	resolved, err := resolveTarget(cfg, RunOptions{LookPath: alwaysFound, ChooseRandom: chooseOnly(AgentClaude)}, AgentCodex, true)
+	versionLookup := func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil }
+	resolved, err := resolveTarget(cfg, RunOptions{LookPath: alwaysFound, VersionLookup: versionLookup, ChooseRandom: chooseOnly(AgentClaude)}, AgentCodex, true)
 	if err != nil {
 		t.Fatalf("resolve random target: %v", err)
 	}
@@ -192,19 +193,76 @@ func TestTargetResolutionEnforcesEligibility(t *testing.T) {
 	}
 	_, err = resolveTarget(cfg, RunOptions{Agent: "unknown"}, "", false)
 	requireDispatchExitCode(t, err, ExitUsage)
-	_, err = chooseRandomTarget(cfg, AgentCodex, true, alwaysFound, chooseOnly(AgentCodex))
+	_, err = chooseRandomTarget(cfg, "", AgentCodex, true, alwaysFound, versionLookup, chooseOnly(AgentCodex))
 	requireDispatchExitCode(t, err, ExitTargetFailure)
-	_, err = chooseRandomTarget(cfg, "", false, func(string) (string, error) {
+	_, err = chooseRandomTarget(cfg, "", "", false, func(string) (string, error) {
 		return "", exec.ErrNotFound
-	}, nil)
+	}, versionLookup, nil)
 	requireDispatchExitCode(t, err, ExitUnavailable)
 	chooserErr := errors.New("random source failed")
-	_, err = chooseRandomTarget(cfg, "", false, alwaysFound, func([]string) (string, error) {
+	_, err = chooseRandomTarget(cfg, "", "", false, alwaysFound, versionLookup, func([]string) (string, error) {
 		return "", chooserErr
 	})
 	requireDispatchExitCode(t, err, ExitTargetFailure)
 	if !errors.Is(err, chooserErr) {
 		t.Fatalf("chooser error was not preserved: %v", err)
+	}
+}
+
+func TestRandomEligibilitySkipsIncompatibleProvidersBeforeChoice(t *testing.T) {
+	cfg := dispatchTestConfig(AgentCodex, AgentClaude, AgentAntigravity)
+	lookups := map[string]int{}
+	versionLookup := func(_ string, agent string) (string, error) {
+		lookups[agent]++
+		if agent == AgentCodex {
+			return "0.0.1", nil
+		}
+		if agent == AgentAntigravity {
+			return "", errors.New("unreadable version")
+		}
+		return "999.0.0", nil
+	}
+	selected, err := chooseRandomTarget(cfg, "", "", false, alwaysFound, versionLookup, func(pool []string) (string, error) {
+		if got := strings.Join(pool, ","); got != AgentClaude {
+			return "", fmt.Errorf("pool = %q, want %q", got, AgentClaude)
+		}
+		return AgentClaude, nil
+	})
+	if err != nil {
+		t.Fatalf("chooseRandomTarget: %v", err)
+	}
+	if selected.Target.Name != AgentClaude || selected.InstalledVersion != "999.0.0" {
+		t.Fatalf("selected target = %#v", selected)
+	}
+	for _, agent := range []string{AgentCodex, AgentClaude, AgentAntigravity} {
+		if lookups[agent] != 1 {
+			t.Fatalf("version lookups[%s] = %d, want 1", agent, lookups[agent])
+		}
+	}
+}
+
+func TestBuildOptionsResolvesEachProviderBinaryOnce(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	lookups := map[string]int{}
+	_, err := BuildOptions(OptionsRequest{
+		Root: root,
+		Env:  []string{},
+		LookPath: func(binary string) (string, error) {
+			lookups[binary]++
+			return "/mock/" + binary, nil
+		},
+		VersionLookup: func(_ string, agent string) (string, error) {
+			return supportedProviderVersions[agent], nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildOptions: %v", err)
+	}
+	for _, target := range targetRegistry() {
+		binary := target.Binary
+		if lookups[binary] != 1 {
+			t.Fatalf("LookPath(%q) calls = %d, want 1", binary, lookups[binary])
+		}
 	}
 }
 

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -324,6 +324,12 @@ func TestRunRandomExcludesCallerAndExecutesCodex(t *testing.T) {
 	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	pathLookups := map[string]int{}
+	versionLookups := map[string]int{}
+	lookPath := mockLookPath(binDir)
+	codexTarget, _ := lookupTarget(AgentCodex)
+	claudeTarget, _ := lookupTarget(AgentClaude)
+	antigravityTarget, _ := lookupTarget(AgentAntigravity)
 	err := Run(RunOptions{
 		Root:       root,
 		Agent:      AgentRandom,
@@ -331,7 +337,14 @@ func TestRunRandomExcludesCallerAndExecutesCodex(t *testing.T) {
 		Env:        env,
 		Stdout:     &stdout,
 		Stderr:     &stderr,
-		LookPath:   mockLookPath(binDir),
+		LookPath: func(binary string) (string, error) {
+			pathLookups[binary]++
+			return lookPath(binary)
+		},
+		VersionLookup: func(_ string, agent string) (string, error) {
+			versionLookups[agent]++
+			return supportedProviderVersions[agent], nil
+		},
 		ChooseRandom: func(pool []string) (string, error) {
 			if strings.Join(pool, ",") != "codex,antigravity" {
 				return "", fmt.Errorf("pool = %v", pool)
@@ -344,6 +357,12 @@ func TestRunRandomExcludesCallerAndExecutesCodex(t *testing.T) {
 	}
 	if stdout.String() != "codex ok" {
 		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if pathLookups[codexTarget.Binary] != 1 || pathLookups[antigravityTarget.Binary] != 1 || pathLookups[claudeTarget.Binary] != 0 {
+		t.Fatalf("random preflight path lookups = %#v, want one per non-caller candidate", pathLookups)
+	}
+	if versionLookups[AgentCodex] != 1 || versionLookups[AgentAntigravity] != 1 || versionLookups[AgentClaude] != 0 {
+		t.Fatalf("random preflight version lookups = %#v, want one per installed non-caller candidate", versionLookups)
 	}
 	if !strings.Contains(stderr.String(), "] codex · fresh") {
 		t.Fatalf("expected dispatch identity, got %q", stderr.String())

--- a/internal/agentdispatch/failure_contract_test.go
+++ b/internal/agentdispatch/failure_contract_test.go
@@ -78,7 +78,11 @@ func TestWriteOptionsRendersCurrentContractAndPropagatesWriterFailure(t *testing
 	if err != nil {
 		t.Fatalf("WriteOptions text: %v", err)
 	}
-	if !strings.Contains(text.String(), "fresh=false resume=false inspect=true") {
+	if !strings.Contains(text.String(), "fresh=false resume=false inspect=true random_eligible=false") ||
+		!strings.Contains(text.String(), "random: excluded (provider binary not found)") ||
+		!strings.Contains(text.String(), "model: override_supported=true") ||
+		!strings.Contains(text.String(), "reasoning_effort: override_supported=") ||
+		!strings.Contains(text.String(), "Random pool:  (excludes_caller=false empty=true)") {
 		t.Fatalf("options text = %q", text.String())
 	}
 	err = WriteOptions(OptionsRequest{Root: root, Env: []string{}, Stdout: failingWriter{}, LookPath: func(string) (string, error) { return "", exec.ErrNotFound }})
@@ -123,6 +127,9 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	}
 	_, err = executeProvider(providerCommand{Path: "/bin/sh", Args: []string{"-c", `printf answer`}, Env: os.Environ(), Provider: AgentAntigravity, Plain: true, LogPath: timeoutLog}, nil, timeoutRun, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
+	if timedOut, readErr := antigravityTimeoutReported(timeoutRun.Record.StderrPath, filepath.Join(root, "missing-log")); readErr == nil || timedOut {
+		t.Fatalf("missing Antigravity diagnostics = timedOut %t, error %v", timedOut, readErr)
+	}
 
 	if err := replayAnswer(filepath.Join(root, "missing-answer"), io.Discard); err == nil {
 		t.Fatal("replayAnswer accepted a missing capture")

--- a/internal/agentdispatch/failure_contract_test.go
+++ b/internal/agentdispatch/failure_contract_test.go
@@ -130,6 +130,12 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	if timedOut, readErr := antigravityTimeoutReported(timeoutRun.Record.StderrPath, filepath.Join(root, "missing-log")); readErr == nil || timedOut {
 		t.Fatalf("missing Antigravity diagnostics = timedOut %t, error %v", timedOut, readErr)
 	}
+	if err := os.WriteFile(timeoutRun.Record.StderrPath, []byte("Error: timeout waiting for response\n"), 0o600); err != nil {
+		t.Fatalf("write timeout stderr: %v", err)
+	}
+	if timedOut, readErr := antigravityTimeoutReported(timeoutRun.Record.StderrPath, filepath.Join(root, "missing-log")); readErr == nil || timedOut {
+		t.Fatalf("timeout stderr with missing Antigravity log = timedOut %t, error %v", timedOut, readErr)
+	}
 
 	if err := replayAnswer(filepath.Join(root, "missing-answer"), io.Discard); err == nil {
 		t.Fatal("replayAnswer accepted a missing capture")

--- a/internal/agentdispatch/options.go
+++ b/internal/agentdispatch/options.go
@@ -3,6 +3,7 @@ package agentdispatch
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -73,6 +74,19 @@ type FieldOption struct {
 	AllowCustom       bool     `json:"allow_custom"`
 }
 
+type targetDiscovery struct {
+	Target                targetMeta
+	Enabled               bool
+	Installed             bool
+	InstalledVersion      string
+	CompatibilityWarning  string
+	Fresh                 CapabilityOption
+	RandomEligible        bool
+	RandomExclusionReason string
+}
+
+type targetVersionDiscovery func(string, targetMeta) (string, string, error)
+
 // BuildOptions loads strict project config and reports each operation's exact
 // availability for the installed provider version.
 func BuildOptions(req OptionsRequest) (*OptionsResponse, error) {
@@ -128,7 +142,7 @@ func WriteOptions(req OptionsRequest) error {
 		return err
 	}
 	for _, target := range options.Targets {
-		if _, err := fmt.Fprintf(stdout, "- %s enabled=%t installed=%t version=%s fresh=%t resume=%t inspect=%t\n", target.Agent, target.Enabled, target.Installed, displayVersion(target.InstalledVersion), target.Capabilities.Fresh.Supported, target.Capabilities.Resume.Supported, target.Capabilities.Inspect.Supported); err != nil {
+		if _, err := fmt.Fprintf(stdout, "- %s enabled=%t installed=%t installed_version=%s supported_version=%s fresh=%t resume=%t inspect=%t random_eligible=%t\n", target.Agent, target.Enabled, target.Installed, displayVersion(target.InstalledVersion), target.SupportedVersion, target.Capabilities.Fresh.Supported, target.Capabilities.Resume.Supported, target.Capabilities.Inspect.Supported, target.RandomEligible); err != nil {
 			return err
 		}
 		if target.Capabilities.Fresh.Reason != "" {
@@ -141,8 +155,27 @@ func WriteOptions(req OptionsRequest) error {
 				return err
 			}
 		}
+		if target.RandomExclusionReason != nil {
+			if _, err := fmt.Fprintf(stdout, "  random: excluded (%s)\n", *target.RandomExclusionReason); err != nil {
+				return err
+			}
+		}
+		if err := writeFieldOption(stdout, "model", target.Model); err != nil {
+			return err
+		}
+		if err := writeFieldOption(stdout, "reasoning_effort", target.ReasoningEffort); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(stdout, "Random pool: %s (excludes_caller=%t empty=%t)\n", strings.Join(options.Random.Pool, ","), options.Random.ExcludesCaller, options.Random.Empty); err != nil {
+		return err
 	}
 	return nil
+}
+
+func writeFieldOption(stdout io.Writer, name string, option FieldOption) error {
+	_, err := fmt.Fprintf(stdout, "  %s: override_supported=%t configured=%q allow_custom=%t suggestions=%q\n", name, option.OverrideSupported, option.Configured, option.AllowCustom, option.Suggestions)
+	return err
 }
 
 func displayVersion(value string) string {
@@ -160,66 +193,38 @@ func buildTargetOptions(cfg config.Config, caller string, callerKnown bool, disc
 	targets := targetRegistry()
 	result := make([]TargetOption, 0, len(targets))
 	for _, target := range targets {
-		_, installedErr := discovery.LookPath(target.Binary)
-		installed := installedErr == nil
-		enabled := targetEnabled(cfg, target.Name)
-		version := ""
-		versionOK := false
-		versionWarning := ""
-		if installed {
-			path, _ := discovery.LookPath(target.Binary)
-			readVersion := lookup
-			if readVersion == nil {
-				readVersion = providerVersion
-			}
-			version, installedErr = readVersion(path, target.Name)
-			if installedErr == nil {
-				warning, compatErr := providerVersionCompatibility(target.Name, version)
-				versionOK = compatErr == nil
-				versionWarning = warning
-			}
-		}
-		fresh := CapabilityOption{Supported: enabled && installed && versionOK}
-		if !fresh.Supported {
-			switch {
-			case !enabled:
-				fresh.Reason = "disabled in config"
-			case !installed:
-				fresh.Reason = "provider binary not found"
-			case installedErr != nil:
-				fresh.Reason = "provider version could not be verified"
-			default:
-				fresh.Reason = "unsupported provider version; install " + supportedProviderVersions[target.Name]
-			}
-		}
-		resume := fresh
+		facts := discoverTarget(cfg, target, caller, callerKnown, discovery.LookPath, rawTargetVersionDiscovery(lookup))
+		resume := facts.Fresh
 		inspect := CapabilityOption{Supported: true}
-		randomEligible := fresh.Supported && (!callerKnown || target.Name != caller)
 		var exclusion *string
-		if !randomEligible {
-			reason := fresh.Reason
-			if callerKnown && target.Name == caller {
-				reason = "caller"
-			}
-			exclusion = &reason
+		if facts.RandomExclusionReason != "" {
+			exclusion = &facts.RandomExclusionReason
 		}
 		reasons := []string{}
-		if !fresh.Supported {
-			reasons = append(reasons, fresh.Reason)
+		if !facts.Fresh.Supported {
+			reasons = append(reasons, facts.Fresh.Reason)
 		}
 		fieldDiscovery := discovery
-		if !fresh.Supported {
+		if !facts.Fresh.Supported {
 			fieldDiscovery.Live = false
+		} else {
+			resolvedPath := facts.Target.Binary
+			fieldDiscovery.LookPath = func(binary string) (string, error) {
+				if binary == target.Binary {
+					return resolvedPath, nil
+				}
+				return discovery.LookPath(binary)
+			}
 		}
 		result = append(result, TargetOption{
 			Agent:                 target.Name,
-			Enabled:               enabled,
-			Installed:             installed,
-			InstalledVersion:      version,
+			Enabled:               facts.Enabled,
+			Installed:             facts.Installed,
+			InstalledVersion:      facts.InstalledVersion,
 			SupportedVersion:      supportedProviderVersions[target.Name],
-			CompatibilityWarning:  versionWarning,
-			Capabilities:          TargetCapabilities{Fresh: fresh, Resume: resume, Inspect: inspect},
-			RandomEligible:        randomEligible,
+			CompatibilityWarning:  facts.CompatibilityWarning,
+			Capabilities:          TargetCapabilities{Fresh: facts.Fresh, Resume: resume, Inspect: inspect},
+			RandomEligible:        facts.RandomEligible,
 			RandomExclusionReason: exclusion,
 			Model:                 fieldOptionWithDiscovery(cfg, target, agentoptions.KindModel, fieldDiscovery),
 			ReasoningEffort:       fieldOptionWithDiscovery(cfg, target, agentoptions.KindReasoningEffort, fieldDiscovery),
@@ -227,6 +232,56 @@ func buildTargetOptions(cfg config.Config, caller string, callerKnown bool, disc
 		})
 	}
 	return result
+}
+
+func rawTargetVersionDiscovery(lookup func(string, string) (string, error)) targetVersionDiscovery {
+	return func(path string, target targetMeta) (string, string, error) {
+		readVersion := lookup
+		if readVersion == nil {
+			readVersion = providerVersion
+		}
+		installed, err := readVersion(path, target.Name)
+		if err != nil {
+			return "", "", err
+		}
+		warning, err := providerVersionCompatibility(target.Name, installed)
+		return installed, warning, err
+	}
+}
+
+func discoverTarget(cfg config.Config, target targetMeta, caller string, callerKnown bool, lookPath func(string) (string, error), discoverVersion targetVersionDiscovery) targetDiscovery {
+	facts := targetDiscovery{Target: target, Enabled: targetEnabled(cfg, target.Name)}
+	path, pathErr := lookPath(target.Binary)
+	var versionErr error
+	if pathErr == nil {
+		facts.Installed = true
+		facts.Target.Binary = path
+		version, warning, err := discoverVersion(path, target)
+		facts.InstalledVersion = version
+		facts.CompatibilityWarning = warning
+		versionErr = err
+	}
+	facts.Fresh.Supported = facts.Enabled && facts.Installed && versionErr == nil
+	if !facts.Fresh.Supported {
+		switch {
+		case !facts.Enabled:
+			facts.Fresh.Reason = "disabled in config"
+		case !facts.Installed:
+			facts.Fresh.Reason = "provider binary not found"
+		case facts.InstalledVersion == "":
+			facts.Fresh.Reason = "provider version could not be verified"
+		default:
+			facts.Fresh.Reason = "unsupported provider version; install " + supportedProviderVersions[target.Name]
+		}
+	}
+	facts.RandomEligible = facts.Fresh.Supported && (!callerKnown || target.Name != caller)
+	if !facts.RandomEligible {
+		facts.RandomExclusionReason = facts.Fresh.Reason
+		if callerKnown && target.Name == caller {
+			facts.RandomExclusionReason = "caller"
+		}
+	}
+	return facts
 }
 
 func fieldOptionWithDiscovery(cfg config.Config, target targetMeta, kind agentoptions.Kind, discovery agentoptions.DiscoveryRequest) FieldOption {

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -424,14 +424,19 @@ func readStructuredEvents(reader io.Reader, rawWriter io.Writer, agent string, e
 	}
 }
 
+// antigravitySessionID extracts one consistent conversation ID from a run log.
 func antigravitySessionID(logPath string) (string, error) {
-	data, err := os.ReadFile(logPath) // #nosec G304 -- path is created in this run's private directory.
+	file, err := os.Open(logPath) // #nosec G304 -- path is created in this run's private directory.
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = file.Close() }()
+
 	found := ""
-	for _, line := range strings.Split(string(data), "\n") {
-		candidate := strings.TrimSpace(line)
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), maxCaptureBytes)
+	for scanner.Scan() {
+		candidate := strings.TrimSpace(scanner.Text())
 		if match := antigravityLogPrefix.FindStringSubmatch(candidate); len(match) == 2 {
 			candidate = match[1]
 		}
@@ -448,6 +453,9 @@ func antigravitySessionID(logPath string) (string, error) {
 			return "", fmt.Errorf("antigravity dispatch log reported conflicting conversation IDs %s and %s", found, id)
 		}
 		found = id
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read Antigravity dispatch log: %w", err)
 	}
 	return found, nil
 }

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -349,7 +349,7 @@ func reduceCodexEvent(value map[string]any) ([]providerEvent, error) {
 	case "turn.completed":
 		return []providerEvent{{Kind: eventComplete}}, nil
 	case "turn.failed", "turn.aborted", "error":
-		reason, _ := firstStringV013(value, "message", "reason")
+		reason, _ := firstStringV013(value, "message", "reason", "error")
 		if reason == "" {
 			if details, ok := mapValueV013(value, "error"); ok {
 				reason, _ = firstStringV013(details, "message", "reason")

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -349,7 +349,12 @@ func reduceCodexEvent(value map[string]any) ([]providerEvent, error) {
 	case "turn.completed":
 		return []providerEvent{{Kind: eventComplete}}, nil
 	case "turn.failed", "turn.aborted", "error":
-		reason, _ := firstStringV013(value, "message", "error", "reason")
+		reason, _ := firstStringV013(value, "message", "reason")
+		if reason == "" {
+			if details, ok := mapValueV013(value, "error"); ok {
+				reason, _ = firstStringV013(details, "message", "reason")
+			}
+		}
 		if reason == "" {
 			reason = "Codex reported a terminal failure"
 		}
@@ -374,34 +379,49 @@ func reduceCodexEvent(value map[string]any) ([]providerEvent, error) {
 }
 
 func readStructuredEvents(reader io.Reader, rawWriter io.Writer, agent string, expectedSession string, consume func(providerEvent) error) error {
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 64*1024), maxStructuredEventBytes)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if _, err := rawWriter.Write(line); err != nil {
-			return err
-		}
-		if _, err := rawWriter.Write([]byte{'\n'}); err != nil {
-			return err
-		}
-		trimmed := bytes.TrimSpace(line)
-		if len(trimmed) == 0 {
-			continue
-		}
-		events, err := reduceStructuredEvent(agent, expectedSession, trimmed)
-		if err != nil {
-			return err
-		}
-		for _, event := range events {
-			if err := consume(event); err != nil {
+	buffered := bufio.NewReaderSize(reader, 64*1024)
+	line := make([]byte, 0, 64*1024)
+	for {
+		fragment, readErr := buffered.ReadSlice('\n')
+		if len(fragment) > 0 {
+			if _, err := rawWriter.Write(fragment); err != nil {
 				return err
 			}
+			line = append(line, fragment...)
+			contentBytes := len(line)
+			if line[contentBytes-1] == '\n' {
+				contentBytes--
+			}
+			if contentBytes > maxStructuredEventBytes {
+				return fmt.Errorf("read %s structured event: event exceeded %d byte limit", agent, maxStructuredEventBytes)
+			}
+		}
+		if readErr == bufio.ErrBufferFull {
+			continue
+		}
+		if readErr != nil && readErr != io.EOF {
+			return fmt.Errorf("read %s structured event (maximum %d bytes): %w", agent, maxStructuredEventBytes, readErr)
+		}
+		if len(line) == 0 && readErr == io.EOF {
+			return nil
+		}
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) > 0 {
+			events, err := reduceStructuredEvent(agent, expectedSession, trimmed)
+			if err != nil {
+				return err
+			}
+			for _, event := range events {
+				if err := consume(event); err != nil {
+					return err
+				}
+			}
+		}
+		line = line[:0]
+		if readErr == io.EOF {
+			return nil
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read %s structured event (maximum %d bytes): %w", agent, maxStructuredEventBytes, err)
-	}
-	return nil
 }
 
 func antigravitySessionID(logPath string) (string, error) {
@@ -409,19 +429,27 @@ func antigravitySessionID(logPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	found := ""
 	for _, line := range strings.Split(string(data), "\n") {
 		candidate := strings.TrimSpace(line)
 		if match := antigravityLogPrefix.FindStringSubmatch(candidate); len(match) == 2 {
 			candidate = match[1]
 		}
+		var id string
 		if match := antigravityCreatedConversation.FindStringSubmatch(candidate); len(match) == 2 {
-			return strings.ToLower(match[1]), nil
+			id = strings.ToLower(match[1])
+		} else if match := antigravityPrintConversation.FindStringSubmatch(candidate); len(match) == 2 {
+			id = strings.ToLower(match[1])
 		}
-		if match := antigravityPrintConversation.FindStringSubmatch(candidate); len(match) == 2 {
-			return strings.ToLower(match[1]), nil
+		if id == "" {
+			continue
 		}
+		if found != "" && found != id {
+			return "", fmt.Errorf("antigravity dispatch log reported conflicting conversation IDs %s and %s", found, id)
+		}
+		found = id
 	}
-	return "", nil
+	return found, nil
 }
 
 func compatibleTargetVersion(path string, target targetMeta, lookup func(string, string) (string, error)) (targetMeta, string, error) {

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -273,6 +273,13 @@ func TestAntigravityLogIDIsStrictAndVersionGateFailsLoudly(t *testing.T) {
 	if id, err := antigravitySessionID(logPath); err == nil || id != "" {
 		t.Fatalf("conflicting Antigravity IDs = %q, %v", id, err)
 	}
+	longDiagnostic := strings.Repeat("x", 128*1024)
+	if err := os.WriteFile(logPath, []byte(longDiagnostic+"\nCreated conversation AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA\n"), 0o600); err != nil {
+		t.Fatalf("write long diagnostic log: %v", err)
+	}
+	if id, err := antigravitySessionID(logPath); err != nil || id != "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" {
+		t.Fatalf("long diagnostic log ID = %q, %v", id, err)
+	}
 	_, err = requireSupportedVersion("ignored", AgentCodex, func(string, string) (string, error) { return "0.1.0", nil })
 	requireDispatchExitCode(t, err, ExitUnavailable)
 }

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -178,6 +178,10 @@ func TestStructuredEventsRejectChangedProviderContracts(t *testing.T) {
 	if err != nil || len(flatEvents) != 1 || flatEvents[0].Answer != "compatible answer" {
 		t.Fatalf("Codex flat compatibility events = %#v, %v", flatEvents, err)
 	}
+	failureEvents, err := reduceStructuredEvent(AgentCodex, "", []byte(`{"type":"turn.failed","error":{"message":"model quota exhausted"}}`))
+	if err != nil || len(failureEvents) != 1 || failureEvents[0].Kind != eventFailure || failureEvents[0].Reason != "model quota exhausted" {
+		t.Fatalf("Codex nested failure events = %#v, %v", failureEvents, err)
+	}
 	var raw bytes.Buffer
 	if err := readStructuredEvents(strings.NewReader("not-json\n"), &raw, AgentCodex, "", func(providerEvent) error { return nil }); err == nil {
 		t.Fatal("invalid provider JSON was accepted")
@@ -191,6 +195,14 @@ func TestStructuredEventsRejectChangedProviderContracts(t *testing.T) {
 	}
 	if raw.String() != "\n  \n" {
 		t.Fatalf("blank raw evidence = %q", raw.String())
+	}
+	raw.Reset()
+	oversized := bytes.Repeat([]byte("x"), maxStructuredEventBytes+1)
+	if err := readStructuredEvents(bytes.NewReader(oversized), &raw, AgentCodex, "", func(providerEvent) error { return nil }); err == nil {
+		t.Fatal("oversized provider event was accepted")
+	}
+	if !bytes.Equal(raw.Bytes(), oversized) {
+		t.Fatalf("oversized raw evidence retained %d bytes, want %d", raw.Len(), len(oversized))
 	}
 }
 
@@ -214,6 +226,12 @@ func TestRunnerBuffersOnlyCompletedAnswer(t *testing.T) {
 	})
 	if err != nil || !result.Complete || !result.AnswerSeen || persisted != runtimeSessionID {
 		t.Fatalf("success result=%#v err=%v persisted=%q", result, err, persisted)
+	}
+	if result.Answer != "answer" {
+		t.Fatalf("terminal answer candidate = %q", result.Answer)
+	}
+	if _, statErr := os.Stat(successfulRun.Record.AnswerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("runner published answer before provider-specific terminal validation: %v", statErr)
 	}
 
 	incompleteRun, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], "fresh")
@@ -246,6 +264,14 @@ func TestAntigravityLogIDIsStrictAndVersionGateFailsLoudly(t *testing.T) {
 	id, err := antigravitySessionID(logPath)
 	if err != nil || id != "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" {
 		t.Fatalf("Antigravity ID = %q, %v", id, err)
+	}
+	conflicting := "Created conversation AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA\n" +
+		"Print mode: conversation=BBBBBBBB-BBBB-4BBB-8BBB-BBBBBBBBBBBB, sending message\n"
+	if err := os.WriteFile(logPath, []byte(conflicting), 0o600); err != nil {
+		t.Fatalf("write conflicting log: %v", err)
+	}
+	if id, err := antigravitySessionID(logPath); err == nil || id != "" {
+		t.Fatalf("conflicting Antigravity IDs = %q, %v", id, err)
 	}
 	_, err = requireSupportedVersion("ignored", AgentCodex, func(string, string) (string, error) { return "0.1.0", nil })
 	requireDispatchExitCode(t, err, ExitUnavailable)

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -182,6 +182,10 @@ func TestStructuredEventsRejectChangedProviderContracts(t *testing.T) {
 	if err != nil || len(failureEvents) != 1 || failureEvents[0].Kind != eventFailure || failureEvents[0].Reason != "model quota exhausted" {
 		t.Fatalf("Codex nested failure events = %#v, %v", failureEvents, err)
 	}
+	stringFailureEvents, err := reduceStructuredEvent(AgentCodex, "", []byte(`{"type":"error","error":"quota exhausted"}`))
+	if err != nil || len(stringFailureEvents) != 1 || stringFailureEvents[0].Kind != eventFailure || stringFailureEvents[0].Reason != "quota exhausted" {
+		t.Fatalf("Codex string failure events = %#v, %v", stringFailureEvents, err)
+	}
 	var raw bytes.Buffer
 	if err := readStructuredEvents(strings.NewReader("not-json\n"), &raw, AgentCodex, "", func(providerEvent) error { return nil }); err == nil {
 		t.Fatal("invalid provider JSON was accepted")

--- a/internal/agentdispatch/resolve.go
+++ b/internal/agentdispatch/resolve.go
@@ -56,13 +56,19 @@ func chooseRandomTarget(cfg config.Config, root string, caller string, callerKno
 	}
 	pool := make([]string, 0, len(targetRegistry()))
 	discovered := make(map[string]targetDiscovery, len(targetRegistry()))
-	discoverVersion := func(path string, target targetMeta) (string, string, error) {
-		_, installed, err := compatibleTargetVersionCached(root, path, target, versionLookup)
-		if err != nil {
-			return "", "", err
+	discoverVersion := rawTargetVersionDiscovery(versionLookup)
+	if versionLookup == nil {
+		discoverVersion = func(path string, target targetMeta) (string, string, error) {
+			_, installed, err := compatibleTargetVersionCached(root, path, target, nil)
+			if err != nil {
+				// Unsupported versions are intentionally absent from the cache.
+				// Read them raw so random exclusion still reports the installed
+				// version and canonical compatibility reason.
+				return rawTargetVersionDiscovery(nil)(path, target)
+			}
+			warning, err := providerVersionCompatibility(target.Name, installed)
+			return installed, warning, err
 		}
-		warning, err := providerVersionCompatibility(target.Name, installed)
-		return installed, warning, err
 	}
 	for _, target := range targetRegistry() {
 		if callerKnown && target.Name == caller {

--- a/internal/agentdispatch/resolve.go
+++ b/internal/agentdispatch/resolve.go
@@ -12,8 +12,9 @@ import (
 )
 
 type resolution struct {
-	Target targetMeta
-	Notice string
+	Target  targetMeta
+	Version string
+	Notice  string
 }
 
 func resolveTarget(cfg config.Config, req RunOptions, caller string, callerKnown bool) (resolution, error) {
@@ -28,14 +29,14 @@ func resolveTarget(cfg config.Config, req RunOptions, caller string, callerKnown
 		requested = dispatchDefaultForCaller(cfg, caller)
 	}
 	if requested == AgentRandom {
-		selected, err := chooseRandomTarget(cfg, caller, callerKnown, req.LookPath, req.ChooseRandom)
+		selected, err := chooseRandomTarget(cfg, req.Root, caller, callerKnown, req.LookPath, req.VersionLookup, req.ChooseRandom)
 		if err != nil {
 			return resolution{}, err
 		}
-		target, _ := lookupTarget(selected)
 		return resolution{
-			Target: target,
-			Notice: fmt.Sprintf(messages.DispatchTargetRandomFmt, selected),
+			Target:  selected.Target,
+			Version: selected.InstalledVersion,
+			Notice:  fmt.Sprintf(messages.DispatchTargetRandomFmt, selected.Target.Name),
 		}, nil
 	}
 	target, ok := lookupTarget(requested)
@@ -49,11 +50,20 @@ func resolveTarget(cfg config.Config, req RunOptions, caller string, callerKnown
 	return resolved, nil
 }
 
-func chooseRandomTarget(cfg config.Config, caller string, callerKnown bool, lookPath func(string) (string, error), chooser RandomChooser) (string, error) {
+func chooseRandomTarget(cfg config.Config, root string, caller string, callerKnown bool, lookPath func(string) (string, error), versionLookup func(string, string) (string, error), chooser RandomChooser) (targetDiscovery, error) {
 	if lookPath == nil {
 		lookPath = exec.LookPath
 	}
-	var pool []string
+	pool := make([]string, 0, len(targetRegistry()))
+	discovered := make(map[string]targetDiscovery, len(targetRegistry()))
+	discoverVersion := func(path string, target targetMeta) (string, string, error) {
+		_, installed, err := compatibleTargetVersionCached(root, path, target, versionLookup)
+		if err != nil {
+			return "", "", err
+		}
+		warning, err := providerVersionCompatibility(target.Name, installed)
+		return installed, warning, err
+	}
 	for _, target := range targetRegistry() {
 		if callerKnown && target.Name == caller {
 			continue
@@ -61,25 +71,26 @@ func chooseRandomTarget(cfg config.Config, caller string, callerKnown bool, look
 		if !targetEnabled(cfg, target.Name) {
 			continue
 		}
-		if _, err := lookPath(target.Binary); err != nil {
-			continue
+		facts := discoverTarget(cfg, target, caller, callerKnown, lookPath, discoverVersion)
+		if facts.RandomEligible {
+			pool = append(pool, target.Name)
+			discovered[target.Name] = facts
 		}
-		pool = append(pool, target.Name)
 	}
 	if len(pool) == 0 {
-		return "", exitError(ExitUnavailable, messages.DispatchEmptyRandomPool)
+		return targetDiscovery{}, exitError(ExitUnavailable, messages.DispatchEmptyRandomPool)
 	}
 	if chooser == nil {
 		chooser = defaultRandomChooser
 	}
 	selected, err := chooser(pool)
 	if err != nil {
-		return "", wrapExitError(ExitTargetFailure, fmt.Sprintf(messages.DispatchInternalErrorFmt, err), err)
+		return targetDiscovery{}, wrapExitError(ExitTargetFailure, fmt.Sprintf(messages.DispatchInternalErrorFmt, err), err)
 	}
 	normalized := normalizeAgent(selected)
 	if _, ok := lookupTarget(normalized); !ok {
 		invalidErr := fmt.Errorf("random chooser returned invalid target %q", selected)
-		return "", wrapExitError(ExitTargetFailure, fmt.Sprintf(messages.DispatchInternalErrorFmt, invalidErr), invalidErr)
+		return targetDiscovery{}, wrapExitError(ExitTargetFailure, fmt.Sprintf(messages.DispatchInternalErrorFmt, invalidErr), invalidErr)
 	}
 	// A custom chooser must stay inside the pool the resolver computed so
 	// it can't bypass caller-exclusion or availability constraints by
@@ -93,9 +104,9 @@ func chooseRandomTarget(cfg config.Config, caller string, callerKnown bool, look
 	}
 	if !inPool {
 		ineligibleErr := fmt.Errorf("random chooser returned target %q which is not in the eligible pool", selected)
-		return "", wrapExitError(ExitTargetFailure, fmt.Sprintf(messages.DispatchInternalErrorFmt, ineligibleErr), ineligibleErr)
+		return targetDiscovery{}, wrapExitError(ExitTargetFailure, fmt.Sprintf(messages.DispatchInternalErrorFmt, ineligibleErr), ineligibleErr)
 	}
-	return normalized, nil
+	return discovered[normalized], nil
 }
 
 func defaultRandomChooser(pool []string) (string, error) {

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -78,6 +78,7 @@ type executionResult struct {
 	Complete     bool
 	AnswerSeen   bool
 	NotResumable bool
+	Answer       string
 }
 
 func executeProvider(
@@ -312,8 +313,14 @@ func executeProvider(
 			return executionResult{}, exitError(ExitTargetFailure, fmt.Sprintf("Antigravity provider log exceeded the remaining %d byte dispatch capture budget", remaining))
 		}
 	}
-	if command.Provider == AgentAntigravity && antigravityTimeoutReported(run.Record.StderrPath, command.LogPath) {
-		return executionResult{}, exitError(ExitTargetFailure, "antigravity reported terminal failure: Error: timeout waiting for response")
+	if command.Provider == AgentAntigravity {
+		timedOut, err := antigravityTimeoutReported(run.Record.StderrPath, command.LogPath)
+		if err != nil {
+			return executionResult{}, wrapExitError(ExitTargetFailure, "inspect Antigravity terminal diagnostics", err)
+		}
+		if timedOut {
+			return executionResult{}, exitError(ExitTargetFailure, "antigravity reported terminal failure: Error: timeout waiting for response")
+		}
 	}
 	if command.Structured && (!result.Complete || !result.AnswerSeen || result.SessionID == "") {
 		return executionResult{}, exitError(ExitTargetFailure, fmt.Sprintf("%s dispatch completed without required terminal result, session ID, and final answer", command.Provider))
@@ -324,23 +331,21 @@ func executeProvider(
 	resultMu.Lock()
 	terminalAnswer := answerCandidate
 	resultMu.Unlock()
-	if err := writeBytesAtomic(run.Record.AnswerPath, []byte(terminalAnswer), 0o600); err != nil {
-		return executionResult{}, wrapExitError(ExitConfig, "publish dispatch terminal answer", err)
-	}
+	result.Answer = terminalAnswer
 	return result, nil
 }
 
-func antigravityTimeoutReported(stderrPath string, logPath string) bool {
+func antigravityTimeoutReported(stderrPath string, logPath string) (bool, error) {
 	for _, path := range []string{stderrPath, logPath} {
 		data, err := os.ReadFile(path) // #nosec G304 -- paths are in the active isolated run.
 		if err != nil {
-			continue
+			return false, fmt.Errorf("read %s: %w", path, err)
 		}
 		if bytes.Contains(data, []byte("Error: timeout waiting for response")) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func replayAnswer(path string, stdout io.Writer) error {

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -336,16 +336,17 @@ func executeProvider(
 }
 
 func antigravityTimeoutReported(stderrPath string, logPath string) (bool, error) {
+	timedOut := false
 	for _, path := range []string{stderrPath, logPath} {
 		data, err := os.ReadFile(path) // #nosec G304 -- paths are in the active isolated run.
 		if err != nil {
 			return false, fmt.Errorf("read %s: %w", path, err)
 		}
 		if bytes.Contains(data, []byte("Error: timeout waiting for response")) {
-			return true, nil
+			timedOut = true
 		}
 	}
-	return false, nil
+	return timedOut, nil
 }
 
 func replayAnswer(path string, stdout io.Writer) error {

--- a/internal/agentdispatch/runtime_test.go
+++ b/internal/agentdispatch/runtime_test.go
@@ -136,3 +136,83 @@ func TestProviderProcessErrorsNameTheCorrectLifecyclePhase(t *testing.T) {
 		t.Fatalf("wait error = %q", waitErr)
 	}
 }
+
+func TestTerminalCommitKeepsAnswerRunAndClaimCoherent(t *testing.T) {
+	newRunning := func(t *testing.T) (string, *dispatchRun, Session) {
+		t.Helper()
+		root := t.TempDir()
+		run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+		if err != nil {
+			t.Fatalf("new run: %v", err)
+		}
+		session, err := reserveSession(root, run)
+		if err != nil {
+			t.Fatalf("reserve session: %v", err)
+		}
+		run.Record.State = dispatchStateRunning
+		run.Record.RecoveryState = recoveryAcceptanceUnknown
+		if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+			t.Fatalf("start run: %v", err)
+		}
+		return root, run, session
+	}
+
+	t.Run("answer write failure terminalizes without publication", func(t *testing.T) {
+		root, run, session := newRunning(t)
+		blockedParent := filepath.Join(root, "not-a-directory")
+		if err := os.WriteFile(blockedParent, []byte("blocked"), 0o600); err != nil {
+			t.Fatalf("write blocking file: %v", err)
+		}
+		run.Record.AnswerPath = filepath.Join(blockedParent, "answer.txt")
+		err := completeDispatchSuccess(dispatchExecution{Root: root, Run: run, Session: session, Stderr: io.Discard}, executionResult{Answer: "validated"}, session)
+		requireDispatchExitCode(t, err, ExitConfig)
+		record, loadErr := loadRunRecord(root, run.Record.ID)
+		if loadErr != nil || record.State != dispatchStateFailed {
+			t.Fatalf("failed answer publication record = %#v, %v", record, loadErr)
+		}
+	})
+
+	t.Run("completed record conflict retracts answer and releases claim", func(t *testing.T) {
+		root, run, session := newRunning(t)
+		current, err := loadRunRecord(root, run.Record.ID)
+		if err != nil {
+			t.Fatalf("load current run: %v", err)
+		}
+		now := time.Now().UTC()
+		current.State = dispatchStateCancelled
+		current.CompletedAt = &now
+		if err := writeRunRecord(run.Dir, &current); err != nil {
+			t.Fatalf("cancel current run: %v", err)
+		}
+		err = completeDispatchSuccess(dispatchExecution{Root: root, Run: run, Session: session, Stderr: io.Discard}, executionResult{Answer: "validated"}, session)
+		requireDispatchExitCode(t, err, ExitTargetFailure)
+		if _, statErr := os.Stat(run.Record.AnswerPath); !os.IsNotExist(statErr) {
+			t.Fatalf("terminal record conflict retained published answer: %v", statErr)
+		}
+		retained, loadErr := loadSession(root, session.Name)
+		if loadErr != nil || retained.ActiveRunID != "" {
+			t.Fatalf("terminal record conflict retained claim = %#v, %v", retained, loadErr)
+		}
+	})
+
+	t.Run("claim cleanup failure preserves durable success", func(t *testing.T) {
+		root, run, session := newRunning(t)
+		mappingPath, err := sessionPath(root, session.Name)
+		if err != nil {
+			t.Fatalf("session path: %v", err)
+		}
+		if err := os.WriteFile(mappingPath, []byte("not-json"), 0o600); err != nil {
+			t.Fatalf("corrupt test mapping: %v", err)
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		err = completeDispatchSuccess(dispatchExecution{Root: root, Run: run, Session: session, Stdout: &stdout, Stderr: &stderr}, executionResult{Answer: "validated"}, session)
+		if err != nil {
+			t.Fatalf("claim cleanup changed completed outcome: %v", err)
+		}
+		record, loadErr := loadRunRecord(root, run.Record.ID)
+		if loadErr != nil || record.State != dispatchStateCompleted || stdout.String() != "validated" || stderr.Len() == 0 {
+			t.Fatalf("claim cleanup result record=%#v stdout=%q stderr=%q err=%v", record, stdout.String(), stderr.String(), loadErr)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Make random Agent Dispatch selection use the same provider compatibility evidence as fresh execution.
- Harden provider terminal handling so durable state, answers, and conversation claims stay coherent.

## Changes

- Reuse discovered provider paths and versions, expose complete options facts in text output, and reject incompatible random candidates before choice.
- Preserve structured-provider diagnostic evidence, validate Antigravity session and timeout evidence, and publish answers only after terminal validation.
- Preserve top-level string and nested Codex failure diagnostics, and retain exact random-provider compatibility facts without bypassing the cached execution gate.
- Record four intentionally unresolved lifecycle/state/policy findings in `docs/agent-layer/ISSUES.md`.

## Verification

- `go test ./internal/agentdispatch` — passed on `b5bded7d5f163ca685a53724d91d31af34dfad94`.
- `make fmt-check`, `make lint`, and `make test-race` — passed on `b5bded7d5f163ca685a53724d91d31af34dfad94`.
- `git diff --check` — passed.

## Notes

- Provider shutdown escalation, Antigravity runtime log bounding, failed record-write mutation, and random requested-override filtering remain intentionally outside this PR implementation scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded target information in options output, including supported versions, random eligibility, exclusion reasons, field overrides, and random-pool details.
  - Improved random target selection by excluding incompatible or unavailable providers before selection.

- **Bug Fixes**
  - Improved handling of provider failures, oversized event data, conflicting session IDs, and timeout diagnostics.
  - Preserved terminal answers more reliably and kept run status and session cleanup consistent after completion or failure.

- **Documentation**
  - Added deferred notes covering shutdown behavior and runtime log capture limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->