### PR TITLE
fix: enforce CLI cancellation and argument contracts

### DIFF
--- a/cmd/al/args_test.go
+++ b/cmd/al/args_test.go
@@ -86,6 +86,7 @@ func TestNoArgsCommandsRejectExtraArgs(t *testing.T) {
 	}{
 		{name: "sync", cmd: newSyncCmd, args: []string{"unexpected"}},
 		{name: "init", cmd: newInitCmd, args: []string{"unexpected"}},
+		{name: "doctor", cmd: newDoctorCmd, args: []string{"unexpected"}},
 		{name: "probe antigravity", cmd: newProbeAntigravityCmd, args: []string{"unexpected"}},
 	}
 

--- a/cmd/al/doctor.go
+++ b/cmd/al/doctor.go
@@ -30,6 +30,7 @@ func newDoctorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   messages.DoctorUse,
 		Short: messages.DoctorShort,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			quiet, _ := cmd.Flags().GetBool("quiet")

--- a/cmd/al/main.go
+++ b/cmd/al/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
@@ -25,7 +28,9 @@ var (
 )
 
 func main() {
-	runMain(os.Args, os.Stdout, os.Stderr, os.Exit)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	runMain(ctx, os.Args, os.Stdout, os.Stderr, os.Exit)
 }
 
 // SilentExitError reports an exit code without emitting error output.
@@ -38,7 +43,7 @@ func (e SilentExitError) Error() string {
 }
 
 // execute runs the CLI command with the provided args and output writers.
-func execute(args []string, stdout io.Writer, stderr io.Writer) error {
+func execute(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
 	cmd := newRootCmd()
 	cmd.Version = versionString()
 	cmd.SetVersionTemplate(messages.VersionTemplate)
@@ -47,11 +52,11 @@ func execute(args []string, stdout io.Writer, stderr io.Writer) error {
 	}
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
-	return cmd.Execute()
+	return cmd.ExecuteContext(ctx)
 }
 
 // runMain handles version dispatch and executes the CLI, exiting on fatal errors.
-func runMain(args []string, stdout io.Writer, stderr io.Writer, exit func(int)) {
+func runMain(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, exit func(int)) {
 	cwd, err := getwd()
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err)
@@ -68,7 +73,7 @@ func runMain(args []string, stdout io.Writer, stderr io.Writer, exit func(int)) 
 			return
 		}
 	}
-	if handleRunError(executeFunc(args, stdout, stderr), stderr, exit, false) {
+	if handleRunError(executeFunc(ctx, args, stdout, stderr), stderr, exit, false) {
 		return
 	}
 }

--- a/cmd/al/main.go
+++ b/cmd/al/main.go
@@ -29,8 +29,12 @@ var (
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-	runMain(ctx, os.Args, os.Stdout, os.Stderr, os.Exit)
+	restoreSignals := context.AfterFunc(ctx, stop)
+	exitCode := 0
+	runMain(ctx, os.Args, os.Stdout, os.Stderr, func(code int) { exitCode = code })
+	restoreSignals()
+	stop()
+	os.Exit(exitCode)
 }
 
 // SilentExitError reports an exit code without emitting error output.

--- a/cmd/al/main_test.go
+++ b/cmd/al/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,14 +11,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/conn-castle/agent-layer/internal/probe/antigravity"
 	"github.com/conn-castle/agent-layer/internal/testutil"
 	"github.com/conn-castle/agent-layer/internal/versiondispatch"
 )
 
 func TestMainVersion(t *testing.T) {
 	var out bytes.Buffer
-	if err := execute([]string{"al", "--version"}, &out, &out); err != nil {
+	if err := execute(context.Background(), []string{"al", "--version"}, &out, &out); err != nil {
 		t.Fatalf("execute error: %v", err)
 	}
 	if !strings.Contains(out.String(), Version) {
@@ -34,7 +37,7 @@ func TestRunMainSuccess(t *testing.T) {
 
 	var out bytes.Buffer
 	called := false
-	runMain([]string{"al", "--version"}, &out, &out, func(code int) {
+	runMain(context.Background(), []string{"al", "--version"}, &out, &out, func(code int) {
 		called = true
 	})
 	if called {
@@ -51,7 +54,7 @@ func TestRunMainError(t *testing.T) {
 
 	var out bytes.Buffer
 	code := 0
-	runMain([]string{"al", "unknown"}, &out, &out, func(exitCode int) {
+	runMain(context.Background(), []string{"al", "unknown"}, &out, &out, func(exitCode int) {
 		code = exitCode
 	})
 	if code != 1 {
@@ -82,7 +85,7 @@ func TestRunMain_GetwdError(t *testing.T) {
 
 	var out bytes.Buffer
 	var code int
-	runMain([]string{"al"}, &out, &out, func(c int) { code = c })
+	runMain(context.Background(), []string{"al"}, &out, &out, func(c int) { code = c })
 
 	if code != 1 {
 		t.Errorf("expected exit 1, got %d", code)
@@ -101,7 +104,7 @@ func TestRunMain_DispatchError(t *testing.T) {
 
 	var out bytes.Buffer
 	var code int
-	runMain([]string{"al"}, &out, &out, func(c int) { code = c })
+	runMain(context.Background(), []string{"al"}, &out, &out, func(c int) { code = c })
 
 	if code != 1 {
 		t.Errorf("expected exit 1, got %d", code)
@@ -120,7 +123,7 @@ func TestRunMain_Dispatched(t *testing.T) {
 
 	var out bytes.Buffer
 	var code int
-	runMain([]string{"al"}, &out, &out, func(c int) { code = c })
+	runMain(context.Background(), []string{"al"}, &out, &out, func(c int) { code = c })
 
 	if code != 0 {
 		t.Errorf("expected exit 0 (default), got %d (called exit?)", code)
@@ -142,7 +145,7 @@ func TestRunMain_InitBypassesDispatch(t *testing.T) {
 
 	var out bytes.Buffer
 	exitCode := -1
-	runMain([]string{"al", "init", "--help"}, &out, &out, func(code int) {
+	runMain(context.Background(), []string{"al", "init", "--help"}, &out, &out, func(code int) {
 		exitCode = code
 	})
 
@@ -165,7 +168,7 @@ func TestRunMain_UpgradeBypassesDispatch(t *testing.T) {
 
 	var out bytes.Buffer
 	exitCode := -1
-	runMain([]string{"al", "upgrade", "--help"}, &out, &out, func(code int) {
+	runMain(context.Background(), []string{"al", "upgrade", "--help"}, &out, &out, func(code int) {
 		exitCode = code
 	})
 
@@ -260,7 +263,7 @@ func TestRunMain_QuietDispatchUsesDiscard(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	runMain([]string{"al", "--quiet", "--version"}, &out, &out, func(int) {})
+	runMain(context.Background(), []string{"al", "--quiet", "--version"}, &out, &out, func(int) {})
 	if !gotDiscard {
 		t.Fatalf("expected dispatch stderr to be io.Discard")
 	}
@@ -275,7 +278,7 @@ func TestRunMain_SilentExitError(t *testing.T) {
 
 	var out bytes.Buffer
 	exitCode := 0
-	runMain([]string{"al"}, &out, &out, func(code int) { exitCode = code })
+	runMain(context.Background(), []string{"al"}, &out, &out, func(code int) { exitCode = code })
 	if exitCode != 3 {
 		t.Fatalf("expected exit 3, got %d", exitCode)
 	}
@@ -293,7 +296,7 @@ func TestRunMain_DispatchWrappedExitErrorPropagatesCode(t *testing.T) {
 
 	var out bytes.Buffer
 	exitCode := 0
-	runMain([]string{"al"}, &out, &out, func(code int) { exitCode = code })
+	runMain(context.Background(), []string{"al"}, &out, &out, func(code int) { exitCode = code })
 	if exitCode != 42 {
 		t.Fatalf("expected exit 42, got %d", exitCode)
 	}
@@ -310,19 +313,71 @@ func TestRunMain_ExecuteWrappedExitErrorPropagatesCode(t *testing.T) {
 	t.Cleanup(func() { maybeExecFunc = origMaybeExec })
 
 	origExecute := executeFunc
-	executeFunc = func(args []string, stdout io.Writer, stderr io.Writer) error {
+	executeFunc = func(context.Context, []string, io.Writer, io.Writer) error {
 		return fmt.Errorf("execute failed: %w", wrappedExitError(t, 43))
 	}
 	t.Cleanup(func() { executeFunc = origExecute })
 
 	var out bytes.Buffer
 	exitCode := 0
-	runMain([]string{"al"}, &out, &out, func(code int) { exitCode = code })
+	runMain(context.Background(), []string{"al"}, &out, &out, func(code int) { exitCode = code })
 	if exitCode != 43 {
 		t.Fatalf("expected exit 43, got %d", exitCode)
 	}
 	if !strings.Contains(out.String(), "execute failed:") {
 		t.Fatalf("expected wrapped error output, got %q", out.String())
+	}
+}
+
+func TestRunMainCancellationReachesContextAwareCommand(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".agent-layer"), 0o700); err != nil {
+		t.Fatalf("mkdir .agent-layer: %v", err)
+	}
+	originalGetwd := getwd
+	getwd = func() (string, error) { return root, nil }
+	t.Cleanup(func() { getwd = originalGetwd })
+
+	originalMaybeExec := maybeExecFunc
+	maybeExecFunc = func([]string, string, string, io.Writer, func(int)) error { return nil }
+	t.Cleanup(func() { maybeExecFunc = originalMaybeExec })
+
+	started := make(chan struct{})
+	originalProbe := runAntigravityProbe
+	runAntigravityProbe = func(ctx context.Context, _ string) (*antigravity.Result, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() { runAntigravityProbe = originalProbe })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var out bytes.Buffer
+	exitCode := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runMain(ctx, []string{"al", "probe", "agy"}, &out, &out, func(code int) { exitCode = code })
+	}()
+
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe did not start")
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled command did not return")
+	}
+
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+	if got := out.String(); got != context.Canceled.Error()+"\n" {
+		t.Fatalf("diagnostic = %q, want one cancellation diagnostic", got)
 	}
 }
 

--- a/cmd/al/upgrade.go
+++ b/cmd/al/upgrade.go
@@ -181,6 +181,7 @@ func newUpgradeRepairGitignoreBlockCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   messages.UpgradeRepairGitignoreUse,
 		Short: messages.UpgradeRepairGitignoreShort,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root, err := resolveRepoRoot()
 			if err != nil {
@@ -600,6 +601,7 @@ func newUpgradePlanCmd(diffLines *int) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   messages.UpgradePlanUse,
 		Short: messages.UpgradePlanShort,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if diffLines == nil {
 				return fmt.Errorf(messages.UpgradeDiffLinesInvalidFmt, 0)

--- a/cmd/al/upgrade_subcommands_test.go
+++ b/cmd/al/upgrade_subcommands_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/conn-castle/agent-layer/internal/install"
 	"github.com/conn-castle/agent-layer/internal/messages"
 	"github.com/conn-castle/agent-layer/internal/testutil"
@@ -255,6 +257,47 @@ func TestUpgradePrefetchCmd_DevBuildRequiresVersion(t *testing.T) {
 	}
 	if err.Error() != messages.UpgradePrefetchVersionRequired {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpgradeLeafCommands_RejectPositionalArgsBeforeRunE(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  func() *cobra.Command
+	}{
+		{
+			name: "plan",
+			cmd: func() *cobra.Command {
+				diffLines := install.DefaultDiffMaxLines
+				return newUpgradePlanCmd(&diffLines)
+			},
+		},
+		{
+			name: "repair-gitignore-block",
+			cmd:  newUpgradeRepairGitignoreBlockCmd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.cmd()
+			runECalled := false
+			cmd.RunE = func(*cobra.Command, []string) error {
+				runECalled = true
+				return errors.New("RunE executed")
+			}
+			cmd.SetArgs([]string{"unexpected"})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), `unknown command "unexpected"`) {
+				t.Fatalf("Execute() error = %v, want Cobra positional argument error", err)
+			}
+			if runECalled {
+				t.Fatal("RunE executed after positional argument validation failed")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Propagate interrupt and SIGTERM cancellation from the process entrypoint through Cobra so context-aware command work can stop promptly.
- Reject unsupported positional arguments for `al doctor`, `al upgrade plan`, and `al upgrade repair-gitignore-block` before their health, planning, or repair side effects begin.
- Add focused behavioral coverage for cancellation propagation and argument-validation ordering.

## Changes

- Create a signal-aware root context and execute Cobra with that context.
- Apply established `cobra.NoArgs` contracts to the three no-argument command paths.
- Extend shared and upgrade-specific tests to prove invalid arguments cannot reach command execution.

## Verification

- `make ci` — passed the complete canonical lane: 3,306 coverage tests, 91.84% coverage, race checks, 99 release tests, 4 harness tests, 902 required online end-to-end tests with eight upgrade scenarios, and documentation checks.
- Repository pre-commit hooks — passed while creating the delivery commit.

## Notes

- This batches three independently reviewed, compatible improve-codebase dispositions across six files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI commands now reject unexpected positional arguments with a clear error.
  * The CLI responds correctly to interrupt and termination signals, cancelling in-progress commands and exiting with an appropriate error.

* **Tests**
  * Added coverage verifying argument validation and cancellation behavior across affected commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->