### PR TITLE
fix: preserve agent dispatch lifecycle ownership

### DIFF
--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -76,7 +76,10 @@ Each fanout child has its own friendly name, immutable run record, and result
 path. Early child results are persisted immediately. Failure does not cancel
 unrelated children: fanout waits until all are terminal, emits complete
 per-child evidence, then exits nonzero. Cancelling a fanout affects only its
-active children and preserves completed evidence.
+active children and preserves completed evidence. If aggregate reconciliation
+fails after launch, fanout still drains every child to normal terminalization
+and claim release, preserves cancellation as the authoritative aggregate state,
+records the first coordinator error when possible, and only then returns it.
 
 ## Canonical state and concurrency
 
@@ -107,11 +110,14 @@ A per-conversation active claim spans the entire provider execution. A second
 simultaneous resume fails nonzero with the active run handle. It launches no
 provider, queues no prompt, and does not mutate provider conversation state.
 Unrelated conversations and fresh calls remain concurrent; no global lock is
-held while a provider runs.
+held while a provider runs. Publishing `cancelled` does not release the claim:
+the owning execution releases it only after provider termination, or recovery
+replaces it when recorded process-identity evidence proves the owner dead.
 
 `cancel` signals only the exact recorded live process group after verifying
-its process-start identity. A fanout cancellation iterates only nonterminal
-children.
+its process-start identity and retains the claim while that process group may
+still run. A fanout cancellation iterates only nonterminal children and applies
+the same ownership boundary independently to every child.
 
 ## Retention
 

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -27,12 +27,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
-- Issue 2026-07-15 dispatch-run-record-write-mutates-before-publish: Failed record writes can poison subsequent terminalization
-    Priority: High. Area: internal/agentdispatch/state.go writeRunRecord
-    Description: writeRunRecord increments the caller-owned Revision and replaces UpdatedAt before writeJSONAtomic succeeds; after an I/O failure, the in-memory record no longer matches durable state, so a subsequent failure write can be rejected as concurrent and leave the record nonterminal.
-    Next step: Mutate a copy, publish it atomically, and update the caller-owned record only after the durable write succeeds; add an injected write-failure regression covering the terminal failure path.
-    Notes: Deferred because durable state/history repairs were explicitly excluded from PR #151 merge-readiness scope.
-
 - Issue 2026-07-15 dispatch-random-override-filter-policy: Random selection can choose a provider that rejects a requested override
     Priority: Medium. Area: internal/agentdispatch random resolution and fresh preflight
     Description: Random eligibility considers enabled, installed, compatible, and caller facts, while requested model and reasoning support are validated only after a target is chosen; dispatch can therefore fail on the chosen provider even when another eligible pool member supports the override.

--- a/internal/agentdispatch/coordinator.go
+++ b/internal/agentdispatch/coordinator.go
@@ -17,3 +17,23 @@ func launchExecution(request dispatchExecution) executionHandle {
 }
 
 func (handle executionHandle) await() error { return <-handle.done }
+
+// drainExecutionHandles waits for every launched execution and reports each
+// completion in arrival order. Consumers may encounter reconciliation errors,
+// but those errors must not shorten the lifetime of any launched execution.
+func drainExecutionHandles(handles []executionHandle, consume func(index int, handle executionHandle, err error)) {
+	type indexedResult struct {
+		index int
+		err   error
+	}
+	results := make(chan indexedResult, len(handles))
+	for index, handle := range handles {
+		go func(index int, handle executionHandle) {
+			results <- indexedResult{index: index, err: handle.await()}
+		}(index, handle)
+	}
+	for range handles {
+		completed := <-results
+		consume(completed.index, handles[completed.index], completed.err)
+	}
+}

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -260,7 +260,7 @@ func executeDispatch(request dispatchExecution) error {
 		request.Run.Record.State = dispatchStateStarting
 		request.Run.Record.RecoveryState = recoveryRetrySafe
 		if err := writeRunRecord(request.Run.Dir, &request.Run.Record); err != nil {
-			return err
+			return finishDispatchFailure(request, err)
 		}
 		if request.Mode == dispatchModeFresh && request.Target.Name == AgentClaude && attempt == 2 {
 			id, err := newUUID()

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -213,7 +213,7 @@ func executeDispatch(request dispatchExecution) error {
 		return exitError(ExitConfig, "dispatch execution was not initialized")
 	}
 	if current, err := loadRunRecord(request.Root, request.Run.Record.ID); err == nil && current.State == dispatchStateCancelled {
-		return exitError(ExitTargetFailure, fmt.Sprintf("dispatch run %s was cancelled before launch", request.Run.Record.ID))
+		return finishDispatchCancellation(request)
 	}
 	session := request.Session
 	if request.Mode == dispatchModeFresh && request.Target.Name == AgentClaude {
@@ -358,8 +358,7 @@ func completeDispatchSuccess(request dispatchExecution, result executionResult, 
 
 func finishDispatchFailure(request dispatchExecution, cause error) error {
 	if current, err := loadRunRecord(request.Root, request.Run.Record.ID); err == nil && current.State == dispatchStateCancelled {
-		_ = releaseConversation(request.Root, request.Session.Name, request.Run.Record.ID)
-		return exitError(ExitTargetFailure, fmt.Sprintf("dispatch run %s was cancelled", request.Run.Record.ID))
+		return finishDispatchCancellation(request)
 	}
 	now := time.Now().UTC()
 	request.Run.Record.State = dispatchStateFailed
@@ -391,6 +390,17 @@ func finishDispatchFailure(request dispatchExecution, cause error) error {
 		}
 	}
 	return cause
+}
+
+// finishDispatchCancellation is called only by the owning execution after no
+// provider was launched or the provider wait path returned. That ownership
+// boundary, rather than publication of the cancelled state, releases the
+// conversation for another execution.
+func finishDispatchCancellation(request dispatchExecution) error {
+	if err := releaseConversation(request.Root, request.Session.Name, request.Run.Record.ID); err != nil {
+		return err
+	}
+	return exitError(ExitTargetFailure, fmt.Sprintf("dispatch run %s was cancelled", request.Run.Record.ID))
 }
 
 func isSafePreStartFailure(err error) bool {

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -2,10 +2,13 @@ package agentdispatch
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/clients"
@@ -111,6 +114,100 @@ func TestFailureFinalizationReleasesClaimWhenTerminalWriteFails(t *testing.T) {
 	}
 }
 
+func TestFailedRunRecordPublicationPreservesCallerRevisionForFailureFinalization(t *testing.T) {
+	root := t.TempDir()
+	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+	if err != nil {
+		t.Fatalf("new run: %v", err)
+	}
+	session, err := reserveSession(root, run)
+	if err != nil {
+		t.Fatalf("reserve session: %v", err)
+	}
+	durableBefore, err := loadRunRecord(root, run.Record.ID)
+	if err != nil {
+		t.Fatalf("load durable record before injected failure: %v", err)
+	}
+
+	run.Record.State = dispatchStateStarting
+	publicationErr := errors.New("injected run-record publication failure")
+	err = writeRunRecordWithPublisher(run.Dir, &run.Record, func(string, any) error {
+		return publicationErr
+	})
+	if !errors.Is(err, publicationErr) {
+		t.Fatalf("writeRunRecordWithPublisher error = %v, want injected failure", err)
+	}
+	if run.Record.Revision != durableBefore.Revision || !run.Record.UpdatedAt.Equal(durableBefore.UpdatedAt) {
+		t.Fatalf("failed publication advanced caller state: caller revision/time = %d/%s, durable = %d/%s", run.Record.Revision, run.Record.UpdatedAt, durableBefore.Revision, durableBefore.UpdatedAt)
+	}
+	durableAfter, err := loadRunRecord(root, run.Record.ID)
+	if err != nil {
+		t.Fatalf("load durable record after injected failure: %v", err)
+	}
+	if durableAfter.Revision != run.Record.Revision || !durableAfter.UpdatedAt.Equal(run.Record.UpdatedAt) {
+		t.Fatalf("caller and durable state diverged after failed publication: caller = %#v, durable = %#v", run.Record, durableAfter)
+	}
+
+	project := &config.ProjectConfig{Root: root, Config: dispatchTestConfig(AgentCodex)}
+	cause := exitError(ExitTargetFailure, "provider failed after publication error")
+	err = finishDispatchFailure(dispatchExecution{Root: root, Project: project, Run: run, Session: session, Mode: dispatchModeFresh}, cause)
+	requireDispatchExitCode(t, err, ExitTargetFailure)
+	terminal, err := loadRunRecord(root, run.Record.ID)
+	if err != nil {
+		t.Fatalf("load terminal record: %v", err)
+	}
+	if terminal.State != dispatchStateFailed || terminal.CompletedAt == nil || terminal.TerminalReason != cause.Error() {
+		t.Fatalf("failure finalization did not persist canonical terminal history: %#v", terminal)
+	}
+	if terminal.Revision != durableBefore.Revision+1 || run.Record.Revision != terminal.Revision || !run.Record.UpdatedAt.Equal(terminal.UpdatedAt) {
+		t.Fatalf("terminal caller/durable state mismatch: caller = %#v, durable = %#v", run.Record, terminal)
+	}
+}
+
+func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
+	root := t.TempDir()
+	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+	if err != nil {
+		t.Fatalf("new run: %v", err)
+	}
+	session, err := reserveSession(root, run)
+	if err != nil {
+		t.Fatalf("reserve session: %v", err)
+	}
+	if err := Cancel(CancelRequest{Root: root, ID: run.Record.ID}); err != nil {
+		t.Fatalf("Cancel pending run: %v", err)
+	}
+	claimed, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.ActiveRunID != run.Record.ID {
+		t.Fatalf("pre-launch cancellation released before its owner ran: %#v", claimed)
+	}
+
+	var launches atomic.Int32
+	project := &config.ProjectConfig{Root: root, Config: dispatchTestConfig(AgentCodex)}
+	err = launchExecution(dispatchExecution{
+		Root: root, Project: project, Target: targetMeta{Name: AgentCodex},
+		Run: run, Session: session, Mode: dispatchModeFresh,
+		NewCommand: func(string, ...string) *exec.Cmd {
+			launches.Add(1)
+			return exec.Command("/bin/sh", "-c", "exit 0") // #nosec G204 -- fixed test command must remain unlaunched.
+		},
+	}).await()
+	requireDispatchExitCode(t, err, ExitTargetFailure)
+	if launches.Load() != 0 {
+		t.Fatalf("provider launches after pre-launch cancellation = %d, want 0", launches.Load())
+	}
+	finalized, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finalized.ActiveRunID != "" {
+		t.Fatalf("owning execution did not release pre-launch cancellation: %#v", finalized)
+	}
+}
+
 func TestDeleteProtectsRunningRecordWithUnprovableOwnership(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
@@ -128,10 +225,36 @@ func TestDeleteProtectsRunningRecordWithUnprovableOwnership(t *testing.T) {
 	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
 		t.Fatal(err)
 	}
+	// Compatibility mappings created before explicit active claims use RunID
+	// as their only owner reference.
+	session.ActiveRunID = ""
+	if err := persistSession(root, session); err != nil {
+		t.Fatal(err)
+	}
 	if err := Delete(root, session.Name); err == nil {
 		t.Fatal("Delete removed a mapping whose run may still be live")
 	} else {
 		requireDispatchExitCode(t, err, ExitUnavailable)
+	}
+	beforeClaim, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeResume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err == nil {
+		t.Fatal("replacement bypassed compatibility owner evidence")
+	} else {
+		requireDispatchExitCode(t, err, ExitUnavailable)
+	}
+	afterClaim, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterClaim != beforeClaim {
+		t.Fatalf("blocked compatibility claim mutated mapping: before = %#v, after = %#v", beforeClaim, afterClaim)
 	}
 }
 

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -164,7 +164,7 @@ func TestFailedRunRecordPublicationPreservesCallerRevisionForFailureFinalization
 	}
 }
 
-func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
+func TestPreLaunchCancellationAllowsSafeReplacementWithoutProcessIdentity(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
 	if err != nil {
@@ -188,17 +188,12 @@ func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err == nil {
-		t.Fatal("pre-launch cancellation allowed a replacement before owner finalization")
-	} else {
-		requireDispatchExitCode(t, err, ExitUnavailable)
-	}
-	blocked, err := loadSession(root, session.Name)
+	replaced, err := claimConversation(root, session.Name, replacement.Record.ID)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("replace never-launched cancelled claim: %v", err)
 	}
-	if blocked != claimed {
-		t.Fatalf("blocked pre-launch replacement mutated mapping: before = %#v, after = %#v", claimed, blocked)
+	if replaced.ActiveRunID != replacement.Record.ID || replaced.RunID != replacement.Record.ID {
+		t.Fatalf("replacement claim was not published: %#v", replaced)
 	}
 
 	var launches atomic.Int32
@@ -219,16 +214,60 @@ func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if finalized.ActiveRunID != "" {
-		t.Fatalf("owning execution did not release pre-launch cancellation: %#v", finalized)
+	if finalized.ActiveRunID != replacement.Record.ID || finalized.RunID != replacement.Record.ID {
+		t.Fatalf("old owner finalization released replacement claim: %#v", finalized)
 	}
-	replaced, err := claimConversation(root, session.Name, replacement.Record.ID)
-	if err != nil {
-		t.Fatalf("claim after owning pre-launch finalization: %v", err)
+}
+
+func TestNeverLaunchedCancelledClaimRecoveryOperations(t *testing.T) {
+	setup := func(t *testing.T) (string, *dispatchRun, Session) {
+		t.Helper()
+		root := t.TempDir()
+		run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+		if err != nil {
+			t.Fatalf("new run: %v", err)
+		}
+		session, err := reserveSession(root, run)
+		if err != nil {
+			t.Fatalf("reserve session: %v", err)
+		}
+		if err := Cancel(CancelRequest{Root: root, ID: run.Record.ID}); err != nil {
+			t.Fatalf("cancel pending run: %v", err)
+		}
+		return root, run, session
 	}
-	if replaced.ActiveRunID != replacement.Record.ID || replaced.RunID != replacement.Record.ID {
-		t.Fatalf("replacement claim was not published after owner finalization: %#v", replaced)
-	}
+
+	t.Run("orphan reconciliation releases stale claim", func(t *testing.T) {
+		root, run, session := setup(t)
+		record, err := loadRunRecord(root, run.Record.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := reconcileOrphan(root, record); err != nil {
+			t.Fatalf("reconcile cancelled run: %v", err)
+		}
+		reconciled, err := loadSession(root, session.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reconciled.ActiveRunID != "" {
+			t.Fatalf("reconciliation retained never-launched claim: %#v", reconciled)
+		}
+	})
+
+	t.Run("delete removes stale mapping", func(t *testing.T) {
+		root, _, session := setup(t)
+		if err := Delete(root, session.Name); err != nil {
+			t.Fatalf("delete never-launched cancelled mapping: %v", err)
+		}
+		path, err := sessionPath(root, session.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("deleted mapping remains: %v", err)
+		}
+	})
 }
 
 func TestCancellationRevisionRaceIsFinalizedByOwningExecution(t *testing.T) {

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -184,6 +184,22 @@ func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
 	if claimed.ActiveRunID != run.Record.ID {
 		t.Fatalf("pre-launch cancellation released before its owner ran: %#v", claimed)
 	}
+	replacement, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeResume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err == nil {
+		t.Fatal("pre-launch cancellation allowed a replacement before owner finalization")
+	} else {
+		requireDispatchExitCode(t, err, ExitUnavailable)
+	}
+	blocked, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != claimed {
+		t.Fatalf("blocked pre-launch replacement mutated mapping: before = %#v, after = %#v", claimed, blocked)
+	}
 
 	var launches atomic.Int32
 	project := &config.ProjectConfig{Root: root, Config: dispatchTestConfig(AgentCodex)}
@@ -205,6 +221,13 @@ func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
 	}
 	if finalized.ActiveRunID != "" {
 		t.Fatalf("owning execution did not release pre-launch cancellation: %#v", finalized)
+	}
+	replaced, err := claimConversation(root, session.Name, replacement.Record.ID)
+	if err != nil {
+		t.Fatalf("claim after owning pre-launch finalization: %v", err)
+	}
+	if replaced.ActiveRunID != replacement.Record.ID || replaced.RunID != replacement.Record.ID {
+		t.Fatalf("replacement claim was not published after owner finalization: %#v", replaced)
 	}
 }
 
@@ -284,6 +307,7 @@ func TestDeleteProtectsRunningRecordWithUnprovableOwnership(t *testing.T) {
 	// Compatibility mappings created before explicit active claims use RunID
 	// as their only owner reference.
 	session.ActiveRunID = ""
+	session.ActiveClaimKnown = false
 	if err := persistSession(root, session); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -208,6 +208,62 @@ func TestPreLaunchCancellationIsReleasedOnlyByOwningExecution(t *testing.T) {
 	}
 }
 
+func TestCancellationRevisionRaceIsFinalizedByOwningExecution(t *testing.T) {
+	root := t.TempDir()
+	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+	if err != nil {
+		t.Fatalf("new run: %v", err)
+	}
+	session, err := reserveSession(root, run)
+	if err != nil {
+		t.Fatalf("reserve session: %v", err)
+	}
+
+	var cancelErr error
+	var cancelled atomic.Bool
+	var launches atomic.Int32
+	project := &config.ProjectConfig{Root: root, Config: dispatchTestConfig(AgentCodex)}
+	err = launchExecution(dispatchExecution{
+		Root: root, Project: project, Target: targetMeta{Name: AgentCodex},
+		Version: supportedProviderVersions[AgentCodex], Run: run, Session: session, Mode: dispatchModeFresh,
+		Stderr: dispatchTestWriter(func(data []byte) (int, error) {
+			if cancelled.CompareAndSwap(false, true) {
+				cancelErr = Cancel(CancelRequest{Root: root, ID: run.Record.ID})
+			}
+			return len(data), nil
+		}),
+		NewCommand: func(string, ...string) *exec.Cmd {
+			launches.Add(1)
+			return exec.Command("/bin/sh", "-c", "exit 0") // #nosec G204 -- fixed test command must remain unlaunched.
+		},
+	}).await()
+	if cancelErr != nil {
+		t.Fatalf("Cancel during identity publication: %v", cancelErr)
+	}
+	requireDispatchExitCode(t, err, ExitTargetFailure)
+	if launches.Load() != 0 {
+		t.Fatalf("provider launches after cancellation revision race = %d, want 0", launches.Load())
+	}
+	finalized, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finalized.ActiveRunID != "" {
+		t.Fatalf("cancellation revision race left the owner claim stuck: %#v", finalized)
+	}
+	record, err := loadRunRecord(root, run.Record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != dispatchStateCancelled {
+		t.Fatalf("cancellation revision race lost terminal evidence: %#v", record)
+	}
+}
+
+type dispatchTestWriter func([]byte) (int, error)
+
+func (write dispatchTestWriter) Write(data []byte) (int, error) { return write(data) }
+
 func TestDeleteProtectsRunningRecordWithUnprovableOwnership(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)

--- a/internal/agentdispatch/fanout.go
+++ b/internal/agentdispatch/fanout.go
@@ -349,7 +349,11 @@ func writeFanoutManifest(root string, manifest FanoutManifest) error {
 	}
 	defer func() { _ = unix.Flock(int(lock.Fd()), unix.LOCK_UN) }() //nolint:gosec // supported Unix descriptor.
 	var current FanoutManifest
-	if err := readJSON(path, &current); err == nil && current.State == dispatchStateCancelled {
+	readErr := readJSON(path, &current)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return wrapExitError(ExitConfig, "read fanout manifest before update", readErr)
+	}
+	if readErr == nil && current.State == dispatchStateCancelled {
 		manifest.State = dispatchStateCancelled
 		manifest.CompletedAt = current.CompletedAt
 		terminalChildren := make(map[string]FanoutChild, len(current.Children))

--- a/internal/agentdispatch/fanout.go
+++ b/internal/agentdispatch/fanout.go
@@ -286,12 +286,9 @@ func coordinateFanout(root string, manifest FanoutManifest, handles []executionH
 	}
 	published, err := state.loadManifest(root, manifest.ID)
 	if err != nil {
-		recordCoordinatorError(err)
-		if manifest.State != dispatchStateCancelled {
-			manifest.State = dispatchStateFailed
-		}
-		_ = state.writeManifest(root, manifest)
-		return coordinatorErr
+		// The terminal manifest was already published successfully. A read-back
+		// failure must be surfaced without replacing that durable evidence.
+		return err
 	}
 	manifest = published
 	encoder := json.NewEncoder(stdout)

--- a/internal/agentdispatch/fanout.go
+++ b/internal/agentdispatch/fanout.go
@@ -35,6 +35,21 @@ type FanoutManifest struct {
 	CreatedAt   time.Time     `json:"created_at"`
 	CompletedAt *time.Time    `json:"completed_at,omitempty"`
 	Children    []FanoutChild `json:"children"`
+	Error       string        `json:"error,omitempty"`
+}
+
+type fanoutCoordinatorState struct {
+	loadRunRecord func(root string, id string) (RunRecord, error)
+	loadManifest  func(root string, id string) (FanoutManifest, error)
+	writeManifest func(root string, manifest FanoutManifest) error
+}
+
+func defaultFanoutCoordinatorState() fanoutCoordinatorState {
+	return fanoutCoordinatorState{
+		loadRunRecord: loadRunRecord,
+		loadManifest:  loadFanoutManifest,
+		writeManifest: writeFanoutManifest,
+	}
 }
 
 type preparedFanoutChild struct {
@@ -83,6 +98,10 @@ func ParseFanoutTarget(value string) (FanoutTarget, error) {
 // Fanout sends one shared prompt and skill to two or more independently
 // recorded targets, waits for all children, then emits one aggregate manifest.
 func Fanout(opts FanoutOptions) error {
+	return fanout(opts, defaultFanoutCoordinatorState())
+}
+
+func fanout(opts FanoutOptions, coordinatorState fanoutCoordinatorState) error {
 	if len(opts.Targets) < 2 {
 		return exitError(ExitUsage, "dispatch fanout requires at least two --target specifications")
 	}
@@ -185,40 +204,65 @@ func Fanout(opts FanoutOptions) error {
 	for index := range prepared {
 		handles[index] = launchExecution(prepared[index].request)
 	}
-	type childResult struct {
-		index int
-		err   error
-	}
-	results := make(chan childResult, len(handles))
-	for index, handle := range handles {
-		go func(index int, handle executionHandle) { results <- childResult{index: index, err: handle.await()} }(index, handle)
-	}
+	return coordinateFanout(opts.Root, manifest, handles, writerOrDiscard(opts.Stdout), coordinatorState)
+}
+
+// coordinateFanout drains every launched execution before returning, even
+// when coordinator state cannot be reconciled. The first coordinator failure
+// remains the caller-visible cause while later work contributes best-effort
+// terminal aggregate evidence.
+func coordinateFanout(root string, manifest FanoutManifest, handles []executionHandle, stdout io.Writer, state fanoutCoordinatorState) error {
 	failed := false
-	for range handles {
-		completed := <-results
-		index := completed.index
-		handle := handles[index]
-		childErr := completed.err
-		record, loadErr := loadRunRecord(opts.Root, handle.runID)
+	var coordinatorErr error
+	recordCoordinatorError := func(cause error) {
+		failed = true
+		if coordinatorErr == nil {
+			coordinatorErr = cause
+			manifest.Error = cause.Error()
+		}
+	}
+	observeCancellation := func() {
+		current, err := state.loadManifest(root, manifest.ID)
+		if err != nil {
+			recordCoordinatorError(err)
+			return
+		}
+		if current.State == dispatchStateCancelled {
+			manifest.State = current.State
+			manifest.CompletedAt = current.CompletedAt
+		}
+	}
+	reconcileChild := func(index int, handle executionHandle) {
+		record, loadErr := state.loadRunRecord(root, handle.runID)
 		if loadErr != nil {
-			finalizeFanoutFailure(opts.Root, &manifest, index, loadErr)
-			return loadErr
+			recordCoordinatorError(loadErr)
+			return
 		}
-		currentManifest, manifestErr := loadFanoutManifest(opts.Root, groupID)
-		if manifestErr != nil {
-			finalizeFanoutFailure(opts.Root, &manifest, index, manifestErr)
-			return manifestErr
-		}
-		manifest = currentManifest
 		manifest.Children[index].Status = record.State
+		if terminalDispatchState(record.State) && record.State != dispatchStateCompleted && manifest.Children[index].Error == "" {
+			manifest.Children[index].Error = record.TerminalReason
+		}
+	}
+
+	drainExecutionHandles(handles, func(index int, handle executionHandle, childErr error) {
 		if childErr != nil {
 			failed = true
 			manifest.Children[index].Error = childErr.Error()
 		}
-		if err := writeFanoutManifest(opts.Root, manifest); err != nil {
-			return err
+		reconcileChild(index, handle)
+		observeCancellation()
+		if err := state.writeManifest(root, manifest); err != nil {
+			recordCoordinatorError(err)
 		}
+	})
+
+	// A transient state failure may have prevented an earlier child update.
+	// Re-read every terminal record after all handles are drained so the final
+	// aggregate is as complete as durable child evidence allows.
+	for index, handle := range handles {
+		reconcileChild(index, handle)
 	}
+	observeCancellation()
 	now := time.Now().UTC()
 	if manifest.State != dispatchStateCancelled {
 		manifest.CompletedAt = &now
@@ -227,30 +271,38 @@ func Fanout(opts FanoutOptions) error {
 			manifest.State = dispatchStateFailed
 		}
 	}
-	if err := writeFanoutManifest(opts.Root, manifest); err != nil {
-		return err
+	if err := state.writeManifest(root, manifest); err != nil {
+		recordCoordinatorError(err)
+		if manifest.State != dispatchStateCancelled {
+			manifest.State = dispatchStateFailed
+		}
+		// The failed publication happened before the aggregate error was
+		// recorded. Make one recovery attempt with complete terminal evidence;
+		// the first publication error remains the caller-visible cause.
+		_ = state.writeManifest(root, manifest)
 	}
-	encoder := json.NewEncoder(writerOrDiscard(opts.Stdout))
+	if coordinatorErr != nil {
+		return coordinatorErr
+	}
+	published, err := state.loadManifest(root, manifest.ID)
+	if err != nil {
+		recordCoordinatorError(err)
+		if manifest.State != dispatchStateCancelled {
+			manifest.State = dispatchStateFailed
+		}
+		_ = state.writeManifest(root, manifest)
+		return coordinatorErr
+	}
+	manifest = published
+	encoder := json.NewEncoder(stdout)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(manifest); err != nil {
 		return wrapExitError(ExitTargetFailure, "write fanout manifest", err)
 	}
 	if failed {
-		return exitError(ExitTargetFailure, fmt.Sprintf("dispatch fanout %s completed with one or more failed children", groupID))
+		return exitError(ExitTargetFailure, fmt.Sprintf("dispatch fanout %s completed with one or more failed children", manifest.ID))
 	}
 	return nil
-}
-
-// finalizeFanoutFailure terminalizes the aggregate manifest when the wait
-// loop itself cannot read child or manifest state, so an aborted fanout does
-// not stay running forever and escape retention. The write is best-effort;
-// the original cause is what the caller returns.
-func finalizeFanoutFailure(root string, manifest *FanoutManifest, index int, cause error) {
-	now := time.Now().UTC()
-	manifest.Children[index].Error = cause.Error()
-	manifest.State = dispatchStateFailed
-	manifest.CompletedAt = &now
-	_ = writeFanoutManifest(root, *manifest)
 }
 
 func fanoutStateRoot(root string) string {
@@ -297,9 +349,22 @@ func writeFanoutManifest(root string, manifest FanoutManifest) error {
 	}
 	defer func() { _ = unix.Flock(int(lock.Fd()), unix.LOCK_UN) }() //nolint:gosec // supported Unix descriptor.
 	var current FanoutManifest
-	if err := readJSON(path, &current); err == nil && current.State == dispatchStateCancelled && manifest.State != dispatchStateCancelled {
+	if err := readJSON(path, &current); err == nil && current.State == dispatchStateCancelled {
 		manifest.State = dispatchStateCancelled
 		manifest.CompletedAt = current.CompletedAt
+		terminalChildren := make(map[string]FanoutChild, len(current.Children))
+		for _, child := range current.Children {
+			if terminalDispatchState(child.Status) {
+				terminalChildren[child.RunID] = child
+			}
+		}
+		for index := range manifest.Children {
+			child := &manifest.Children[index]
+			if terminal, ok := terminalChildren[child.RunID]; ok && !terminalDispatchState(child.Status) {
+				child.Status = terminal.Status
+				child.Error = terminal.Error
+			}
+		}
 	}
 	return writeJSONAtomic(path, manifest)
 }

--- a/internal/agentdispatch/fanout_test.go
+++ b/internal/agentdispatch/fanout_test.go
@@ -489,6 +489,47 @@ func TestFanoutRecoversDurableEvidenceAfterFinalManifestWriteFailure(t *testing.
 	}
 }
 
+func TestFanoutPreservesCompletedManifestAfterReadBackFailure(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	command := func(string, ...string) *exec.Cmd {
+		return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"done"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
+	}
+
+	injectedErr := errors.New("injected terminal manifest read-back failure")
+	coordinatorState := defaultFanoutCoordinatorState()
+	coordinatorState.loadManifest = func(root string, id string) (FanoutManifest, error) {
+		manifest, err := loadFanoutManifest(root, id)
+		if err == nil && manifest.State == dispatchStateCompleted {
+			return FanoutManifest{}, injectedErr
+		}
+		return manifest, err
+	}
+
+	err := fanout(FanoutOptions{
+		Root: root, Targets: []FanoutTarget{{Agent: AgentCodex}, {Agent: AgentCodex}}, PromptArgs: []string{"shared"}, Env: []string{},
+		LookPath: alwaysFound, VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil },
+		NewCommand: command,
+	}, coordinatorState)
+	if !errors.Is(err, injectedErr) {
+		t.Fatalf("Fanout error = %v, want terminal read-back failure", err)
+	}
+
+	manifestEntries, err := os.ReadDir(fanoutStateRoot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifestEntries) != 1 {
+		t.Fatalf("manifest count = %d, want 1", len(manifestEntries))
+	}
+	manifest, err := loadFanoutManifest(root, manifestEntries[0].Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.State != dispatchStateCompleted || manifest.CompletedAt == nil || manifest.Error != "" {
+		t.Fatalf("read-back failure mutated durable completed evidence: %#v", manifest)
+	}
+}
+
 func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)

--- a/internal/agentdispatch/fanout_test.go
+++ b/internal/agentdispatch/fanout_test.go
@@ -3,11 +3,13 @@ package agentdispatch
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -214,6 +216,279 @@ func TestFanoutPartialFailurePreservesCompleteTerminalEvidence(t *testing.T) {
 	}
 }
 
+func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
+	root := t.TempDir()
+	manifestID, err := newUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := FanoutManifest{ID: manifestID, State: dispatchStateRunning, CreatedAt: time.Now().UTC()}
+	type liveChild struct {
+		run     *dispatchRun
+		session Session
+		cmd     *exec.Cmd
+	}
+	children := make([]liveChild, 0, 2)
+	defer func() {
+		for _, child := range children {
+			if processAlive(child.cmd.Process.Pid) == processStatusAlive {
+				_ = syscall.Kill(-child.cmd.Process.Pid, syscall.SIGKILL)
+				_ = child.cmd.Wait()
+			}
+		}
+	}()
+	for index := 0; index < 2; index++ {
+		run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+		if err != nil {
+			t.Fatal(err)
+		}
+		session, err := reserveSession(root, run)
+		if err != nil {
+			t.Fatal(err)
+		}
+		readyPath := filepath.Join(t.TempDir(), "ready")
+		cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; touch "$1"; while :; do sleep 1; done`, "sh", readyPath) // #nosec G204 -- test-owned path passed as a positional argument.
+		prepareProviderProcessGroup(cmd)
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		waitForFanoutTestPath(t, readyPath)
+		run.Record.State = dispatchStateRunning
+		run.Record.RecoveryState = recoveryAcceptanceUnknown
+		run.Record.PID = cmd.Process.Pid
+		run.Record.ProcessGroupID = cmd.Process.Pid
+		run.Record.ProcessStartIdentity = processStartIdentity(cmd.Process.Pid)
+		if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+			t.Fatal(err)
+		}
+		manifest.Children = append(manifest.Children, FanoutChild{RunID: run.Record.ID, Name: session.Name, Status: dispatchStateRunning})
+		children = append(children, liveChild{run: run, session: session, cmd: cmd})
+	}
+	if err := writeFanoutManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := cancelFanout(root, manifest.ID); err != nil {
+		t.Fatalf("cancelFanout: %v", err)
+	}
+	terminalManifest, err := loadFanoutManifest(root, manifest.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if terminalManifest.State != dispatchStateCancelled || terminalManifest.CompletedAt == nil {
+		t.Fatalf("cancelled fanout manifest = %#v", terminalManifest)
+	}
+	for _, child := range children {
+		record, err := loadRunRecord(root, child.run.Record.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		retained, err := loadSession(root, child.session.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.State != dispatchStateCancelled || !processOwned(record) || retained.ActiveRunID != record.ID {
+			t.Fatalf("fanout cancellation released a live child owner: record = %#v, session = %#v", record, retained)
+		}
+	}
+}
+
+func TestFanoutManifestWritePreservesCancelledChildEvidence(t *testing.T) {
+	root := t.TempDir()
+	id, err := newUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	children := []FanoutChild{
+		{RunID: "11111111-1111-4111-8111-111111111111", Name: "small-bright-resistor", Status: dispatchStateCancelled},
+		{RunID: "22222222-2222-4222-8222-222222222222", Name: "large-steady-relay", Status: dispatchStateCancelled},
+	}
+	if err := writeFanoutManifest(root, FanoutManifest{ID: id, State: dispatchStateCancelled, CreatedAt: now, CompletedAt: &now, Children: children}); err != nil {
+		t.Fatal(err)
+	}
+	stale := FanoutManifest{ID: id, State: dispatchStateCancelled, CreatedAt: now, CompletedAt: &now, Children: append([]FanoutChild(nil), children...)}
+	stale.Children[0].Status = dispatchStateFailed
+	stale.Children[0].Error = "owning execution returned"
+	stale.Children[1].Status = dispatchStatePending
+	if err := writeFanoutManifest(root, stale); err != nil {
+		t.Fatal(err)
+	}
+	published, err := loadFanoutManifest(root, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if published.Children[0].Status != dispatchStateFailed || published.Children[1].Status != dispatchStateCancelled {
+		t.Fatalf("stale coordinator write regressed terminal child evidence: %#v", published.Children)
+	}
+}
+
+func TestFanoutDrainsChildrenAfterPostLaunchCoordinatorFailure(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	gatePath := filepath.Join(t.TempDir(), "coordinator-failed")
+	siblingDonePath := filepath.Join(t.TempDir(), "sibling-done")
+	var calls atomic.Int32
+	command := func(string, ...string) *exec.Cmd {
+		if calls.Add(1) == 1 {
+			return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"first"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
+		}
+		return exec.Command("/bin/sh", "-c", `cat >/dev/null; while [ ! -f "$1" ]; do sleep 0.01; done; touch "$2"; printf '{"type":"thread.started","thread_id":"22222222-2222-4222-8222-222222222222"}\n{"type":"agent_message","message":"second"}\n{"type":"turn.completed"}\n'`, "sh", gatePath, siblingDonePath) // #nosec G204 -- test-owned paths passed as positional arguments.
+	}
+
+	injectedErr := errors.New("injected post-launch coordinator load failure")
+	coordinatorState := defaultFanoutCoordinatorState()
+	var coordinatorLoads atomic.Int32
+	coordinatorState.loadRunRecord = func(root string, id string) (RunRecord, error) {
+		if coordinatorLoads.Add(1) == 1 {
+			if _, err := os.Stat(siblingDonePath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("delayed sibling completed before injected coordinator failure: %v", err)
+			}
+			if err := os.WriteFile(gatePath, []byte("failed"), 0o600); err != nil {
+				t.Fatalf("release delayed sibling: %v", err)
+			}
+			return RunRecord{}, injectedErr
+		}
+		return loadRunRecord(root, id)
+	}
+
+	err := fanout(FanoutOptions{
+		Root: root, Targets: []FanoutTarget{{Agent: AgentCodex}, {Agent: AgentCodex}},
+		PromptArgs: []string{"shared"}, Env: []string{}, LookPath: alwaysFound,
+		VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil },
+		NewCommand:    command,
+	}, coordinatorState)
+	if !errors.Is(err, injectedErr) {
+		t.Fatalf("Fanout error = %v, want original coordinator failure", err)
+	}
+	if _, err := os.Stat(siblingDonePath); err != nil {
+		t.Fatalf("Fanout returned before delayed sibling completed: %v", err)
+	}
+
+	runEntries, err := os.ReadDir(dispatchRunPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runEntries) != 2 {
+		t.Fatalf("run count = %d, want 2", len(runEntries))
+	}
+	for _, entry := range runEntries {
+		record, err := loadRunRecord(root, entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !terminalDispatchState(record.State) || record.CompletedAt == nil {
+			t.Fatalf("child did not terminalize: %#v", record)
+		}
+		if processOwned(record) {
+			t.Fatalf("provider remains active after Fanout returned: %#v", record)
+		}
+		session, err := loadSession(root, record.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if session.ActiveRunID != "" {
+			t.Fatalf("child claim remains active: %#v", session)
+		}
+	}
+
+	manifestEntries, err := os.ReadDir(fanoutStateRoot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifestEntries) != 1 {
+		t.Fatalf("manifest count = %d, want 1", len(manifestEntries))
+	}
+	manifest, err := loadFanoutManifest(root, manifestEntries[0].Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.State != dispatchStateFailed || manifest.Error != injectedErr.Error() || manifest.CompletedAt == nil {
+		t.Fatalf("aggregate coordinator failure evidence = %#v", manifest)
+	}
+	for _, child := range manifest.Children {
+		if child.Status != dispatchStateCompleted {
+			t.Fatalf("aggregate omitted terminal child evidence: %#v", manifest.Children)
+		}
+	}
+}
+
+func TestFanoutRecoversDurableEvidenceAfterFinalManifestWriteFailure(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	var calls atomic.Int32
+	command := func(string, ...string) *exec.Cmd {
+		if calls.Add(1) == 1 {
+			return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"first"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
+		}
+		return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"22222222-2222-4222-8222-222222222222"}\n{"type":"agent_message","message":"second"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
+	}
+
+	injectedErr := errors.New("injected final manifest publication failure")
+	coordinatorState := defaultFanoutCoordinatorState()
+	var failedTerminalWrite atomic.Bool
+	coordinatorState.writeManifest = func(root string, manifest FanoutManifest) error {
+		if manifest.CompletedAt != nil && manifest.State == dispatchStateCompleted && failedTerminalWrite.CompareAndSwap(false, true) {
+			return injectedErr
+		}
+		return writeFanoutManifest(root, manifest)
+	}
+
+	err := fanout(FanoutOptions{
+		Root: root, Targets: []FanoutTarget{{Agent: AgentCodex}, {Agent: AgentCodex}},
+		PromptArgs: []string{"shared"}, Env: []string{}, LookPath: alwaysFound,
+		VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil },
+		NewCommand:    command,
+	}, coordinatorState)
+	if !errors.Is(err, injectedErr) {
+		t.Fatalf("Fanout error = %v, want original final publication failure", err)
+	}
+	if !failedTerminalWrite.Load() {
+		t.Fatal("terminal manifest write was not injected")
+	}
+
+	runEntries, err := os.ReadDir(dispatchRunPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runEntries) != 2 {
+		t.Fatalf("run count = %d, want 2", len(runEntries))
+	}
+	for _, entry := range runEntries {
+		record, err := loadRunRecord(root, entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.State != dispatchStateCompleted || record.CompletedAt == nil || processOwned(record) {
+			t.Fatalf("child lifecycle evidence = %#v", record)
+		}
+		session, err := loadSession(root, record.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if session.ActiveRunID != "" {
+			t.Fatalf("child claim remains active: %#v", session)
+		}
+	}
+
+	manifestEntries, err := os.ReadDir(fanoutStateRoot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifestEntries) != 1 {
+		t.Fatalf("manifest count = %d, want 1", len(manifestEntries))
+	}
+	manifest, err := loadFanoutManifest(root, manifestEntries[0].Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.State != dispatchStateFailed || manifest.Error != injectedErr.Error() || manifest.CompletedAt == nil {
+		t.Fatalf("recovered aggregate evidence = %#v", manifest)
+	}
+	for _, child := range manifest.Children {
+		if child.Status != dispatchStateCompleted {
+			t.Fatalf("recovered aggregate omitted terminal child evidence: %#v", manifest.Children)
+		}
+	}
+}
+
 func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
@@ -227,36 +502,112 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	session.State = "durable"
 	session.ProviderSessionID = runtimeSessionID
 	session.ActiveRunID = ""
+	completed := time.Now().UTC()
+	run.Record.State = dispatchStateCompleted
+	run.Record.RecoveryState = recoveryResumeRequired
+	run.Record.CompletedAt = &completed
+	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+		t.Fatal(err)
+	}
 	if err := persistSession(root, session); err != nil {
 		t.Fatal(err)
 	}
 
-	started := make(chan struct{})
+	startedPath := filepath.Join(t.TempDir(), "provider-started")
+	releasePath := filepath.Join(t.TempDir(), "release-provider")
 	var launches atomic.Int32
 	command := func(string, ...string) *exec.Cmd {
 		if launches.Add(1) == 1 {
-			close(started)
-			return exec.Command("/bin/sh", "-c", `cat >/dev/null; sleep 2; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"done"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
+			return exec.Command("/bin/sh", "-c", `trap 'while [ ! -f "$1" ]; do sleep 0.01; done; exit 0' TERM; touch "$2"; while :; do sleep 1; done`, "sh", releasePath, startedPath) // #nosec G204 -- test-owned paths passed as positional arguments.
 		}
-		return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"unexpected"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
+		return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"resumed"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
 	}
 	firstDone := make(chan error, 1)
 	go func() {
 		firstDone <- Resume(ResumeOptions{Root: root, Name: session.Name, PromptArgs: []string{"one"}, Env: []string{}, LookPath: alwaysFound, VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil }, NewCommand: command})
 	}()
-	select {
-	case <-started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("first resume did not launch")
+	waitForFanoutTestPath(t, startedPath)
+	active, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForFanoutRunState(t, root, active.ActiveRunID, dispatchStateRunning)
+	if err := Cancel(CancelRequest{Root: root, ID: active.ActiveRunID}); err != nil {
+		t.Fatalf("Cancel first resume: %v", err)
+	}
+	cancelledOwner, err := loadRunRecord(root, active.ActiveRunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cancelledOwner.State != dispatchStateCancelled || !processOwned(cancelledOwner) {
+		t.Fatalf("cancel did not preserve live owner evidence: %#v", cancelledOwner)
+	}
+	afterCancel, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterCancel.ActiveRunID != active.ActiveRunID {
+		t.Fatalf("cancel released the live owner claim: %#v", afterCancel)
 	}
 	err = Resume(ResumeOptions{Root: root, Name: session.Name, PromptArgs: []string{"two"}, Env: []string{}, LookPath: alwaysFound, VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil }, NewCommand: command})
 	if err == nil || !strings.Contains(err.Error(), "already active in run") {
 		t.Fatalf("second resume error = %v", err)
 	}
-	if err := <-firstDone; err != nil {
-		t.Fatalf("first resume: %v", err)
+	blocked, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != afterCancel {
+		t.Fatalf("blocked resume mutated conversation mapping: before = %#v, after = %#v", afterCancel, blocked)
 	}
 	if launches.Load() != 1 {
 		t.Fatalf("provider launches = %d, want 1", launches.Load())
 	}
+	if err := os.WriteFile(releasePath, []byte("release"), 0o600); err != nil {
+		t.Fatalf("release cancelled provider: %v", err)
+	}
+	requireDispatchExitCode(t, <-firstDone, ExitTargetFailure)
+	finalized, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finalized.ActiveRunID != "" {
+		t.Fatalf("owning execution did not release after provider termination: %#v", finalized)
+	}
+	if err := Resume(ResumeOptions{Root: root, Name: session.Name, PromptArgs: []string{"three"}, Env: []string{}, LookPath: alwaysFound, VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil }, NewCommand: command}); err != nil {
+		t.Fatalf("resume after owning finalization: %v", err)
+	}
+	if launches.Load() != 2 {
+		t.Fatalf("provider launches after finalization = %d, want 2", launches.Load())
+	}
+}
+
+func waitForFanoutTestPath(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("inspect test path %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for test path %s", path)
+}
+
+func waitForFanoutRunState(t *testing.T, root string, runID string, state string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		record, err := loadRunRecord(root, runID)
+		if err != nil {
+			t.Fatalf("load run %s while waiting for %s: %v", runID, state, err)
+		}
+		if record.State == state {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for run %s to reach %s", runID, state)
 }

--- a/internal/agentdispatch/fanout_test.go
+++ b/internal/agentdispatch/fanout_test.go
@@ -252,6 +252,7 @@ func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
 		if err := cmd.Start(); err != nil {
 			t.Fatal(err)
 		}
+		children = append(children, liveChild{run: run, session: session, cmd: cmd})
 		waitForFanoutTestPath(t, readyPath)
 		run.Record.State = dispatchStateRunning
 		run.Record.RecoveryState = recoveryAcceptanceUnknown
@@ -262,7 +263,6 @@ func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
 			t.Fatal(err)
 		}
 		manifest.Children = append(manifest.Children, FanoutChild{RunID: run.Record.ID, Name: session.Name, Status: dispatchStateRunning})
-		children = append(children, liveChild{run: run, session: session, cmd: cmd})
 	}
 	if err := writeFanoutManifest(root, manifest); err != nil {
 		t.Fatal(err)
@@ -502,6 +502,7 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	session.State = "durable"
 	session.ProviderSessionID = runtimeSessionID
 	session.ActiveRunID = ""
+	session.ActiveClaimKnown = false
 	completed := time.Now().UTC()
 	run.Record.State = dispatchStateCompleted
 	run.Record.RecoveryState = recoveryResumeRequired
@@ -516,13 +517,29 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	startedPath := filepath.Join(t.TempDir(), "provider-started")
 	releasePath := filepath.Join(t.TempDir(), "release-provider")
 	var launches atomic.Int32
+	var firstCommand atomic.Pointer[exec.Cmd]
+	var firstFinished atomic.Bool
+	firstDone := make(chan error, 1)
+	t.Cleanup(func() {
+		if firstFinished.Load() {
+			return
+		}
+		if cmd := firstCommand.Load(); cmd != nil && cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		select {
+		case <-firstDone:
+		case <-time.After(2 * time.Second):
+		}
+	})
 	command := func(string, ...string) *exec.Cmd {
 		if launches.Add(1) == 1 {
-			return exec.Command("/bin/sh", "-c", `trap 'while [ ! -f "$1" ]; do sleep 0.01; done; exit 0' TERM; touch "$2"; while :; do sleep 1; done`, "sh", releasePath, startedPath) // #nosec G204 -- test-owned paths passed as positional arguments.
+			cmd := exec.Command("/bin/sh", "-c", `trap 'while [ ! -f "$1" ]; do sleep 0.01; done; exit 0' TERM; touch "$2"; while :; do sleep 1; done`, "sh", releasePath, startedPath) // #nosec G204 -- test-owned paths passed as positional arguments.
+			firstCommand.Store(cmd)
+			return cmd
 		}
 		return exec.Command("/bin/sh", "-c", `cat >/dev/null; printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"resumed"}\n{"type":"turn.completed"}\n'`) // #nosec G204 -- fixed test command.
 	}
-	firstDone := make(chan error, 1)
 	go func() {
 		firstDone <- Resume(ResumeOptions{Root: root, Name: session.Name, PromptArgs: []string{"one"}, Env: []string{}, LookPath: alwaysFound, VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil }, NewCommand: command})
 	}()
@@ -567,6 +584,7 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 		t.Fatalf("release cancelled provider: %v", err)
 	}
 	requireDispatchExitCode(t, <-firstDone, ExitTargetFailure)
+	firstFinished.Store(true)
 	finalized, err := loadSession(root, session.Name)
 	if err != nil {
 		t.Fatal(err)
@@ -579,6 +597,31 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	}
 	if launches.Load() != 2 {
 		t.Fatalf("provider launches after finalization = %d, want 2", launches.Load())
+	}
+}
+
+func TestWriteFanoutManifestPreservesUnreadableEvidence(t *testing.T) {
+	root := t.TempDir()
+	id, err := newUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := fanoutPath(root, id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := []byte("{not-json")
+	if err := os.WriteFile(path, corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = writeFanoutManifest(root, FanoutManifest{ID: id, State: dispatchStateRunning, CreatedAt: time.Now().UTC()})
+	requireDispatchExitCode(t, err, ExitConfig)
+	retained, err := os.ReadFile(path) // #nosec G304 -- path is test-owned fanout evidence.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(retained, corrupt) {
+		t.Fatalf("unreadable manifest was overwritten: got %q, want %q", retained, corrupt)
 	}
 }
 

--- a/internal/agentdispatch/lifecycle_operations_test.go
+++ b/internal/agentdispatch/lifecycle_operations_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -166,7 +167,7 @@ func TestRetentionRemovesOnlyExpiredUnreferencedTerminalEvidence(t *testing.T) {
 	}
 }
 
-func TestCancelSignalsExactOwnedProcessGroup(t *testing.T) {
+func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
 	if err != nil {
@@ -176,12 +177,20 @@ func TestCancelSignalsExactOwnedProcessGroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("/bin/sh", "-c", "sleep 30") // #nosec G204 -- fixed test process.
+	readyPath := filepath.Join(t.TempDir(), "sigterm-handler-ready")
+	cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; touch "$1"; while :; do sleep 1; done`, "sh", readyPath) // #nosec G204 -- test-owned path passed as a positional argument.
 	prepareProviderProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = cmd.Process.Kill(); _ = cmd.Wait() }()
+	waitForFanoutTestPath(t, readyPath)
+	stopped := false
+	defer func() {
+		if !stopped {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			_ = cmd.Wait()
+		}
+	}()
 	run.Record.State = dispatchStateRunning
 	run.Record.PID = cmd.Process.Pid
 	run.Record.ProcessGroupID = cmd.Process.Pid
@@ -203,8 +212,42 @@ func TestCancelSignalsExactOwnedProcessGroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if retained.ActiveRunID != "" {
-		t.Fatalf("cancel retained active claim: %#v", retained)
+	if retained.ActiveRunID != run.Record.ID || !processOwned(record) {
+		t.Fatalf("cancel released a claim while its owned process remained live: session = %#v, record = %#v", retained, record)
+	}
+	replacement, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeResume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeBlockedClaim := retained
+	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err == nil {
+		t.Fatal("cancelled live owner was replaced")
+	} else {
+		requireDispatchExitCode(t, err, ExitUnavailable)
+	}
+	afterBlockedClaim, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterBlockedClaim != beforeBlockedClaim {
+		t.Fatalf("blocked replacement mutated conversation mapping: before = %#v, after = %#v", beforeBlockedClaim, afterBlockedClaim)
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("stop test process group: %v", err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("SIGKILLed test process exited successfully")
+	}
+	stopped = true
+	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err != nil {
+		t.Fatalf("replace cancelled claim after conservative dead-owner proof: %v", err)
+	}
+	recovered, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.ActiveRunID != replacement.Record.ID || recovered.RunID != replacement.Record.ID {
+		t.Fatalf("dead-owner recovery did not publish replacement claim: %#v", recovered)
 	}
 	if _, err := os.Stat(filepath.Join(run.Dir, dispatchRunFile)); err != nil {
 		t.Fatalf("cancel removed evidence: %v", err)

--- a/internal/agentdispatch/lifecycle_operations_test.go
+++ b/internal/agentdispatch/lifecycle_operations_test.go
@@ -183,7 +183,6 @@ func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	waitForFanoutTestPath(t, readyPath)
 	stopped := false
 	defer func() {
 		if !stopped {
@@ -191,6 +190,7 @@ func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
 			_ = cmd.Wait()
 		}
 	}()
+	waitForFanoutTestPath(t, readyPath)
 	run.Record.State = dispatchStateRunning
 	run.Record.PID = cmd.Process.Pid
 	run.Record.ProcessGroupID = cmd.Process.Pid

--- a/internal/agentdispatch/operations.go
+++ b/internal/agentdispatch/operations.go
@@ -181,6 +181,18 @@ func inspectionFromRecord(record RunRecord) Inspection {
 }
 
 func reconcileOrphan(root string, record RunRecord) (RunRecord, error) {
+	if record.State == dispatchStateCancelled {
+		// Cancellation is terminal user-visible evidence, but the active claim
+		// remains owned until the execution releases it or the recorded wrapper
+		// is provably dead. Inspection may perform that conservative recovery.
+		if processOwnership(record) != ownershipDead {
+			return record, nil
+		}
+		if err := releaseConversation(root, record.Name, record.ID); err != nil {
+			return RunRecord{}, err
+		}
+		return record, nil
+	}
 	if record.State != dispatchStateRunning {
 		return record, nil
 	}
@@ -316,7 +328,10 @@ func Cancel(request CancelRequest) error {
 	if err := writeRunRecord(filepathForRun(request.Root, record.ID), &record); err != nil {
 		return err
 	}
-	return releaseConversation(request.Root, record.Name, record.ID)
+	// The owning execution releases the claim after its provider wait path has
+	// stopped. Cancel returning only records intent and sends SIGTERM; neither
+	// action proves that the execution no longer owns the conversation.
+	return nil
 }
 
 func cancelFanout(root string, id string) error {
@@ -398,12 +413,12 @@ func Delete(root string, name string) error {
 	if err != nil {
 		return err
 	}
-	if session.RunID != "" {
-		record, recordErr := loadRunRecord(root, session.RunID)
+	if ownerRunID := sessionOwnerRunID(session); ownerRunID != "" {
+		record, recordErr := loadRunRecord(root, ownerRunID)
 		if recordErr != nil && !errors.Is(recordErr, errDispatchRunNotFound) {
 			return recordErr
 		}
-		if recordErr == nil && (record.State == dispatchStatePending || record.State == dispatchStateStarting || (record.State == dispatchStateRunning && processOwnership(record) != ownershipDead)) {
+		if recordErr == nil && activeClaimBlocksReplacement(record) {
 			return exitError(ExitUnavailable, fmt.Sprintf("dispatch session %q is active; inspect it or wait for terminal completion before deleting the mapping", name))
 		}
 	}

--- a/internal/agentdispatch/operations.go
+++ b/internal/agentdispatch/operations.go
@@ -184,8 +184,9 @@ func reconcileOrphan(root string, record RunRecord) (RunRecord, error) {
 	if record.State == dispatchStateCancelled {
 		// Cancellation is terminal user-visible evidence, but the active claim
 		// remains owned until the execution releases it or the recorded wrapper
-		// is provably dead. Inspection may perform that conservative recovery.
-		if processOwnership(record) != ownershipDead {
+		// never acquired process identity or is provably dead. Inspection may
+		// perform that conservative recovery.
+		if !cancelledClaimReleasable(record) {
 			return record, nil
 		}
 		if err := releaseConversation(root, record.Name, record.ID); err != nil {

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -281,10 +281,11 @@ func claimConversation(root string, name string, runID string) (Session, error) 
 		if err := readJSON(path, &session); err != nil {
 			return wrapExitError(ExitConfig, "read dispatch mapping for active claim", err)
 		}
-		if session.ActiveRunID != "" && session.ActiveRunID != runID {
-			active, loadErr := loadRunRecord(root, session.ActiveRunID)
-			if loadErr == nil && !terminalDispatchState(active.State) {
-				return exitError(ExitUnavailable, fmt.Sprintf("dispatch conversation %q is already active in run %s", name, session.ActiveRunID))
+		ownerRunID := sessionOwnerRunID(session)
+		if ownerRunID != "" && ownerRunID != runID {
+			active, loadErr := loadRunRecord(root, ownerRunID)
+			if loadErr == nil && activeClaimBlocksReplacement(active) {
+				return exitError(ExitUnavailable, fmt.Sprintf("dispatch conversation %q is already active in run %s", name, ownerRunID))
 			}
 			if loadErr != nil && !errors.Is(loadErr, errDispatchRunNotFound) {
 				return loadErr
@@ -359,6 +360,27 @@ func terminalDispatchState(state string) bool {
 	default:
 		return false
 	}
+}
+
+// activeClaimBlocksReplacement distinguishes terminal execution evidence from
+// completed ownership. Cancellation is published before a live provider has
+// necessarily stopped, so only conservative process evidence can recover an
+// abandoned cancelled claim. Other terminal states are written by the owning
+// execution after provider termination or a proven pre-start failure.
+func activeClaimBlocksReplacement(record RunRecord) bool {
+	if record.State == dispatchStateCancelled {
+		return processOwnership(record) != ownershipDead
+	}
+	return !terminalDispatchState(record.State)
+}
+
+// sessionOwnerRunID resolves the explicit active claim and the compatibility
+// representation used before ActiveRunID existed.
+func sessionOwnerRunID(session Session) string {
+	if session.ActiveRunID != "" {
+		return session.ActiveRunID
+	}
+	return session.RunID
 }
 
 func deleteSession(root string, name string) error {
@@ -512,14 +534,17 @@ func pruneExpiredSession(root string, name string, cutoff time.Time) error {
 }
 
 func dispatchSessionActive(root string, session Session) bool {
-	if session.RunID == "" {
+	activeRunID := sessionOwnerRunID(session)
+	if activeRunID == "" {
 		return false
 	}
-	record, err := loadRunRecord(root, session.RunID)
+	record, err := loadRunRecord(root, activeRunID)
 	if err != nil {
-		return false
+		// Retention must not erase a mapping when its active claim cannot be
+		// interpreted conservatively. Explicit operations surface the error.
+		return true
 	}
-	return record.State == dispatchStateRunning && processOwned(record)
+	return activeClaimBlocksReplacement(record)
 }
 
 func withSessionLock(root string, name string, fn func() error) error {
@@ -549,10 +574,19 @@ func withSessionLock(root string, name string, fn func() error) error {
 }
 
 func writeRunRecord(dir string, record *RunRecord) error {
+	return writeRunRecordWithPublisher(dir, record, writeJSONAtomic)
+}
+
+// writeRunRecordWithPublisher publishes the next record revision without
+// advancing caller-owned concurrency state until publication succeeds.
+func writeRunRecordWithPublisher(dir string, record *RunRecord, publish func(string, any) error) error {
 	if record == nil {
 		return exitError(ExitConfig, "write nil dispatch run record")
 	}
-	if err := validateRunRecord(*record); err != nil {
+	next := *record
+	next.Revision++
+	next.UpdatedAt = time.Now().UTC()
+	if err := validateRunRecord(next); err != nil {
 		return err
 	}
 	return withRunLock(dir, func() error {
@@ -562,17 +596,17 @@ func writeRunRecord(dir string, record *RunRecord) error {
 			if current.Revision != record.Revision {
 				return exitError(ExitUnavailable, fmt.Sprintf("dispatch run %s changed concurrently (expected revision %d, active revision %d)", record.ID, record.Revision, current.Revision))
 			}
-			if terminalDispatchState(current.State) && !terminalDispatchState(record.State) {
+			if terminalDispatchState(current.State) && !terminalDispatchState(next.State) {
 				return exitError(ExitUnavailable, fmt.Sprintf("dispatch run %s is already terminal (%s)", record.ID, current.State))
 			}
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			return wrapExitError(ExitConfig, "read dispatch run record before update", err)
 		}
-		record.Revision++
-		record.UpdatedAt = time.Now().UTC()
-		if err := writeJSONAtomic(path, record); err != nil {
+		if err := publish(path, next); err != nil {
 			return wrapExitError(ExitConfig, "write dispatch run record", err)
 		}
+		record.Revision = next.Revision
+		record.UpdatedAt = next.UpdatedAt
 		return nil
 	})
 }

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -367,14 +367,22 @@ func terminalDispatchState(state string) bool {
 
 // activeClaimBlocksReplacement distinguishes terminal execution evidence from
 // completed ownership. Cancellation is published before a live provider has
-// necessarily stopped, so only conservative process evidence can recover an
+// necessarily stopped, so only a record that never acquired process identity
+// or conservative proof that the recorded process is dead can recover an
 // abandoned cancelled claim. Other terminal states are written by the owning
 // execution after provider termination or a proven pre-start failure.
 func activeClaimBlocksReplacement(record RunRecord) bool {
 	if record.State == dispatchStateCancelled {
-		return processOwnership(record) != ownershipDead
+		return !cancelledClaimReleasable(record)
 	}
 	return !terminalDispatchState(record.State)
+}
+
+func cancelledClaimReleasable(record RunRecord) bool {
+	if record.PID == 0 && record.ProcessGroupID == 0 && record.ProcessStartIdentity == "" {
+		return true
+	}
+	return processOwnership(record) == ownershipDead
 }
 
 // sessionOwnerRunID resolves the explicit active claim and the compatibility

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -58,6 +58,7 @@ type Session struct {
 	State             string    `json:"state,omitempty"`
 	RunID             string    `json:"run_id,omitempty"`
 	ActiveRunID       string    `json:"active_run_id,omitempty"`
+	ActiveClaimKnown  bool      `json:"active_claim_known,omitempty"`
 }
 
 // RunRecord is private, recoverable dispatch evidence. It never contains the
@@ -234,7 +235,7 @@ func reserveSession(root string, run *dispatchRun) (Session, error) {
 			return Session{}, err
 		}
 		now := time.Now().UTC()
-		session := Session{Name: name, Agent: run.Record.Agent, CreatedAt: now, LastUsedAt: now, State: sessionStatePending, RunID: run.Record.ID, ActiveRunID: run.Record.ID}
+		session := Session{Name: name, Agent: run.Record.Agent, CreatedAt: now, LastUsedAt: now, State: sessionStatePending, RunID: run.Record.ID, ActiveRunID: run.Record.ID, ActiveClaimKnown: true}
 		file, openErr := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- name is generated from fixed vocabularies.
 		if errors.Is(openErr, fs.ErrExist) {
 			continue
@@ -292,6 +293,7 @@ func claimConversation(root string, name string, runID string) (Session, error) 
 			}
 		}
 		session.ActiveRunID = runID
+		session.ActiveClaimKnown = true
 		session.RunID = runID
 		session.LastUsedAt = time.Now().UTC()
 		if err := writeJSONAtomic(path, session); err != nil {
@@ -349,6 +351,7 @@ func releaseConversation(root string, name string, runID string) error {
 			return nil
 		}
 		session.ActiveRunID = ""
+		session.ActiveClaimKnown = true
 		return writeJSONAtomic(path, session)
 	})
 }
@@ -379,6 +382,9 @@ func activeClaimBlocksReplacement(record RunRecord) bool {
 func sessionOwnerRunID(session Session) string {
 	if session.ActiveRunID != "" {
 		return session.ActiveRunID
+	}
+	if session.ActiveClaimKnown {
+		return ""
 	}
 	return session.RunID
 }

--- a/internal/agentdispatch/state_operations_test.go
+++ b/internal/agentdispatch/state_operations_test.go
@@ -119,7 +119,9 @@ func TestDispatchSessionRetentionPrunesOnlyExpiredInactiveMappings(t *testing.T)
 	expired := Session{Name: "tiny-round-capacitor", Agent: AgentCodex, State: "durable", ProviderSessionID: runtimeSessionID, CreatedAt: old, LastUsedAt: old}
 	current := Session{Name: "small-bright-resistor", Agent: AgentClaude, State: "durable", ProviderSessionID: runtimeSessionID, CreatedAt: old, LastUsedAt: now.Add(-time.Hour)}
 	active := Session{Name: "large-steady-relay", Agent: AgentCodex, State: "durable", ProviderSessionID: runtimeSessionID, CreatedAt: old, LastUsedAt: old, RunID: runtimeSessionID}
-	for _, session := range []Session{expired, current, active} {
+	cancelledRunID := "22222222-2222-4222-8222-222222222222"
+	cancelled := Session{Name: "short-curved-diode", Agent: AgentCodex, State: "durable", ProviderSessionID: runtimeSessionID, CreatedAt: old, LastUsedAt: old, RunID: cancelledRunID}
+	for _, session := range []Session{expired, current, active, cancelled} {
 		if err := persistSession(root, session); err != nil {
 			t.Fatalf("persist %s: %v", session.Name, err)
 		}
@@ -131,11 +133,21 @@ func TestDispatchSessionRetentionPrunesOnlyExpiredInactiveMappings(t *testing.T)
 	if err := writeJSONAtomic(filepath.Join(runDir, dispatchRunFile), RunRecord{ID: runtimeSessionID, State: dispatchStateRunning, RecoveryState: recoveryAcceptanceUnknown, PID: os.Getpid(), ProcessStartIdentity: processStartIdentity(os.Getpid())}); err != nil {
 		t.Fatalf("write active run: %v", err)
 	}
+	cancelledRunDir := filepath.Join(dispatchRunPath(root), cancelledRunID)
+	if err := os.MkdirAll(cancelledRunDir, 0o700); err != nil {
+		t.Fatalf("create cancelled run: %v", err)
+	}
+	if err := writeJSONAtomic(filepath.Join(cancelledRunDir, dispatchRunFile), RunRecord{ID: cancelledRunID, State: dispatchStateCancelled, RecoveryState: recoveryAcceptanceUnknown, CompletedAt: &old}); err != nil {
+		t.Fatalf("write cancelled run: %v", err)
+	}
 	if err := pruneExpiredSessions(root, now); err != nil {
 		t.Fatalf("pruneExpiredSessions: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dispatchStatePath(root), expired.Name+".json")); !os.IsNotExist(err) {
 		t.Fatalf("expired inactive mapping remains: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dispatchStatePath(root), cancelled.Name+".json")); !os.IsNotExist(err) {
+		t.Fatalf("expired never-launched cancelled mapping remains: %v", err)
 	}
 	for _, path := range []string{
 		filepath.Join(dispatchStatePath(root), current.Name+".json"),
@@ -146,7 +158,7 @@ func TestDispatchSessionRetentionPrunesOnlyExpiredInactiveMappings(t *testing.T)
 		}
 	}
 
-	corruptPath := filepath.Join(dispatchStatePath(root), "short-curved-diode.json")
+	corruptPath := filepath.Join(dispatchStatePath(root), "calm-amber-switch.json")
 	if err := os.WriteFile(corruptPath, []byte("not-json"), 0o600); err != nil {
 		t.Fatalf("write corrupt mapping: %v", err)
 	}

--- a/internal/agentdispatch/v013_test.go
+++ b/internal/agentdispatch/v013_test.go
@@ -159,6 +159,7 @@ func TestAntigravityResumeWithoutParsedIDRetainsDurableMapping(t *testing.T) {
 	session.ProviderSessionID = runtimeSessionID
 	session.State = "durable"
 	session.ActiveRunID = ""
+	session.ActiveClaimKnown = false
 	completed := time.Now().UTC()
 	run.Record.State = dispatchStateCompleted
 	run.Record.RecoveryState = recoveryResumeRequired

--- a/internal/agentdispatch/v013_test.go
+++ b/internal/agentdispatch/v013_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFreshCodexThenResumeUsesOnlyDurableMapping(t *testing.T) {
@@ -158,6 +159,13 @@ func TestAntigravityResumeWithoutParsedIDRetainsDurableMapping(t *testing.T) {
 	session.ProviderSessionID = runtimeSessionID
 	session.State = "durable"
 	session.ActiveRunID = ""
+	completed := time.Now().UTC()
+	run.Record.State = dispatchStateCompleted
+	run.Record.RecoveryState = recoveryResumeRequired
+	run.Record.CompletedAt = &completed
+	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+		t.Fatalf("complete prior run: %v", err)
+	}
 	if err := persistSession(root, session); err != nil {
 		t.Fatalf("persist session: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Make dispatch run-record publication transactional so failed writes do not corrupt caller-owned revision state.
- Drain every launched fanout child through terminal evidence even when coordinator reconciliation fails.
- Retain cancellation claims until provider termination or conservative dead-owner recovery proves replacement safe.

## Changes

- Publish copied run-record revisions atomically and update in-memory concurrency state only after durable success.
- Add fanout coordination drainage, first-error preservation, cancellation precedence, and terminal manifest reconciliation.
- Keep live cancelled executions as conversation owners, improve compatibility claim recovery, and document the lifecycle contract.
- Add regression coverage for failed publication, fanout coordinator errors, cancellation ownership, and compatibility mappings.

## Verification

- `make ci` — passed the complete documented lane: 3,312 coverage tests at 91.97%, the Agent Dispatch race lane, 99 release checks, 902 end-to-end checks with eight upgrade scenarios, and documentation checks.
- `git diff --cached --check` — passed.
- `git diff --cached -- go.mod go.sum` — empty; module files are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so active claims remain protected until the owning process has fully stopped.
  * Fanout operations now preserve completed child results and finish draining launched tasks after coordination errors.
  * Prevented stale updates from overwriting terminal or cancelled run evidence.
  * Improved recovery of durable status after finalization or publication failures.
* **Documentation**
  * Clarified fanout cancellation, ownership, and process-lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->