### PR TITLE
Harden root discovery and launcher diagnostics

### DIFF
--- a/cmd/al/antigravity.go
+++ b/cmd/al/antigravity.go
@@ -32,7 +32,7 @@ func newAntigravityCmd() *cobra.Command {
 }
 
 func runAntigravity(cmd *cobra.Command, root string, quiet bool, passArgs []string) error {
-	return clients.Run(cmd.Context(), root, "antigravity", func(cfg *config.Config) *bool {
+	return clients.RunWithStderr(cmd.Context(), root, "antigravity", func(cfg *config.Config) *bool {
 		return cfg.Agents.Antigravity.Enabled
-	}, antigravity.Launch, quiet, passArgs, Version)
+	}, antigravity.Launch, quiet, passArgs, Version, cmd.ErrOrStderr())
 }

--- a/cmd/al/claude.go
+++ b/cmd/al/claude.go
@@ -23,9 +23,9 @@ func newClaudeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return clients.Run(cmd.Context(), root, "claude", func(cfg *config.Config) *bool {
+			return clients.RunWithStderr(cmd.Context(), root, "claude", func(cfg *config.Config) *bool {
 				return cfg.Agents.Claude.Enabled
-			}, claude.Launch, quiet, passArgs, Version)
+			}, claude.Launch, quiet, passArgs, Version, cmd.ErrOrStderr())
 		},
 	}
 

--- a/cmd/al/codex.go
+++ b/cmd/al/codex.go
@@ -23,9 +23,9 @@ func newCodexCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return clients.Run(cmd.Context(), root, "codex", func(cfg *config.Config) *bool {
+			return clients.RunWithStderr(cmd.Context(), root, "codex", func(cfg *config.Config) *bool {
 				return cfg.Agents.Codex.Enabled
-			}, codex.Launch, quiet, passArgs, Version)
+			}, codex.Launch, quiet, passArgs, Version, cmd.ErrOrStderr())
 		},
 	}
 

--- a/cmd/al/copilot.go
+++ b/cmd/al/copilot.go
@@ -23,9 +23,9 @@ func newCopilotCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return clients.Run(cmd.Context(), root, "copilot", func(cfg *config.Config) *bool {
+			return clients.RunWithStderr(cmd.Context(), root, "copilot", func(cfg *config.Config) *bool {
 				return cfg.Agents.CopilotCLI.Enabled
-			}, copilotcli.Launch, quiet, passArgs, Version)
+			}, copilotcli.Launch, quiet, passArgs, Version, cmd.ErrOrStderr())
 		},
 	}
 

--- a/cmd/al/no_sync_args.go
+++ b/cmd/al/no_sync_args.go
@@ -32,9 +32,9 @@ func newNoSyncLaunchCmd(
 				return err
 			}
 			if noSync {
-				return clients.RunNoSync(root, agentName, enabledFn, launchFn, quiet, passArgs)
+				return clients.RunNoSyncWithStderr(root, agentName, enabledFn, launchFn, quiet, passArgs, cmd.ErrOrStderr())
 			}
-			return clients.Run(cmd.Context(), root, agentName, enabledFn, launchFn, quiet, passArgs, Version)
+			return clients.RunWithStderr(cmd.Context(), root, agentName, enabledFn, launchFn, quiet, passArgs, Version, cmd.ErrOrStderr())
 		},
 	}
 

--- a/cmd/al/no_sync_args_test.go
+++ b/cmd/al/no_sync_args_test.go
@@ -269,15 +269,26 @@ func captureProcessStderr(t *testing.T, fn func()) string {
 		_ = reader.Close()
 		_ = writer.Close()
 	}()
+	readDone := make(chan struct {
+		captured []byte
+		err      error
+	}, 1)
+	go func() {
+		captured, readErr := io.ReadAll(reader)
+		readDone <- struct {
+			captured []byte
+			err      error
+		}{captured: captured, err: readErr}
+	}()
 
 	fn()
+	os.Stderr = original
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}
-	os.Stderr = original
-	captured, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatalf("read process stderr: %v", err)
+	result := <-readDone
+	if result.err != nil {
+		t.Fatalf("read process stderr: %v", result.err)
 	}
-	return string(captured)
+	return string(result.captured)
 }

--- a/cmd/al/no_sync_args_test.go
+++ b/cmd/al/no_sync_args_test.go
@@ -1,9 +1,118 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/config"
+	"github.com/conn-castle/agent-layer/internal/run"
+	"github.com/conn-castle/agent-layer/internal/testutil"
 )
+
+func TestClientLaunchDiagnosticsUseCommandStderr(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "synchronized", args: []string{"--client-arg"}},
+		{name: "no sync", args: []string{"--no-sync", "--client-arg"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeClientLaunchDiagnosticRepo(t, false)
+			var gotArgs []string
+			launchCalls := 0
+			cmd := newNoSyncLaunchCmd("test", "test", "vscode", func(cfg *config.Config) *bool {
+				return cfg.Agents.VSCode.Enabled
+			}, func(_ *config.ProjectConfig, _ *run.Info, _ []string, args []string) error {
+				launchCalls++
+				gotArgs = append([]string(nil), args...)
+				return nil
+			})
+			var commandStderr bytes.Buffer
+			cmd.SetErr(&commandStderr)
+
+			var runErr error
+			processStderr := captureProcessStderr(t, func() {
+				testutil.WithWorkingDir(t, root, func() {
+					runErr = cmd.RunE(cmd, tt.args)
+				})
+			})
+			if runErr != nil {
+				t.Fatalf("run client command: %v", runErr)
+			}
+			if commandStderr.Len() == 0 {
+				t.Fatal("expected launch diagnostic on the command stderr writer")
+			}
+			if processStderr != "" {
+				t.Fatalf("expected no launch diagnostic on process stderr, got %q", processStderr)
+			}
+			if launchCalls != 1 {
+				t.Fatalf("launch calls = %d, want 1", launchCalls)
+			}
+			if want := []string{"--client-arg"}; !slices.Equal(gotArgs, want) {
+				t.Fatalf("launch args = %#v, want %#v", gotArgs, want)
+			}
+		})
+	}
+}
+
+func TestClientLaunchQuietSuppressesCommandDiagnostics(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		configQuiet bool
+	}{
+		{name: "synchronized flag", args: []string{"--quiet", "--client-arg"}},
+		{name: "synchronized config", args: []string{"--client-arg"}, configQuiet: true},
+		{name: "no sync flag", args: []string{"--no-sync", "--quiet", "--client-arg"}},
+		{name: "no sync config", args: []string{"--no-sync", "--client-arg"}, configQuiet: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeClientLaunchDiagnosticRepo(t, tt.configQuiet)
+			var gotArgs []string
+			launchCalls := 0
+			cmd := newNoSyncLaunchCmd("test", "test", "vscode", func(cfg *config.Config) *bool {
+				return cfg.Agents.VSCode.Enabled
+			}, func(_ *config.ProjectConfig, _ *run.Info, _ []string, args []string) error {
+				launchCalls++
+				gotArgs = append([]string(nil), args...)
+				return nil
+			})
+			var commandStderr bytes.Buffer
+			cmd.SetErr(&commandStderr)
+
+			var runErr error
+			processStderr := captureProcessStderr(t, func() {
+				testutil.WithWorkingDir(t, root, func() {
+					runErr = cmd.RunE(cmd, tt.args)
+				})
+			})
+			if runErr != nil {
+				t.Fatalf("run client command: %v", runErr)
+			}
+			if commandStderr.Len() != 0 {
+				t.Fatalf("expected quiet launch to suppress command diagnostics, got %q", commandStderr.String())
+			}
+			if processStderr != "" {
+				t.Fatalf("expected quiet launch to suppress process diagnostics, got %q", processStderr)
+			}
+			if launchCalls != 1 {
+				t.Fatalf("launch calls = %d, want 1", launchCalls)
+			}
+			if want := []string{"--client-arg"}; !slices.Equal(gotArgs, want) {
+				t.Fatalf("launch args = %#v, want %#v", gotArgs, want)
+			}
+		})
+	}
+}
 
 func TestSplitNoSyncArgs(t *testing.T) {
 	tests := []struct {
@@ -105,4 +214,70 @@ func TestSplitNoSyncArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func writeClientLaunchDiagnosticRepo(t *testing.T, quiet bool) string {
+	t.Helper()
+	root := t.TempDir()
+	writeTestRepo(t, root)
+	paths := config.DefaultPaths(root)
+	configToml := `
+[approvals]
+mode = "yolo"
+
+[agents.antigravity]
+enabled = true
+
+[agents.claude]
+enabled = true
+
+[agents.claude_vscode]
+enabled = true
+
+[agents.codex]
+enabled = true
+
+[agents.vscode]
+enabled = true
+
+[agents.copilot_cli]
+enabled = true
+`
+	if quiet {
+		configToml += "\n[warnings]\nnoise_mode = \"quiet\"\n"
+	}
+	if err := os.WriteFile(paths.ConfigPath, []byte(configToml), 0o600); err != nil {
+		t.Fatalf("write diagnostic config fixture: %v", err)
+	}
+
+	binDir := t.TempDir()
+	testutil.WriteStub(t, binDir, "al")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return root
+}
+
+func captureProcessStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	original := os.Stderr
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = original
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	os.Stderr = original
+	captured, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read process stderr: %v", err)
+	}
+	return string(captured)
 }

--- a/cmd/al/root_resolve_test.go
+++ b/cmd/al/root_resolve_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -44,5 +45,42 @@ func TestResolveRepoRootAndWorkingDirPreservesCallerDirectory(t *testing.T) {
 	}
 	if root != "/config-root" || gotWorkingDir != workingDir {
 		t.Fatalf("resolved root/workdir = %q/%q", root, gotWorkingDir)
+	}
+}
+
+func TestResolveRepoRootAndWorkingDirResolvesRootWithoutRewritingCallerDirectory(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".agent-layer"), 0o700); err != nil {
+		t.Fatalf("mkdir .agent-layer: %v", err)
+	}
+	descendant := filepath.Join(repo, "packages", "service")
+	if err := os.MkdirAll(descendant, 0o700); err != nil {
+		t.Fatalf("mkdir descendant: %v", err)
+	}
+
+	logicalParent := t.TempDir()
+	linkedRepo := filepath.Join(logicalParent, "linked-repo")
+	if err := os.Symlink(repo, linkedRepo); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+	logicalWorkingDir := filepath.Join(linkedRepo, "packages", "service")
+
+	originalGetwd := getwd
+	getwd = func() (string, error) { return logicalWorkingDir, nil }
+	t.Cleanup(func() { getwd = originalGetwd })
+
+	gotRoot, gotWorkingDir, err := resolveRepoRootAndWorkingDir()
+	if err != nil {
+		t.Fatalf("resolve root and working directory: %v", err)
+	}
+	wantRoot, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve expected repository root: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("resolved root = %q, want real root %q", gotRoot, wantRoot)
+	}
+	if gotWorkingDir != logicalWorkingDir {
+		t.Fatalf("working directory = %q, want original caller value %q", gotWorkingDir, logicalWorkingDir)
 	}
 }

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -17,15 +17,15 @@ const (
 // FindAgentLayerRoot walks upward from start until it finds a directory containing .agent-layer/.
 // It returns the root path, whether it was found, and any error encountered.
 func FindAgentLayerRoot(start string) (string, bool, error) {
-	if start == "" {
-		return "", false, fmt.Errorf(messages.RootStartPathRequired)
-	}
-	abs, err := filepath.Abs(start)
+	resolved, err := resolveStartPath(start)
 	if err != nil {
-		return "", false, fmt.Errorf(messages.RootResolvePathFmt, start, err)
+		return "", false, err
 	}
+	return findAgentLayerRoot(resolved)
+}
 
-	dir := abs
+func findAgentLayerRoot(start string) (string, bool, error) {
+	dir := start
 	for {
 		candidate := filepath.Join(dir, agentLayerDir)
 		info, err := os.Stat(candidate)
@@ -50,21 +50,18 @@ func FindAgentLayerRoot(start string) (string, bool, error) {
 // FindRepoRoot returns the repo root for initialization.
 // It prefers an existing .agent-layer directory, then a .git directory or file, and falls back to start.
 func FindRepoRoot(start string) (string, error) {
-	if start == "" {
-		return "", fmt.Errorf(messages.RootStartPathRequired)
-	}
-	abs, err := filepath.Abs(start)
+	resolved, err := resolveStartPath(start)
 	if err != nil {
-		return "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
+		return "", err
 	}
 
-	if root, found, err := FindAgentLayerRoot(abs); err != nil {
+	if root, found, err := findAgentLayerRoot(resolved); err != nil {
 		return "", err
 	} else if found {
 		return root, nil
 	}
 
-	dir := abs
+	dir := resolved
 	for {
 		candidate := filepath.Join(dir, gitDir)
 		info, err := os.Stat(candidate)
@@ -80,8 +77,23 @@ func FindRepoRoot(start string) (string, error) {
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return abs, nil
+			return resolved, nil
 		}
 		dir = parent
 	}
+}
+
+func resolveStartPath(start string) (string, error) {
+	if start == "" {
+		return "", fmt.Errorf(messages.RootStartPathRequired)
+	}
+	abs, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
+	}
+	return resolved, nil
 }

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -17,11 +17,22 @@ const (
 // FindAgentLayerRoot walks upward from start until it finds a directory containing .agent-layer/.
 // It returns the root path, whether it was found, and any error encountered.
 func FindAgentLayerRoot(start string) (string, bool, error) {
-	resolved, err := resolveStartPath(start)
+	logical, physical, err := resolveStartPaths(start)
 	if err != nil {
 		return "", false, err
 	}
-	return findAgentLayerRoot(resolved)
+	for _, candidate := range distinctStartPaths(logical, physical) {
+		root, found, err := findAgentLayerRoot(candidate)
+		if err != nil || !found {
+			if err != nil {
+				return "", false, err
+			}
+			continue
+		}
+		resolved, err := resolveFoundRoot(start, root)
+		return resolved, true, err
+	}
+	return "", false, nil
 }
 
 func findAgentLayerRoot(start string) (string, bool, error) {
@@ -50,48 +61,81 @@ func findAgentLayerRoot(start string) (string, bool, error) {
 // FindRepoRoot returns the repo root for initialization.
 // It prefers an existing .agent-layer directory, then a .git directory or file, and falls back to start.
 func FindRepoRoot(start string) (string, error) {
-	resolved, err := resolveStartPath(start)
+	logical, physical, err := resolveStartPaths(start)
 	if err != nil {
 		return "", err
 	}
+	starts := distinctStartPaths(logical, physical)
 
-	if root, found, err := findAgentLayerRoot(resolved); err != nil {
-		return "", err
-	} else if found {
-		return root, nil
+	for _, candidate := range starts {
+		root, found, err := findAgentLayerRoot(candidate)
+		if err != nil {
+			return "", err
+		}
+		if found {
+			return resolveFoundRoot(start, root)
+		}
 	}
 
-	dir := resolved
+	for _, candidate := range starts {
+		root, found, err := findGitRoot(candidate)
+		if err != nil {
+			return "", err
+		}
+		if found {
+			return resolveFoundRoot(start, root)
+		}
+	}
+	return physical, nil
+}
+
+func findGitRoot(start string) (string, bool, error) {
+	dir := start
 	for {
 		candidate := filepath.Join(dir, gitDir)
 		info, err := os.Stat(candidate)
 		if err == nil {
 			if info.IsDir() || info.Mode().IsRegular() {
-				return dir, nil
+				return dir, true, nil
 			}
-			return "", fmt.Errorf(messages.RootPathNotDirOrFileFmt, candidate)
+			return "", false, fmt.Errorf(messages.RootPathNotDirOrFileFmt, candidate)
 		}
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf(messages.RootCheckPathFmt, candidate, err)
+			return "", false, fmt.Errorf(messages.RootCheckPathFmt, candidate, err)
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return resolved, nil
+			return "", false, nil
 		}
 		dir = parent
 	}
 }
 
-func resolveStartPath(start string) (string, error) {
+func resolveStartPaths(start string) (string, string, error) {
 	if start == "" {
-		return "", fmt.Errorf(messages.RootStartPathRequired)
+		return "", "", fmt.Errorf(messages.RootStartPathRequired)
 	}
 	abs, err := filepath.Abs(start)
 	if err != nil {
-		return "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
+		return "", "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
 	}
 	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
+	}
+	return abs, resolved, nil
+}
+
+func distinctStartPaths(logical string, physical string) []string {
+	if logical == physical {
+		return []string{logical}
+	}
+	return []string{logical, physical}
+}
+
+func resolveFoundRoot(start string, root string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		return "", fmt.Errorf(messages.RootResolvePathFmt, start, err)
 	}

--- a/internal/root/root_test.go
+++ b/internal/root/root_test.go
@@ -62,6 +62,29 @@ func TestFindAgentLayerRootResolvesSymlinkedDescendant(t *testing.T) {
 	}
 }
 
+func TestFindAgentLayerRootPreservesLogicalAncestorOfSymlinkedSubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".agent-layer"), 0o700); err != nil {
+		t.Fatalf("mkdir .agent-layer: %v", err)
+	}
+	target := t.TempDir()
+	linkedSubdirectory := filepath.Join(repo, "service")
+	if err := os.Symlink(target, linkedSubdirectory); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	got, found, err := FindAgentLayerRoot(linkedSubdirectory)
+	if err != nil {
+		t.Fatalf("FindAgentLayerRoot error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected logical repository root above symlinked subdirectory")
+	}
+	if want := resolvedTestPath(t, repo); got != want {
+		t.Fatalf("expected logical ancestor root %s, got %s", want, got)
+	}
+}
+
 func TestFindAgentLayerRootMissing(t *testing.T) {
 	root := t.TempDir()
 	got, found, err := FindAgentLayerRoot(root)
@@ -150,6 +173,26 @@ func TestFindRepoRootResolvesSymlinkedDescendant(t *testing.T) {
 	want := resolvedTestPath(t, repo)
 	if got != want {
 		t.Fatalf("expected real Git root %s, got %s", want, got)
+	}
+}
+
+func TestFindRepoRootPreservesLogicalGitAncestorOfSymlinkedSubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	target := t.TempDir()
+	linkedSubdirectory := filepath.Join(repo, "service")
+	if err := os.Symlink(target, linkedSubdirectory); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	got, err := FindRepoRoot(linkedSubdirectory)
+	if err != nil {
+		t.Fatalf("FindRepoRoot error: %v", err)
+	}
+	if want := resolvedTestPath(t, repo); got != want {
+		t.Fatalf("expected logical Git ancestor %s, got %s", want, got)
 	}
 }
 

--- a/internal/root/root_test.go
+++ b/internal/root/root_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -25,8 +26,39 @@ func TestFindAgentLayerRootFound(t *testing.T) {
 	if !found {
 		t.Fatalf("expected root to be found")
 	}
-	if got != root {
-		t.Fatalf("expected root %s, got %s", root, got)
+	want := resolvedTestPath(t, root)
+	if got != want {
+		t.Fatalf("expected root %s, got %s", want, got)
+	}
+}
+
+func TestFindAgentLayerRootResolvesSymlinkedDescendant(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".agent-layer"), 0o700); err != nil {
+		t.Fatalf("mkdir .agent-layer: %v", err)
+	}
+	descendant := filepath.Join(repo, "packages", "service")
+	if err := os.MkdirAll(descendant, 0o700); err != nil {
+		t.Fatalf("mkdir descendant: %v", err)
+	}
+
+	logicalParent := t.TempDir()
+	linkedRepo := filepath.Join(logicalParent, "linked-repo")
+	if err := os.Symlink(repo, linkedRepo); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+	logicalDescendant := filepath.Join(linkedRepo, "packages", "service")
+
+	got, found, err := FindAgentLayerRoot(logicalDescendant)
+	if err != nil {
+		t.Fatalf("FindAgentLayerRoot error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected root to be found through symlinked descendant")
+	}
+	want := resolvedTestPath(t, repo)
+	if got != want {
+		t.Fatalf("expected real root %s, got %s", want, got)
 	}
 }
 
@@ -69,8 +101,9 @@ func TestFindRepoRootPrefersAgentLayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindRepoRoot error: %v", err)
 	}
-	if got != root {
-		t.Fatalf("expected root %s, got %s", root, got)
+	want := resolvedTestPath(t, root)
+	if got != want {
+		t.Fatalf("expected root %s, got %s", want, got)
 	}
 }
 
@@ -88,8 +121,35 @@ func TestFindRepoRootUsesGit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindRepoRoot error: %v", err)
 	}
-	if got != root {
-		t.Fatalf("expected root %s, got %s", root, got)
+	want := resolvedTestPath(t, root)
+	if got != want {
+		t.Fatalf("expected root %s, got %s", want, got)
+	}
+}
+
+func TestFindRepoRootResolvesSymlinkedDescendant(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	descendant := filepath.Join(repo, "packages", "service")
+	if err := os.MkdirAll(descendant, 0o700); err != nil {
+		t.Fatalf("mkdir descendant: %v", err)
+	}
+
+	logicalParent := t.TempDir()
+	linkedRepo := filepath.Join(logicalParent, "linked-repo")
+	if err := os.Symlink(repo, linkedRepo); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	got, err := FindRepoRoot(filepath.Join(linkedRepo, "packages", "service"))
+	if err != nil {
+		t.Fatalf("FindRepoRoot error: %v", err)
+	}
+	want := resolvedTestPath(t, repo)
+	if got != want {
+		t.Fatalf("expected real Git root %s, got %s", want, got)
 	}
 }
 
@@ -99,8 +159,9 @@ func TestFindRepoRootFallsBackToStart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindRepoRoot error: %v", err)
 	}
-	if got != root {
-		t.Fatalf("expected root %s, got %s", root, got)
+	want := resolvedTestPath(t, root)
+	if got != want {
+		t.Fatalf("expected root %s, got %s", want, got)
 	}
 }
 
@@ -110,6 +171,46 @@ func TestFindRootsRequireStartPath(t *testing.T) {
 	}
 	if _, err := FindRepoRoot(""); err == nil {
 		t.Fatal("expected FindRepoRoot to reject empty start")
+	}
+}
+
+func TestFindRootsRejectBrokenSymlinkStart(t *testing.T) {
+	parent := t.TempDir()
+	broken := filepath.Join(parent, "broken")
+	if err := os.Symlink(filepath.Join(parent, "missing-target"), broken); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		find func() error
+	}{
+		{
+			name: "agent layer root",
+			find: func() error {
+				_, _, err := FindAgentLayerRoot(broken)
+				return err
+			},
+		},
+		{
+			name: "repository root",
+			find: func() error {
+				_, err := FindRepoRoot(broken)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.find()
+			if err == nil {
+				t.Fatal("expected broken symlink to fail")
+			}
+			if !strings.Contains(err.Error(), "resolve path ") || !strings.Contains(err.Error(), broken) {
+				t.Fatalf("expected actionable path-resolution error for %s, got %v", broken, err)
+			}
+		})
 	}
 }
 
@@ -124,8 +225,9 @@ func TestFindRepoRootUsesGitFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindRepoRoot error: %v", err)
 	}
-	if got != root {
-		t.Fatalf("expected root %s, got %s", root, got)
+	want := resolvedTestPath(t, root)
+	if got != want {
+		t.Fatalf("expected root %s, got %s", want, got)
 	}
 }
 
@@ -143,4 +245,13 @@ func TestFindRepoRootGitSpecialFileErrors(t *testing.T) {
 	if _, err := FindRepoRoot(root); err == nil {
 		t.Fatal("expected error when .git is neither directory nor regular file")
 	}
+}
+
+func resolvedTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve test path %s: %v", path, err)
+	}
+	return resolved
 }

--- a/internal/versiondispatch/dispatch_test.go
+++ b/internal/versiondispatch/dispatch_test.go
@@ -1047,3 +1047,39 @@ func TestMaybeExec_UsesProvidedStderr(t *testing.T) {
 		t.Fatalf("expected version source output, got %q", stderr.String())
 	}
 }
+
+func TestMaybeExec_UsesPinFromRealRootOfSymlinkedDescendant(t *testing.T) {
+	repo := t.TempDir()
+	agentLayerDir := filepath.Join(repo, ".agent-layer")
+	if err := os.Mkdir(agentLayerDir, 0o700); err != nil {
+		t.Fatalf("mkdir .agent-layer: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentLayerDir, "al.version"), []byte("1.0.0\n"), 0o600); err != nil {
+		t.Fatalf("write pin: %v", err)
+	}
+	descendant := filepath.Join(repo, "packages", "service")
+	if err := os.MkdirAll(descendant, 0o700); err != nil {
+		t.Fatalf("mkdir descendant: %v", err)
+	}
+
+	logicalParent := t.TempDir()
+	linkedRepo := filepath.Join(logicalParent, "linked-repo")
+	if err := os.Symlink(repo, linkedRepo); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	err := MaybeExec(
+		[]string{"al"},
+		"1.0.0",
+		filepath.Join(linkedRepo, "packages", "service"),
+		&stderr,
+		func(int) {},
+	)
+	if err != nil {
+		t.Fatalf("MaybeExec error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "(pin)") {
+		t.Fatalf("expected repository pin to be resolved through symlinked descendant, got %q", stderr.String())
+	}
+}

--- a/scripts/test-e2e/harness.sh
+++ b/scripts/test-e2e/harness.sh
@@ -66,7 +66,7 @@ setup_scenario_dir() {
   local dir
   dir="$(mktemp -d "$E2E_TMP_ROOT/scenario-XXXXXX")"
   mkdir -p "$dir/.git"
-  echo "$dir"
+  (cd "$dir" && pwd -P)
 }
 
 # cleanup_scenario_dir <dir> — remove a scenario directory.


### PR DESCRIPTION
## Summary

- Resolve repository roots through symlinks while preserving the caller's original working directory for downstream behavior.
- Route client-launch diagnostics through Cobra's configured `cmd.ErrOrStderr()` writer for standard and no-sync launch paths.
- Keep macOS end-to-end path expectations aligned with physical root resolution.

## Changes

- Canonicalize launch roots once before `.agent-layer` and Git ancestry walks, with actionable errors for broken symlinks.
- Add behavioral coverage for symlinked roots, caller working-directory preservation, version dispatch, diagnostic capture, quiet modes, and argument pass-through.
- Return physical scenario paths from the end-to-end harness so launcher assertions match the production root contract.

## Verification

- `make ci` — passed: 3,304 tests, 91.84% coverage, race checks, 99/99 release checks, 902/902 mandatory end-to-end assertions with all 8 upgrade scenarios, and documentation checks.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics routing for agent launch commands, ensuring error output appears in the command’s configured error stream.
  * Quiet mode now consistently suppresses launch diagnostics.
  * Improved repository detection when working from symlinked directories.
  * Added clearer errors for broken path symlinks.
  * Improved version resolution from symlinked repository paths.

* **Tests**
  * Added coverage for diagnostics routing, quiet mode, symlink handling, and repository root resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->