### PR TITLE
fix: harden dispatch recovery lifecycle

### DIFF
--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -111,13 +111,21 @@ simultaneous resume fails nonzero with the active run handle. It launches no
 provider, queues no prompt, and does not mutate provider conversation state.
 Unrelated conversations and fresh calls remain concurrent; no global lock is
 held while a provider runs. Publishing `cancelled` does not release the claim:
-the owning execution releases it only after provider termination, or recovery
-replaces it when recorded process-identity evidence proves the owner dead.
+the cancellation or owning execution path releases it only after complete
+process-group death is proven, or recovery replaces it when recorded process
+identity and group evidence prove the owner dead.
 
-`cancel` signals only the exact recorded live process group after verifying
-its process-start identity and retains the claim while that process group may
-still run. A fanout cancellation iterates only nonterminal children and applies
-the same ownership boundary independently to every child.
+`cancel` publishes authoritative cancelled state, then signals only the exact
+recorded live process group after verifying its process-start identity and
+group membership. Dispatch first sends `SIGTERM` and escalates to `SIGKILL`
+after a one-second grace period. The same bounded process-group terminator is
+used after forwarded caller signals, running-state publication failure, and
+provider reduction or capture failure. After forced escalation, Dispatch uses a
+second one-second bound to prove the group is gone; failure to prove death is
+reported and retains the claim. The claim is released only after group-death
+proof and the owning execution's pipe drainage and `Wait`, when applicable. A
+fanout cancellation iterates only nonterminal children and applies this
+ownership boundary independently to every child.
 
 ## Retention
 

--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -122,8 +122,9 @@ after a one-second grace period. The same bounded process-group terminator is
 used after forwarded caller signals, running-state publication failure, and
 provider reduction or capture failure. After forced escalation, Dispatch uses a
 second one-second bound to prove the group is gone; failure to prove death is
-reported and retains the claim. The claim is released only after group-death
-proof and the owning execution's pipe drainage and `Wait`, when applicable. A
+reported and retains the claim. `cancel` may release the claim immediately
+after group-death proof; owner-driven release additionally waits for the owning
+execution's pipe drainage and `Wait`. A
 fanout cancellation iterates only nonterminal children and applies this
 ownership boundary independently to every child.
 

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -33,12 +33,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
     Next step: Decide whether random pools should be filtered by requested override support or preserve provider-only eligibility and fail after selection, then encode the chosen public policy in focused selection tests.
     Notes: Deferred because filtering semantics are a public-policy choice outside PR #151's classified production repairs.
 
-- Issue 2026-07-15 dispatch-provider-sigterm-no-escalation: Provider shutdown can hang after cancellation or internal failure
-    Priority: High. Area: internal/agentdispatch runner and runtime helpers
-    Description: Dispatch sends SIGTERM after caller signals, cancellation, reducer failure, or capture failure, but a provider or descendant that ignores SIGTERM can keep the pipes and Wait blocked indefinitely while the owned process group remains alive.
-    Next step: Choose whether shutdown escalates to SIGKILL after a fixed grace period or remains indefinitely graceful/user-driven, then encode the policy in one process-group terminator.
-    Notes: Requires a user-owned cancellation/cleanup policy; do not weaken process identity or group ownership checks.
-
 - Issue 2026-07-13 corrupt-run-record-blocks-delete-cancel: A corrupt run record leaves its mapping undeletable and uncancellable
     Priority: Low. Area: internal/agentdispatch/operations.go (Delete, Cancel) + state.go retention
     Description: Delete and Cancel deliberately fail loud on a corrupt referenced run record (tested behavior consistent with the retention stance of never hiding corrupt evidence), so the only recovery is manual removal of the run directory; history already skips-and-warns, but the mapping stays blocked and retention never expires nonterminal corrupt records.

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -374,6 +374,12 @@ func completeDispatchSuccess(request dispatchExecution, result executionResult, 
 }
 
 func finishDispatchFailure(request dispatchExecution, cause error) error {
+	var terminationFailure *unprovenProviderTerminationError
+	if errors.As(cause, &terminationFailure) {
+		// The provider group may still be live. Keep both the nonterminal run
+		// evidence and active claim so no replacement can overlap it.
+		return cause
+	}
 	if current, err := loadRunRecord(request.Root, request.Run.Record.ID); err == nil && current.State == dispatchStateCancelled {
 		return finishDispatchCancellation(request)
 	}

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -89,6 +89,13 @@ func Run(opts RunOptions) error {
 
 // Resume continues exactly the provider session addressed by name.
 func Resume(opts ResumeOptions) error {
+	return resume(opts, writeRunRecord)
+}
+
+// resume continues a durable provider session and publishes every attempted
+// run outcome. The rejected-run writer is injectable so publication failures
+// can be verified without mutating process-wide state.
+func resume(opts ResumeOptions, writeRejectedRunRecord func(string, *RunRecord) error) error {
 	project, stderr, env, depth, err := loadDispatchProject(opts.Root, opts.Stderr, opts.Env)
 	if err != nil {
 		return err
@@ -148,13 +155,7 @@ func Resume(opts ResumeOptions) error {
 	}
 	session, err = claimConversation(opts.Root, session.Name, run.Record.ID)
 	if err != nil {
-		now := time.Now().UTC()
-		run.Record.State = dispatchStateFailed
-		run.Record.RecoveryState = recoveryRetrySafe
-		run.Record.CompletedAt = &now
-		run.Record.TerminalReason = err.Error()
-		_ = writeRunRecord(run.Dir, &run.Record)
-		return err
+		return finishRejectedResume(run, err, writeRejectedRunRecord)
 	}
 	preflightRequest := dispatchExecution{Root: opts.Root, WorkDir: opts.WorkDir, Project: project, Target: target, Version: version, Mode: dispatchModeResume, Run: run, Session: session}
 	if err := prepareProjection(project, opts.Root, stderr, opts.Quiet); err != nil {
@@ -185,6 +186,22 @@ func Resume(opts ResumeOptions) error {
 		NewCommand:    opts.NewCommand,
 		VersionLookup: opts.VersionLookup,
 	}).await()
+}
+
+// finishRejectedResume makes claim rejection and its attempted-run evidence one
+// durable outcome. A publication failure is joined with the rejection because
+// either error alone would hide material recovery state from the caller.
+func finishRejectedResume(run *dispatchRun, claimErr error, publish func(string, *RunRecord) error) error {
+	now := time.Now().UTC()
+	run.Record.State = dispatchStateFailed
+	run.Record.RecoveryState = recoveryRetrySafe
+	run.Record.CompletedAt = &now
+	run.Record.TerminalReason = claimErr.Error()
+	if err := publish(run.Dir, &run.Record); err != nil {
+		message := fmt.Sprintf("resume claim rejected (%v); publish rejected resume terminal evidence: %v", claimErr, err)
+		return wrapExitError(ExitConfig, message, errors.Join(claimErr, err))
+	}
+	return claimErr
 }
 
 type dispatchExecution struct {

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -149,6 +149,41 @@ func TestExecuteDispatchPreservesFailedFreshRunForRecoveryHistory(t *testing.T) 
 	}
 }
 
+func TestUnprovenProviderTerminationRetainsRunAndActiveClaim(t *testing.T) {
+	root := t.TempDir()
+	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := reserveSession(root, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Record.State = dispatchStateRunning
+	run.Record.RecoveryState = recoveryAcceptanceUnknown
+	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+		t.Fatal(err)
+	}
+	cause := &unprovenProviderTerminationError{err: exitError(ExitTargetFailure, "provider process group death was not proven")}
+	if err := finishDispatchFailure(dispatchExecution{Root: root, Run: run, Session: session, Mode: dispatchModeFresh}, cause); !errors.Is(err, cause) {
+		t.Fatalf("finishDispatchFailure error = %v, want unproven termination failure", err)
+	}
+	retained, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retained.ActiveRunID != run.Record.ID {
+		t.Fatalf("unproven termination released active claim: %#v", retained)
+	}
+	durable, err := loadRunRecord(root, run.Record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if durable.State != dispatchStateRunning || durable.CompletedAt != nil || durable.TerminalReason != "" {
+		t.Fatalf("unproven termination terminalized run evidence: %#v", durable)
+	}
+}
+
 func TestFailureFinalizationReleasesClaimWhenTerminalWriteFails(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -29,6 +29,68 @@ func TestResumeValidatesVersionPromptAndSkillBeforeLaunch(t *testing.T) {
 	requireDispatchExitCode(t, err, ExitConfig)
 }
 
+func TestRejectedResumeExposesTerminalPublicationFailure(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	active, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeResume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active.Record.Name = "short-bright-transistor"
+	if err := writeRunRecord(active.Dir, &active.Record); err != nil {
+		t.Fatal(err)
+	}
+	session := Session{
+		Name: active.Record.Name, Agent: AgentCodex, State: sessionStateDurable,
+		ProviderSessionID: runtimeSessionID, RunID: active.Record.ID,
+		ActiveRunID: active.Record.ID, ActiveClaimKnown: true,
+	}
+	if err := persistSession(root, session); err != nil {
+		t.Fatal(err)
+	}
+
+	publicationErr := errors.New("injected rejected-resume publication failure")
+	var launches atomic.Int32
+	err = resume(ResumeOptions{
+		Root: root, Name: session.Name, PromptArgs: []string{"resume"}, Env: []string{},
+		LookPath: alwaysFound,
+		VersionLookup: func(_ string, agent string) (string, error) {
+			return supportedProviderVersions[agent], nil
+		},
+		NewCommand: func(string, ...string) *exec.Cmd {
+			launches.Add(1)
+			return exec.Command("/bin/sh", "-c", "exit 0") // #nosec G204 -- fixed test command must remain unlaunched.
+		},
+	}, func(string, *RunRecord) error {
+		return publicationErr
+	})
+	requireDispatchExitCode(t, err, ExitConfig)
+	if !errors.Is(err, publicationErr) || !strings.Contains(err.Error(), "already active in run "+active.Record.ID) {
+		t.Fatalf("Resume error = %v, want claim rejection and publication failure", err)
+	}
+	if launches.Load() != 0 {
+		t.Fatalf("provider launches = %d, want 0", launches.Load())
+	}
+	retained, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retained != session {
+		t.Fatalf("publication failure mutated active mapping: before = %#v, after = %#v", session, retained)
+	}
+	records, warnings, err := listRunRecords(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 || len(records) != 2 {
+		t.Fatalf("run evidence = %#v, warnings = %#v", records, warnings)
+	}
+	for _, record := range records {
+		if record.ID != active.Record.ID && record.State != dispatchStatePending {
+			t.Fatalf("failed terminal publication changed attempted record: %#v", record)
+		}
+	}
+}
+
 func TestRunUsesConfiguredDefaultAndHonorsQuietOutput(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	replaceDispatchConfigText(t, root, "instruction_token_threshold = 50000", "instruction_token_threshold = 1")

--- a/internal/agentdispatch/failure_contract_test.go
+++ b/internal/agentdispatch/failure_contract_test.go
@@ -111,6 +111,7 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	}
 
 	failedRun := newRun(t)
+	terminationTestDeadline := 3 * providerTerminationGrace
 	failedStarted := time.Now()
 	_, err = executeProvider(providerCommand{
 		Path:       "/bin/sh",
@@ -121,7 +122,7 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 		Structured: true,
 	}, nil, failedRun, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
-	if elapsed := time.Since(failedStarted); elapsed > 2*time.Second {
+	if elapsed := time.Since(failedStarted); elapsed > terminationTestDeadline {
 		t.Fatalf("reducer failure waited %s for a SIGTERM-ignoring provider", elapsed)
 	}
 
@@ -140,7 +141,7 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 		return exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
 	}, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitUnavailable)
-	if elapsed := time.Since(publicationStarted); elapsed > 2*time.Second {
+	if elapsed := time.Since(publicationStarted); elapsed > terminationTestDeadline {
 		t.Fatalf("running-state publication failure waited %s for a SIGTERM-ignoring provider", elapsed)
 	}
 

--- a/internal/agentdispatch/failure_contract_test.go
+++ b/internal/agentdispatch/failure_contract_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResumeRejectsPendingDisabledAndUnavailableMappings(t *testing.T) {
@@ -110,15 +111,38 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	}
 
 	failedRun := newRun(t)
+	failedStarted := time.Now()
 	_, err = executeProvider(providerCommand{
 		Path:       "/bin/sh",
-		Args:       []string{"-c", `printf '{"type":"turn.failed","message":"provider refused"}\n'`},
+		Args:       []string{"-c", `trap '' TERM; printf '{"type":"turn.failed","message":"provider refused"}\n'; while :; do sleep 1; done`},
 		Env:        os.Environ(),
 		Provider:   AgentCodex,
 		SessionID:  runtimeSessionID,
 		Structured: true,
 	}, nil, failedRun, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
+	if elapsed := time.Since(failedStarted); elapsed > 2*time.Second {
+		t.Fatalf("reducer failure waited %s for a SIGTERM-ignoring provider", elapsed)
+	}
+
+	publicationRun := newRun(t)
+	publicationStarted := time.Now()
+	_, err = executeProvider(providerCommand{
+		Path: "/bin/sh", Env: os.Environ(), Provider: AgentAntigravity, Plain: true,
+	}, nil, publicationRun, root, func(string, ...string) *exec.Cmd {
+		current, loadErr := loadRunRecord(root, publicationRun.Record.ID)
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		if writeErr := writeRunRecord(publicationRun.Dir, &current); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+		return exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
+	}, func(string) error { return nil })
+	requireDispatchExitCode(t, err, ExitUnavailable)
+	if elapsed := time.Since(publicationStarted); elapsed > 2*time.Second {
+		t.Fatalf("running-state publication failure waited %s for a SIGTERM-ignoring provider", elapsed)
+	}
 
 	timeoutRun := newRun(t)
 	timeoutLog := filepath.Join(timeoutRun.Dir, "antigravity.log")

--- a/internal/agentdispatch/fanout.go
+++ b/internal/agentdispatch/fanout.go
@@ -43,6 +43,7 @@ type fanoutCoordinatorState struct {
 	loadManifest           func(root string, id string) (FanoutManifest, error)
 	writeManifest          func(root string, manifest FanoutManifest) error
 	writePreparedRunRecord func(dir string, record *RunRecord) error
+	reserveSession         func(root string, run *dispatchRun) (Session, error)
 }
 
 func defaultFanoutCoordinatorState() fanoutCoordinatorState {
@@ -51,6 +52,7 @@ func defaultFanoutCoordinatorState() fanoutCoordinatorState {
 		loadManifest:           loadFanoutManifest,
 		writeManifest:          writeFanoutManifest,
 		writePreparedRunRecord: writeRunRecord,
+		reserveSession:         reserveSession,
 	}
 }
 
@@ -181,9 +183,10 @@ func fanout(opts FanoutOptions, coordinatorState fanoutCoordinatorState) error {
 			failPreparedFanoutChildren(opts.Root, prepared, stderr, err, coordinatorState.writePreparedRunRecord)
 			return err
 		}
-		session, reserveErr := reserveSession(opts.Root, run)
+		session, reserveErr := coordinatorState.reserveSession(opts.Root, run)
 		if reserveErr != nil {
-			failPreparedFanoutChildren(opts.Root, prepared, stderr, reserveErr, coordinatorState.writePreparedRunRecord)
+			current := preparedFanoutChild{request: dispatchExecution{Root: opts.Root, Run: run, Session: Session{Name: run.Record.Name}}}
+			failPreparedFanoutChildren(opts.Root, append(prepared, current), stderr, reserveErr, coordinatorState.writePreparedRunRecord)
 			return reserveErr
 		}
 		prepared = append(prepared, preparedFanoutChild{target: candidate.spec, request: dispatchExecution{
@@ -325,6 +328,9 @@ func failPreparedFanoutChildren(root string, prepared []preparedFanoutChild, std
 		record.TerminalReason = fmt.Sprintf("fanout preparation failed before launch: %v", cause)
 		if err := publishRunRecord(child.request.Run.Dir, &record); err != nil {
 			_, _ = fmt.Fprintf(stderr, "warning: could not finalize prepared fanout child %s: %v\n", record.ID, err)
+		}
+		if child.request.Session.Name == "" {
+			continue
 		}
 		if err := releaseConversation(root, child.request.Session.Name, record.ID); err != nil {
 			_, _ = fmt.Fprintf(stderr, "warning: could not release claim for fanout child %s: %v\n", child.request.Session.Name, err)

--- a/internal/agentdispatch/fanout.go
+++ b/internal/agentdispatch/fanout.go
@@ -39,16 +39,18 @@ type FanoutManifest struct {
 }
 
 type fanoutCoordinatorState struct {
-	loadRunRecord func(root string, id string) (RunRecord, error)
-	loadManifest  func(root string, id string) (FanoutManifest, error)
-	writeManifest func(root string, manifest FanoutManifest) error
+	loadRunRecord          func(root string, id string) (RunRecord, error)
+	loadManifest           func(root string, id string) (FanoutManifest, error)
+	writeManifest          func(root string, manifest FanoutManifest) error
+	writePreparedRunRecord func(dir string, record *RunRecord) error
 }
 
 func defaultFanoutCoordinatorState() fanoutCoordinatorState {
 	return fanoutCoordinatorState{
-		loadRunRecord: loadRunRecord,
-		loadManifest:  loadFanoutManifest,
-		writeManifest: writeFanoutManifest,
+		loadRunRecord:          loadRunRecord,
+		loadManifest:           loadFanoutManifest,
+		writeManifest:          writeFanoutManifest,
+		writePreparedRunRecord: writeRunRecord,
 	}
 }
 
@@ -167,7 +169,7 @@ func fanout(opts FanoutOptions, coordinatorState fanoutCoordinatorState) error {
 	for _, candidate := range candidates {
 		run, runErr := newDispatchRun(opts.Root, candidate.target.Name, candidate.version, dispatchModeFresh)
 		if runErr != nil {
-			failPreparedFanoutChildren(opts.Root, prepared, stderr, runErr)
+			failPreparedFanoutChildren(opts.Root, prepared, stderr, runErr, coordinatorState.writePreparedRunRecord)
 			return runErr
 		}
 		run.Record.FanoutGroupID = groupID
@@ -175,13 +177,13 @@ func fanout(opts FanoutOptions, coordinatorState fanoutCoordinatorState) error {
 		if parent, ok := clients.GetEnv(env, "AL_RUN_ID"); ok {
 			run.Record.ParentRunID = parent
 		}
-		if err := writeRunRecord(run.Dir, &run.Record); err != nil {
-			failPreparedFanoutChildren(opts.Root, prepared, stderr, err)
+		if err := coordinatorState.writePreparedRunRecord(run.Dir, &run.Record); err != nil {
+			failPreparedFanoutChildren(opts.Root, prepared, stderr, err, coordinatorState.writePreparedRunRecord)
 			return err
 		}
 		session, reserveErr := reserveSession(opts.Root, run)
 		if reserveErr != nil {
-			failPreparedFanoutChildren(opts.Root, prepared, stderr, reserveErr)
+			failPreparedFanoutChildren(opts.Root, prepared, stderr, reserveErr, coordinatorState.writePreparedRunRecord)
 			return reserveErr
 		}
 		prepared = append(prepared, preparedFanoutChild{target: candidate.spec, request: dispatchExecution{
@@ -197,7 +199,7 @@ func fanout(opts FanoutOptions, coordinatorState fanoutCoordinatorState) error {
 		manifest.Children[index] = FanoutChild{RunID: prepared[index].request.Run.Record.ID, Name: prepared[index].request.Session.Name, Target: prepared[index].target, Status: dispatchStatePending, ResultPath: prepared[index].request.Run.Record.AnswerPath}
 	}
 	if err := writeFanoutManifest(opts.Root, manifest); err != nil {
-		failPreparedFanoutChildren(opts.Root, prepared, stderr, err)
+		failPreparedFanoutChildren(opts.Root, prepared, stderr, err, coordinatorState.writePreparedRunRecord)
 		return err
 	}
 	handles := make([]executionHandle, len(prepared))
@@ -313,7 +315,7 @@ func fanoutPath(root string, id string) string {
 // failPreparedFanoutChildren finalizes children that were recorded and
 // reserved but never launched, so a preparation failure does not leave
 // pending runs whose claims only a per-run cancel could release.
-func failPreparedFanoutChildren(root string, prepared []preparedFanoutChild, stderr io.Writer, cause error) {
+func failPreparedFanoutChildren(root string, prepared []preparedFanoutChild, stderr io.Writer, cause error, publishRunRecord func(string, *RunRecord) error) {
 	for _, child := range prepared {
 		record := child.request.Run.Record
 		now := time.Now().UTC()
@@ -321,9 +323,8 @@ func failPreparedFanoutChildren(root string, prepared []preparedFanoutChild, std
 		record.RecoveryState = recoveryRetrySafe
 		record.CompletedAt = &now
 		record.TerminalReason = fmt.Sprintf("fanout preparation failed before launch: %v", cause)
-		if err := writeRunRecord(child.request.Run.Dir, &record); err != nil {
+		if err := publishRunRecord(child.request.Run.Dir, &record); err != nil {
 			_, _ = fmt.Fprintf(stderr, "warning: could not finalize prepared fanout child %s: %v\n", record.ID, err)
-			continue
 		}
 		if err := releaseConversation(root, child.request.Session.Name, record.ID); err != nil {
 			_, _ = fmt.Fprintf(stderr, "warning: could not release claim for fanout child %s: %v\n", child.request.Session.Name, err)

--- a/internal/agentdispatch/fanout_test.go
+++ b/internal/agentdispatch/fanout_test.go
@@ -92,7 +92,7 @@ func TestFanoutPrepFailureFinalizesPreparedChildren(t *testing.T) {
 	prepared := []preparedFanoutChild{{request: dispatchExecution{Root: root, Run: run, Session: session}}}
 
 	var warnings bytes.Buffer
-	failPreparedFanoutChildren(root, prepared, &warnings, errDispatchRunNotFound)
+	failPreparedFanoutChildren(root, prepared, &warnings, errDispatchRunNotFound, writeRunRecord)
 	if warnings.Len() != 0 {
 		t.Fatalf("finalization warned unexpectedly: %q", warnings.String())
 	}
@@ -112,6 +112,75 @@ func TestFanoutPrepFailureFinalizesPreparedChildren(t *testing.T) {
 	}
 	if err := Delete(root, session.Name); err != nil {
 		t.Fatalf("Delete after prep failure: %v", err)
+	}
+}
+
+func TestFanoutPrepPublicationFailureStillReleasesPreparedClaim(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	preparationErr := errors.New("injected fanout preparation failure")
+	publicationErr := errors.New("injected prepared-child terminal publication failure")
+	state := defaultFanoutCoordinatorState()
+	var pendingWrites atomic.Int32
+	state.writePreparedRunRecord = func(dir string, record *RunRecord) error {
+		if record.State == dispatchStateFailed {
+			return publicationErr
+		}
+		if pendingWrites.Add(1) == 2 {
+			return preparationErr
+		}
+		return writeRunRecord(dir, record)
+	}
+	var launches atomic.Int32
+	var warnings bytes.Buffer
+
+	err := fanout(FanoutOptions{
+		Root: root, Targets: []FanoutTarget{{Agent: AgentCodex}, {Agent: AgentCodex}},
+		PromptArgs: []string{"shared"}, Stderr: &warnings, Env: []string{}, LookPath: alwaysFound,
+		VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil },
+		NewCommand: func(string, ...string) *exec.Cmd {
+			launches.Add(1)
+			return exec.Command("/bin/sh", "-c", "exit 0") // #nosec G204 -- fixed test command must remain unlaunched.
+		},
+	}, state)
+	if !errors.Is(err, preparationErr) {
+		t.Fatalf("Fanout error = %v, want preparation failure", err)
+	}
+	if launches.Load() != 0 {
+		t.Fatalf("provider launches = %d, want 0", launches.Load())
+	}
+	if !strings.Contains(warnings.String(), publicationErr.Error()) {
+		t.Fatalf("rollback warnings = %q, want publication failure", warnings.String())
+	}
+
+	runEntries, err := os.ReadDir(dispatchRunPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runEntries) != 2 {
+		t.Fatalf("run count = %d, want 2", len(runEntries))
+	}
+	var preparedRecord RunRecord
+	for _, entry := range runEntries {
+		record, loadErr := loadRunRecord(root, entry.Name())
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		if record.Name != "" {
+			preparedRecord = record
+		}
+	}
+	if preparedRecord.ID == "" {
+		t.Fatalf("prepared child record not found in %#v", runEntries)
+	}
+	if preparedRecord.State != dispatchStatePending {
+		t.Fatalf("failed terminal publication changed durable record: %#v", preparedRecord)
+	}
+	session, err := loadSession(root, preparedRecord.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ActiveRunID != "" {
+		t.Fatalf("terminal publication failure retained prepared claim: %#v", session)
 	}
 }
 
@@ -216,7 +285,7 @@ func TestFanoutPartialFailurePreservesCompleteTerminalEvidence(t *testing.T) {
 	}
 }
 
-func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
+func TestFanoutCancellationReleasesEachClaimAfterGroupDeath(t *testing.T) {
 	root := t.TempDir()
 	manifestID, err := newUUID()
 	if err != nil {
@@ -227,13 +296,17 @@ func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
 		run     *dispatchRun
 		session Session
 		cmd     *exec.Cmd
+		wait    chan error
 	}
 	children := make([]liveChild, 0, 2)
 	defer func() {
 		for _, child := range children {
 			if processAlive(child.cmd.Process.Pid) == processStatusAlive {
 				_ = syscall.Kill(-child.cmd.Process.Pid, syscall.SIGKILL)
-				_ = child.cmd.Wait()
+			}
+			select {
+			case <-child.wait:
+			default:
 			}
 		}
 	}()
@@ -252,7 +325,9 @@ func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
 		if err := cmd.Start(); err != nil {
 			t.Fatal(err)
 		}
-		children = append(children, liveChild{run: run, session: session, cmd: cmd})
+		wait := make(chan error, 1)
+		go func() { wait <- cmd.Wait() }()
+		children = append(children, liveChild{run: run, session: session, cmd: cmd, wait: wait})
 		waitForFanoutTestPath(t, readyPath)
 		run.Record.State = dispatchStateRunning
 		run.Record.RecoveryState = recoveryAcceptanceUnknown
@@ -278,6 +353,9 @@ func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
 		t.Fatalf("cancelled fanout manifest = %#v", terminalManifest)
 	}
 	for _, child := range children {
+		if err := <-child.wait; err == nil {
+			t.Fatal("automatically SIGKILLed fanout child exited successfully")
+		}
 		record, err := loadRunRecord(root, child.run.Record.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -286,8 +364,8 @@ func TestFanoutCancellationRetainsEachLiveChildClaim(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if record.State != dispatchStateCancelled || !processOwned(record) || retained.ActiveRunID != record.ID {
-			t.Fatalf("fanout cancellation released a live child owner: record = %#v, session = %#v", record, retained)
+		if record.State != dispatchStateCancelled || processOwnership(record) != ownershipDead || retained.ActiveRunID != "" {
+			t.Fatalf("fanout cancellation did not release a dead child owner: record = %#v, session = %#v", record, retained)
 		}
 	}
 }
@@ -556,7 +634,6 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	}
 
 	startedPath := filepath.Join(t.TempDir(), "provider-started")
-	releasePath := filepath.Join(t.TempDir(), "release-provider")
 	var launches atomic.Int32
 	var firstCommand atomic.Pointer[exec.Cmd]
 	var firstFinished atomic.Bool
@@ -575,7 +652,7 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 	})
 	command := func(string, ...string) *exec.Cmd {
 		if launches.Add(1) == 1 {
-			cmd := exec.Command("/bin/sh", "-c", `trap 'while [ ! -f "$1" ]; do sleep 0.01; done; exit 0' TERM; touch "$2"; while :; do sleep 1; done`, "sh", releasePath, startedPath) // #nosec G204 -- test-owned paths passed as positional arguments.
+			cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; touch "$1"; while :; do sleep 1; done`, "sh", startedPath) // #nosec G204 -- test-owned path passed as a positional argument.
 			firstCommand.Store(cmd)
 			return cmd
 		}
@@ -590,39 +667,60 @@ func TestConcurrentResumeRejectsSecondOwnerWithActiveRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForFanoutRunState(t, root, active.ActiveRunID, dispatchStateRunning)
-	if err := Cancel(CancelRequest{Root: root, ID: active.ActiveRunID}); err != nil {
-		t.Fatalf("Cancel first resume: %v", err)
-	}
-	cancelledOwner, err := loadRunRecord(root, active.ActiveRunID)
+	activeClaim, err := loadSession(root, session.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cancelledOwner.State != dispatchStateCancelled || !processOwned(cancelledOwner) {
-		t.Fatalf("cancel did not preserve live owner evidence: %#v", cancelledOwner)
-	}
-	afterCancel, err := loadSession(root, session.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if afterCancel.ActiveRunID != active.ActiveRunID {
-		t.Fatalf("cancel released the live owner claim: %#v", afterCancel)
+	if activeClaim.ActiveRunID != active.ActiveRunID {
+		t.Fatalf("running provider did not retain its active claim: %#v", activeClaim)
 	}
 	err = Resume(ResumeOptions{Root: root, Name: session.Name, PromptArgs: []string{"two"}, Env: []string{}, LookPath: alwaysFound, VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil }, NewCommand: command})
 	if err == nil || !strings.Contains(err.Error(), "already active in run") {
 		t.Fatalf("second resume error = %v", err)
 	}
+	records, warnings, listErr := listRunRecords(root)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("list run warnings = %#v", warnings)
+	}
+	var rejected *RunRecord
+	for index := range records {
+		if records[index].Mode == dispatchModeResume && records[index].ID != active.ActiveRunID && records[index].State == dispatchStateFailed {
+			rejected = &records[index]
+			break
+		}
+	}
+	if rejected == nil {
+		t.Fatalf("rejected resume did not publish terminal attempted-run evidence: %#v", records)
+	}
+	if rejected.RecoveryState != recoveryRetrySafe || rejected.CompletedAt == nil || rejected.TerminalReason != err.Error() {
+		t.Fatalf("rejected resume evidence = %#v, error = %v", rejected, err)
+	}
 	blocked, err := loadSession(root, session.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if blocked != afterCancel {
-		t.Fatalf("blocked resume mutated conversation mapping: before = %#v, after = %#v", afterCancel, blocked)
+	if blocked != activeClaim {
+		t.Fatalf("blocked resume mutated conversation mapping: before = %#v, after = %#v", activeClaim, blocked)
+	}
+	expired := time.Now().UTC().Add(-dispatchSessionRetention - time.Hour)
+	rejected.CompletedAt = &expired
+	if err := writeRunRecord(filepath.Join(dispatchRunPath(root), rejected.ID), rejected); err != nil {
+		t.Fatalf("age rejected resume evidence: %v", err)
+	}
+	if err := pruneDispatchEvidence(root, time.Now().UTC()); err != nil {
+		t.Fatalf("prune rejected resume evidence: %v", err)
+	}
+	if _, err := loadRunRecord(root, rejected.ID); !errors.Is(err, errDispatchRunNotFound) {
+		t.Fatalf("expired rejected resume evidence remains: %v", err)
 	}
 	if launches.Load() != 1 {
 		t.Fatalf("provider launches = %d, want 1", launches.Load())
 	}
-	if err := os.WriteFile(releasePath, []byte("release"), 0o600); err != nil {
-		t.Fatalf("release cancelled provider: %v", err)
+	if err := Cancel(CancelRequest{Root: root, ID: active.ActiveRunID}); err != nil {
+		t.Fatalf("Cancel first resume: %v", err)
 	}
 	requireDispatchExitCode(t, <-firstDone, ExitTargetFailure)
 	firstFinished.Store(true)

--- a/internal/agentdispatch/fanout_test.go
+++ b/internal/agentdispatch/fanout_test.go
@@ -184,6 +184,45 @@ func TestFanoutPrepPublicationFailureStillReleasesPreparedClaim(t *testing.T) {
 	}
 }
 
+func TestFanoutReservationFailureFinalizesCurrentChildAndReleasesPartialClaim(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	reservationErr := errors.New("injected fanout reservation failure")
+	state := defaultFanoutCoordinatorState()
+	state.reserveSession = func(root string, run *dispatchRun) (Session, error) {
+		if _, err := reserveSession(root, run); err != nil {
+			return Session{}, err
+		}
+		return Session{}, reservationErr
+	}
+
+	err := fanout(FanoutOptions{
+		Root: root, Targets: []FanoutTarget{{Agent: AgentCodex}, {Agent: AgentClaude}}, PromptArgs: []string{"shared"},
+		Env: []string{}, LookPath: alwaysFound,
+		VersionLookup: func(_ string, agent string) (string, error) { return supportedProviderVersions[agent], nil },
+	}, state)
+	if !errors.Is(err, reservationErr) {
+		t.Fatalf("Fanout error = %v, want reservation failure", err)
+	}
+	records, warnings, err := listRunRecords(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 || len(records) != 1 {
+		t.Fatalf("run evidence = %#v, warnings = %#v", records, warnings)
+	}
+	record := records[0]
+	if record.State != dispatchStateFailed || record.RecoveryState != recoveryRetrySafe || record.CompletedAt == nil {
+		t.Fatalf("reservation-failed child not finalized: %#v", record)
+	}
+	session, err := loadSession(root, record.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ActiveRunID != "" {
+		t.Fatalf("reservation-failed child retained partial claim: %#v", session)
+	}
+}
+
 func TestRetentionPrunesOnlyExpiredTerminalFanoutManifests(t *testing.T) {
 	root := t.TempDir()
 	now := time.Now().UTC()

--- a/internal/agentdispatch/lifecycle_operations_test.go
+++ b/internal/agentdispatch/lifecycle_operations_test.go
@@ -167,7 +167,7 @@ func TestRetentionRemovesOnlyExpiredUnreferencedTerminalEvidence(t *testing.T) {
 	}
 }
 
-func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
+func TestCancelEscalatesButRetainsClaimUntilOwnedProcessIsReaped(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
 	if err != nil {
@@ -184,10 +184,16 @@ func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
 		t.Fatal(err)
 	}
 	stopped := false
+	waitStarted := false
+	waitDone := make(chan error, 1)
 	defer func() {
 		if !stopped {
 			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-			_ = cmd.Wait()
+			if waitStarted {
+				<-waitDone
+			} else {
+				_ = cmd.Wait()
+			}
 		}
 	}()
 	waitForFanoutTestPath(t, readyPath)
@@ -198,9 +204,11 @@ func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
 	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
 		t.Fatal(err)
 	}
-	if err := Cancel(CancelRequest{Root: root, ID: run.Record.ID}); err != nil {
-		t.Fatalf("Cancel: %v", err)
-	}
+	waitStarted = true
+	go func() { waitDone <- cmd.Wait() }()
+	cancelDone := make(chan error, 1)
+	go func() { cancelDone <- Cancel(CancelRequest{Root: root, ID: run.Record.ID}) }()
+	waitForFanoutRunState(t, root, run.Record.ID, dispatchStateCancelled)
 	record, err := loadRunRecord(root, run.Record.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -208,39 +216,38 @@ func TestCancelRetainsClaimUntilOwnedProcessIsProvablyDead(t *testing.T) {
 	if record.State != dispatchStateCancelled || record.RecoveryState != recoveryAcceptanceUnknown {
 		t.Fatalf("cancelled record = %#v", record)
 	}
-	retained, err := loadSession(root, session.Name)
+	retainedDuringGrace, err := loadSession(root, session.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if retained.ActiveRunID != run.Record.ID || !processOwned(record) {
-		t.Fatalf("cancel released a claim while its owned process remained live: session = %#v, record = %#v", retained, record)
+	if retainedDuringGrace.ActiveRunID != run.Record.ID || !processOwned(record) {
+		t.Fatalf("cancel released a claim during the graceful shutdown window: session = %#v, record = %#v", retainedDuringGrace, record)
+	}
+	select {
+	case err := <-cancelDone:
+		if err != nil {
+			t.Fatalf("Cancel: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Cancel did not finish after bounded forced escalation")
+	}
+	if err := <-waitDone; err == nil {
+		t.Fatal("automatically SIGKILLed test process exited successfully")
+	}
+	stopped = true
+	released, err := loadSession(root, session.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released.ActiveRunID != "" {
+		t.Fatalf("cancel retained the claim after proving process-group death: %#v", released)
 	}
 	replacement, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeResume)
 	if err != nil {
 		t.Fatal(err)
 	}
-	beforeBlockedClaim := retained
-	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err == nil {
-		t.Fatal("cancelled live owner was replaced")
-	} else {
-		requireDispatchExitCode(t, err, ExitUnavailable)
-	}
-	afterBlockedClaim, err := loadSession(root, session.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if afterBlockedClaim != beforeBlockedClaim {
-		t.Fatalf("blocked replacement mutated conversation mapping: before = %#v, after = %#v", beforeBlockedClaim, afterBlockedClaim)
-	}
-	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-		t.Fatalf("stop test process group: %v", err)
-	}
-	if err := cmd.Wait(); err == nil {
-		t.Fatal("SIGKILLed test process exited successfully")
-	}
-	stopped = true
 	if _, err := claimConversation(root, session.Name, replacement.Record.ID); err != nil {
-		t.Fatalf("replace cancelled claim after conservative dead-owner proof: %v", err)
+		t.Fatalf("replace cancelled claim after process-group death proof: %v", err)
 	}
 	recovered, err := loadSession(root, session.Name)
 	if err != nil {

--- a/internal/agentdispatch/operations.go
+++ b/internal/agentdispatch/operations.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -311,13 +310,13 @@ func Cancel(request CancelRequest) error {
 	if terminalDispatchState(record.State) {
 		return exitError(ExitUnavailable, fmt.Sprintf("dispatch run %s is already terminal (%s)", record.ID, record.State))
 	}
+	var ownedGroup *ownedProviderProcessGroup
 	if record.State == dispatchStateRunning {
-		if !processOwned(record) || record.ProcessGroupID <= 0 {
-			return exitError(ExitUnavailable, fmt.Sprintf("dispatch run %s has no live owned process to cancel", record.ID))
+		group, groupErr := verifiedProviderProcessGroup(record)
+		if groupErr != nil {
+			return wrapExitError(ExitUnavailable, fmt.Sprintf("dispatch run %s has no live owned process to cancel", record.ID), groupErr)
 		}
-		if err := syscall.Kill(-record.ProcessGroupID, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
-			return wrapExitError(ExitTargetFailure, "cancel dispatch process group", err)
-		}
+		ownedGroup = &group
 	} else if record.State != dispatchStatePending && record.State != dispatchStateStarting {
 		return exitError(ExitUnavailable, fmt.Sprintf("dispatch run %s cannot be cancelled from state %s", record.ID, record.State))
 	}
@@ -329,9 +328,20 @@ func Cancel(request CancelRequest) error {
 	if err := writeRunRecord(filepathForRun(request.Root, record.ID), &record); err != nil {
 		return err
 	}
+	if ownedGroup != nil {
+		if err := ownedGroup.terminateReverified(providerTerminationGrace); err != nil {
+			if processOwnership(record) == ownershipDead {
+				return nil
+			}
+			return wrapExitError(ExitTargetFailure, "cancel dispatch process group", err)
+		}
+		if err := releaseConversation(request.Root, record.Name, record.ID); err != nil {
+			return err
+		}
+	}
 	// The owning execution releases the claim after its provider wait path has
-	// stopped. Cancel returning only records intent and sends SIGTERM; neither
-	// action proves that the execution no longer owns the conversation.
+	// stopped. Cancel may release it first only after the shared terminator has
+	// proven that the complete process group is gone.
 	return nil
 }
 

--- a/internal/agentdispatch/operations.go
+++ b/internal/agentdispatch/operations.go
@@ -330,10 +330,9 @@ func Cancel(request CancelRequest) error {
 	}
 	if ownedGroup != nil {
 		if err := ownedGroup.terminateReverified(providerTerminationGrace); err != nil {
-			if processOwnership(record) == ownershipDead {
-				return nil
+			if processOwnership(record) != ownershipDead || !providerProcessGroupDead(record.ProcessGroupID) {
+				return wrapExitError(ExitTargetFailure, "cancel dispatch process group", err)
 			}
-			return wrapExitError(ExitTargetFailure, "cancel dispatch process group", err)
 		}
 		if err := releaseConversation(request.Root, record.Name, record.ID); err != nil {
 			return err

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -145,6 +144,16 @@ func executeProvider(
 	run.Record.PID = cmd.Process.Pid
 	run.Record.ProcessGroupID = cmd.Process.Pid
 	run.Record.ProcessStartIdentity = processStartIdentity(cmd.Process.Pid)
+	termination, err := newStartedProviderTermination(cmd, run.Record, providerTerminationGrace)
+	if err != nil {
+		// The exec.Cmd is direct proof that this leader is ours, but without a
+		// durable start identity Agent Layer must not signal its process group.
+		// Kill only the directly owned leader and fail before publishing running
+		// state or accepting provider output.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return executionResult{}, wrapExitError(ExitTargetFailure, "verify dispatch provider process-group ownership", err)
+	}
 	run.Record.State = dispatchStateRunning
 	run.Record.RecoveryState = recoveryAcceptanceUnknown
 	started := time.Now().UTC()
@@ -161,13 +170,14 @@ func executeProvider(
 			_, _ = io.Copy(io.Discard, stderrPipe)
 			close(stderrDrained)
 		}()
-		signalProviderProcess(cmd, syscall.SIGTERM)
-		_ = cmd.Wait()
+		termination.request()
 		<-stdoutDrained
 		<-stderrDrained
-		return executionResult{}, err
+		_ = cmd.Wait()
+		terminationErr := termination.providerStopped()
+		return executionResult{}, errors.Join(err, terminationErr)
 	}
-	caughtSignal, stopForwarder := installProviderSignalForwarder(cmd)
+	caughtSignal, stopForwarder := installProviderSignalForwarder(termination.request)
 	defer stopForwarder()
 
 	var result executionResult
@@ -183,7 +193,7 @@ func executeProvider(
 			semanticErr = err
 		}
 		resultMu.Unlock()
-		signalProviderProcess(cmd, syscall.SIGTERM)
+		termination.request()
 	}
 	consume := func(event providerEvent) error {
 		resultMu.Lock()
@@ -279,6 +289,7 @@ func executeProvider(
 	streamResult := <-streamErr
 	stderrResult := <-stderrErr
 	waitErr := cmd.Wait()
+	terminationErr := termination.providerStopped()
 	if signal := caughtSignal(); signal != nil {
 		if signal == os.Interrupt {
 			return executionResult{}, exitError(ExitSigint, fmt.Sprintf("%s interrupted by signal SIGINT", command.Provider))
@@ -290,6 +301,9 @@ func executeProvider(
 	}
 	if stderrResult != nil {
 		return executionResult{}, wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider diagnostics: %v", stderrResult), stderrResult)
+	}
+	if terminationErr != nil {
+		return executionResult{}, wrapExitError(ExitTargetFailure, "terminate dispatch provider process group", terminationErr)
 	}
 	resultMu.Lock()
 	currentSemanticErr := semanticErr

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -88,6 +88,25 @@ type executionResult struct {
 	Answer       string
 }
 
+// unprovenProviderTerminationError marks a provider failure whose process
+// group may still be live. Failure finalization must preserve the active claim
+// and nonterminal run evidence until a later cancellation or recovery proves
+// that ownership is dead.
+type unprovenProviderTerminationError struct{ err error }
+
+func (e *unprovenProviderTerminationError) Error() string { return e.err.Error() }
+func (e *unprovenProviderTerminationError) Unwrap() error { return e.err }
+
+// newUnprovenProviderTerminationError preserves the primary provider exit
+// classification while adding the failed group-death proof. The returned type
+// tells dispatch finalization to retain the active claim and run evidence.
+func newUnprovenProviderTerminationError(primary error, message string, proofErr error) *unprovenProviderTerminationError {
+	return &unprovenProviderTerminationError{err: errors.Join(
+		primary,
+		wrapExitError(ExitTargetFailure, message, proofErr),
+	)}
+}
+
 func executeProvider(
 	command providerCommand,
 	prompt []byte,
@@ -150,8 +169,15 @@ func executeProvider(
 		// durable start identity Agent Layer must not signal its process group.
 		// Kill only the directly owned leader and fail before publishing running
 		// state or accepting provider output.
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
+		killErr := cmd.Process.Kill()
+		waitErr := cmd.Wait()
+		if !providerProcessGroupDead(run.Record.ProcessGroupID) {
+			return executionResult{}, newUnprovenProviderTerminationError(
+				wrapExitError(ExitTargetFailure, "verify dispatch provider process-group ownership", err),
+				"verify dispatch provider process-group ownership and prove group death",
+				errors.Join(killErr, waitErr),
+			)
+		}
 		return executionResult{}, wrapExitError(ExitTargetFailure, "verify dispatch provider process-group ownership", err)
 	}
 	run.Record.State = dispatchStateRunning
@@ -175,6 +201,13 @@ func executeProvider(
 		<-stderrDrained
 		_ = cmd.Wait()
 		terminationErr := termination.providerStopped()
+		if terminationErr != nil {
+			return executionResult{}, newUnprovenProviderTerminationError(
+				err,
+				"terminate dispatch provider process group after running-state publication failure",
+				terminationErr,
+			)
+		}
 		return executionResult{}, errors.Join(err, terminationErr)
 	}
 	caughtSignal, stopForwarder := installProviderSignalForwarder(termination.request)
@@ -290,29 +323,32 @@ func executeProvider(
 	stderrResult := <-stderrErr
 	waitErr := cmd.Wait()
 	terminationErr := termination.providerStopped()
-	if signal := caughtSignal(); signal != nil {
-		if signal == os.Interrupt {
-			return executionResult{}, exitError(ExitSigint, fmt.Sprintf("%s interrupted by signal SIGINT", command.Provider))
-		}
-		return executionResult{}, exitError(ExitSigterm, fmt.Sprintf("%s interrupted by signal SIGTERM", command.Provider))
-	}
-	if streamResult != nil {
-		return executionResult{}, wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider output: %v", streamResult), streamResult)
-	}
-	if stderrResult != nil {
-		return executionResult{}, wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider diagnostics: %v", stderrResult), stderrResult)
-	}
-	if terminationErr != nil {
-		return executionResult{}, wrapExitError(ExitTargetFailure, "terminate dispatch provider process group", terminationErr)
-	}
+	signal := caughtSignal()
 	resultMu.Lock()
 	currentSemanticErr := semanticErr
 	resultMu.Unlock()
-	if currentSemanticErr != nil {
-		return executionResult{}, exitError(ExitTargetFailure, fmt.Sprintf("%s dispatch did not complete: %v", command.Provider, currentSemanticErr))
+	var primaryErr error
+	switch {
+	case signal != nil:
+		if signal == os.Interrupt {
+			primaryErr = exitError(ExitSigint, fmt.Sprintf("%s interrupted by signal SIGINT", command.Provider))
+		} else {
+			primaryErr = exitError(ExitSigterm, fmt.Sprintf("%s interrupted by signal SIGTERM", command.Provider))
+		}
+	case streamResult != nil:
+		primaryErr = wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider output: %v", streamResult), streamResult)
+	case stderrResult != nil:
+		primaryErr = wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider diagnostics: %v", stderrResult), stderrResult)
+	case currentSemanticErr != nil:
+		primaryErr = exitError(ExitTargetFailure, fmt.Sprintf("%s dispatch did not complete: %v", command.Provider, currentSemanticErr))
+	case waitErr != nil:
+		primaryErr = providerWaitError(command.Provider, waitErr)
 	}
-	if waitErr != nil {
-		return executionResult{}, providerWaitError(command.Provider, waitErr)
+	if terminationErr != nil {
+		return executionResult{}, newUnprovenProviderTerminationError(primaryErr, "terminate dispatch provider process group", terminationErr)
+	}
+	if primaryErr != nil {
+		return executionResult{}, primaryErr
 	}
 	if command.Provider == AgentAntigravity {
 		timedOut, err := antigravityTimeoutReported(run.Record.StderrPath, command.LogPath)

--- a/internal/agentdispatch/runtime_helpers.go
+++ b/internal/agentdispatch/runtime_helpers.go
@@ -168,10 +168,9 @@ type providerTermination struct {
 	completed bool
 }
 
-// newStartedProviderTermination latches the process-group ownership proved by
-// this execution's successful cmd.Start call. Unlike a later cancel command,
-// the owning execution does not need a second live-process lookup when a very
-// short provider has already exited before identity capture completes.
+// newStartedProviderTermination latches process-group ownership after cmd.Start
+// only when a durable process-start identity was captured. Once captured, a
+// later ESRCH is safe for a short-lived provider that exited during setup.
 func newStartedProviderTermination(cmd *exec.Cmd, record RunRecord, grace time.Duration) (*providerTermination, error) {
 	if cmd == nil || cmd.Process == nil || cmd.Process.Pid != record.PID || record.PID <= 0 || record.ProcessGroupID != record.PID {
 		return nil, errors.New("started provider command does not match recorded process group")
@@ -179,10 +178,11 @@ func newStartedProviderTermination(cmd *exec.Cmd, record RunRecord, grace time.D
 	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
 		return nil, errors.New("started provider command has no isolated process group")
 	}
-	if record.ProcessStartIdentity != "" {
-		if current := processStartIdentity(record.PID); current != "" && current != record.ProcessStartIdentity {
-			return nil, errors.New("started provider process identity changed before ownership capture")
-		}
+	if record.ProcessStartIdentity == "" {
+		return nil, errors.New("started provider process has no durable start identity")
+	}
+	if current := processStartIdentity(record.PID); current != "" && current != record.ProcessStartIdentity {
+		return nil, errors.New("started provider process identity changed before ownership capture")
 	}
 	if pgid, err := syscall.Getpgid(record.PID); err == nil {
 		if pgid != record.ProcessGroupID {

--- a/internal/agentdispatch/runtime_helpers.go
+++ b/internal/agentdispatch/runtime_helpers.go
@@ -141,6 +141,7 @@ func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
 				select {
 				case <-ticker.C:
 					if providerProcessGroupDead(group.pgid) {
+						proofTimer.Stop()
 						return nil
 					}
 				case <-proofTimer.C:

--- a/internal/agentdispatch/runtime_helpers.go
+++ b/internal/agentdispatch/runtime_helpers.go
@@ -60,19 +60,172 @@ func procStatStartTime(content string) string {
 	return fields[19]
 }
 
-func signalProviderProcess(cmd *exec.Cmd, sig os.Signal) {
-	if cmd == nil || cmd.Process == nil {
-		return
-	}
-	if syscallSig, ok := sig.(syscall.Signal); ok {
-		if err := syscall.Kill(-cmd.Process.Pid, syscallSig); err == nil {
-			return
-		}
-	}
-	_ = cmd.Process.Signal(sig)
+const (
+	providerTerminationGrace        = time.Second
+	providerTerminationPollInterval = 10 * time.Millisecond
+)
+
+type ownedProviderProcessGroup struct {
+	pid   int
+	pgid  int
+	start string
 }
 
-func installProviderSignalForwarder(cmd *exec.Cmd) (caught func() os.Signal, stop func()) {
+// verifiedProviderProcessGroup returns a process-group capability only when
+// the live leader still has the start identity and process group recorded by
+// Agent Layer. Once verified, the capability remains safe to use if the leader
+// exits during the grace period because its descendants keep that process
+// group ID reserved until they also exit.
+func verifiedProviderProcessGroup(record RunRecord) (ownedProviderProcessGroup, error) {
+	if record.PID <= 0 || record.ProcessGroupID <= 0 || record.ProcessStartIdentity == "" {
+		return ownedProviderProcessGroup{}, errors.New("provider process group has incomplete ownership identity")
+	}
+	group := ownedProviderProcessGroup{pid: record.PID, pgid: record.ProcessGroupID, start: record.ProcessStartIdentity}
+	if err := group.verifyLiveIdentity(); err != nil {
+		return ownedProviderProcessGroup{}, err
+	}
+	return group, nil
+}
+
+func (group ownedProviderProcessGroup) verifyLiveIdentity() error {
+	if current := processStartIdentity(group.pid); current == "" || current != group.start {
+		return errors.New("provider process group ownership identity no longer matches")
+	}
+	pgid, err := syscall.Getpgid(group.pid)
+	if err != nil {
+		return fmt.Errorf("read provider process group: %w", err)
+	}
+	if pgid != group.pgid || pgid != group.pid {
+		return fmt.Errorf("provider process group mismatch: pid %d, recorded group %d, live group %d", group.pid, group.pgid, pgid)
+	}
+	return nil
+}
+
+func providerProcessGroupDead(pgid int) bool {
+	if pgid <= 0 {
+		return true
+	}
+	return errors.Is(syscall.Kill(-pgid, 0), syscall.ESRCH)
+}
+
+// terminate sends SIGTERM to one verified Agent Layer-owned process group,
+// escalates to SIGKILL after the bounded grace period, and returns only after
+// group death is proven or a second bounded proof window expires.
+func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
+	if err := syscall.Kill(-group.pgid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("send SIGTERM to provider process group: %w", err)
+	}
+	if grace <= 0 {
+		grace = providerTerminationGrace
+	}
+	timer := time.NewTimer(grace)
+	ticker := time.NewTicker(providerTerminationPollInterval)
+	defer timer.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if providerProcessGroupDead(group.pgid) {
+				return nil
+			}
+		case <-timer.C:
+			if err := syscall.Kill(-group.pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				return fmt.Errorf("send SIGKILL to provider process group after %s grace: %w", grace, err)
+			}
+			proofTimer := time.NewTimer(grace)
+			defer proofTimer.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if providerProcessGroupDead(group.pgid) {
+						return nil
+					}
+				case <-proofTimer.C:
+					return fmt.Errorf("provider process group %d remained live %s after SIGKILL", group.pgid, grace)
+				}
+			}
+		}
+	}
+}
+
+func (group ownedProviderProcessGroup) terminateReverified(grace time.Duration) error {
+	if err := group.verifyLiveIdentity(); err != nil {
+		return err
+	}
+	return group.terminate(grace)
+}
+
+type providerTermination struct {
+	group     ownedProviderProcessGroup
+	grace     time.Duration
+	done      chan error
+	mu        sync.Mutex
+	requested bool
+	completed bool
+}
+
+// newStartedProviderTermination latches the process-group ownership proved by
+// this execution's successful cmd.Start call. Unlike a later cancel command,
+// the owning execution does not need a second live-process lookup when a very
+// short provider has already exited before identity capture completes.
+func newStartedProviderTermination(cmd *exec.Cmd, record RunRecord, grace time.Duration) (*providerTermination, error) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid != record.PID || record.PID <= 0 || record.ProcessGroupID != record.PID {
+		return nil, errors.New("started provider command does not match recorded process group")
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		return nil, errors.New("started provider command has no isolated process group")
+	}
+	if record.ProcessStartIdentity != "" {
+		if current := processStartIdentity(record.PID); current != "" && current != record.ProcessStartIdentity {
+			return nil, errors.New("started provider process identity changed before ownership capture")
+		}
+	}
+	if pgid, err := syscall.Getpgid(record.PID); err == nil {
+		if pgid != record.ProcessGroupID {
+			return nil, fmt.Errorf("started provider process group mismatch: recorded group %d, live group %d", record.ProcessGroupID, pgid)
+		}
+	} else if !errors.Is(err, syscall.ESRCH) {
+		return nil, fmt.Errorf("read started provider process group: %w", err)
+	}
+	group := ownedProviderProcessGroup{pid: record.PID, pgid: record.ProcessGroupID, start: record.ProcessStartIdentity}
+	return &providerTermination{group: group, grace: grace, done: make(chan error, 1)}, nil
+}
+
+func (termination *providerTermination) request() {
+	termination.mu.Lock()
+	if termination.requested || termination.completed {
+		termination.mu.Unlock()
+		return
+	}
+	termination.requested = true
+	termination.mu.Unlock()
+	go func() {
+		termination.done <- termination.group.terminate(termination.grace)
+		close(termination.done)
+	}()
+}
+
+// providerStopped completes the controller after cmd.Wait has reaped the
+// provider leader. It also joins any in-flight escalation before claim release.
+func (termination *providerTermination) providerStopped() error {
+	termination.mu.Lock()
+	if termination.completed {
+		termination.mu.Unlock()
+		return nil
+	}
+	termination.completed = true
+	requested := termination.requested
+	termination.mu.Unlock()
+	if !requested {
+		return nil
+	}
+	return <-termination.done
+}
+
+func installProviderSignalForwarder(requestTermination func()) (caught func() os.Signal, stop func()) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	done := make(chan struct{})
@@ -86,12 +239,12 @@ func installProviderSignalForwarder(cmd *exec.Cmd) (caught func() os.Signal, sto
 		for {
 			select {
 			case sig := <-signals:
-				signalProviderProcess(cmd, sig)
 				mu.Lock()
 				if first == nil {
 					first = sig
 				}
 				mu.Unlock()
+				requestTermination()
 			case <-done:
 				return
 			}

--- a/internal/agentdispatch/runtime_helpers_test.go
+++ b/internal/agentdispatch/runtime_helpers_test.go
@@ -118,6 +118,10 @@ func TestProviderTerminationRejectsMismatchedProcessIdentityWithoutSignalling(t 
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		_ = cmd.Wait()
 	}()
+	missingIdentity := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid}
+	if _, err := newStartedProviderTermination(cmd, missingIdentity, time.Second); err == nil {
+		t.Fatal("missing process-start identity produced a termination controller")
+	}
 	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: "different-start-identity"}
 	if _, err := verifiedProviderProcessGroup(record); err == nil {
 		t.Fatal("mismatched process identity produced a termination capability")

--- a/internal/agentdispatch/runtime_helpers_test.go
+++ b/internal/agentdispatch/runtime_helpers_test.go
@@ -2,6 +2,7 @@ package agentdispatch
 
 import (
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,38 +13,118 @@ import (
 	"time"
 )
 
-func TestSignalProviderProcessTerminatesProviderProcessGroup(t *testing.T) {
-	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
-	cmd := exec.Command("/bin/sh", "-c", `sleep 30 & child=$!; printf '%s\n' "$child" > "$1"; wait "$child"`, "sh", childPIDPath) // #nosec G204 -- fixed test-only shell command.
+func TestProviderTerminationAllowsGracefulProcessGroupExit(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	cmd := exec.Command("/bin/sh", "-c", `trap 'exit 0' TERM; touch "$1"; while :; do sleep 1; done`, "sh", readyPath) // #nosec G204 -- test-owned path passed as an argument.
 	prepareProviderProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start provider process group: %v", err)
 	}
-	waitCalled := false
-	terminated := false
+	stopped := false
 	t.Cleanup(func() {
-		if terminated {
-			return
-		}
-		// Keep the group SIGKILL armed until both the child and the group are
-		// confirmed dead. If an exit assertion below fails, the orphaned child
-		// is still alive and keeps the process group ID reserved, so signalling
-		// -pid reliably reaps the leaked sleeper.
-		signalProviderProcess(cmd, syscall.SIGKILL)
-		if !waitCalled {
+		if !stopped {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 			_ = cmd.Wait()
 		}
 	})
+	waitForFanoutTestPath(t, readyPath)
+	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: processStartIdentity(cmd.Process.Pid)}
+	termination, err := newStartedProviderTermination(cmd, record, 500*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	started := time.Now()
+	termination.request()
+	waitErr := cmd.Wait()
+	stopped = true
+	if waitErr != nil {
+		t.Fatalf("graceful provider exit: %v", waitErr)
+	}
+	if err := termination.providerStopped(); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed >= 500*time.Millisecond {
+		t.Fatalf("graceful termination took %s, want less than escalation grace", elapsed)
+	}
+}
+
+func TestProviderTerminationEscalatesAndUnblocksDescendantPipesAndWait(t *testing.T) {
+	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
+	cmd := exec.Command("/bin/sh", "-c", `trap 'exit 0' TERM; (trap '' TERM; while :; do sleep 1; done) & child=$!; printf '%s\n' "$child" > "$1"; wait "$child"`, "sh", childPIDPath) // #nosec G204 -- fixed test-only shell command.
+	prepareProviderProcessGroup(cmd)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stopped := false
+	waited := false
+	t.Cleanup(func() {
+		if !stopped {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			if !waited {
+				_ = cmd.Wait()
+			}
+		}
+	})
 	childPID := waitForProviderChildPID(t, childPIDPath)
-	signalProviderProcess(cmd, syscall.SIGTERM)
-	waitCalled = true
-	if err := cmd.Wait(); err == nil {
-		t.Fatal("provider process unexpectedly exited successfully after SIGTERM")
+	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: processStartIdentity(cmd.Process.Pid)}
+	termination, err := newStartedProviderTermination(cmd, record, 75*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutDrained := make(chan struct{})
+	stderrDrained := make(chan struct{})
+	go func() { _, _ = io.Copy(io.Discard, stdout); close(stdoutDrained) }()
+	go func() { _, _ = io.Copy(io.Discard, stderr); close(stderrDrained) }()
+
+	termination.request()
+	select {
+	case <-stdoutDrained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider stdout pipe did not drain after forced escalation")
+	}
+	select {
+	case <-stderrDrained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider stderr pipe did not drain after forced escalation")
+	}
+	waited = true
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("graceful provider leader exit: %v", err)
+	}
+	if err := termination.providerStopped(); err != nil {
+		t.Fatal(err)
 	}
 	waitForProviderProcessExit(t, childPID)
 	waitForProviderProcessGroupExit(t, cmd.Process.Pid)
-	terminated = true
+	stopped = true
+}
+
+func TestProviderTerminationRejectsMismatchedProcessIdentityWithoutSignalling(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
+	prepareProviderProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	}()
+	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: "different-start-identity"}
+	if _, err := verifiedProviderProcessGroup(record); err == nil {
+		t.Fatal("mismatched process identity produced a termination capability")
+	}
+	if err := syscall.Kill(cmd.Process.Pid, 0); err != nil {
+		t.Fatalf("identity rejection signalled unrelated process: %v", err)
+	}
 }
 
 func waitForProviderChildPID(t *testing.T, path string) int {
@@ -84,7 +165,7 @@ func waitForProviderProcessExit(t *testing.T, pid int) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("provider child %d remained alive after SIGTERM", pid)
+	t.Fatalf("provider child %d remained alive after termination", pid)
 }
 
 func waitForProviderProcessGroupExit(t *testing.T, pid int) {
@@ -96,5 +177,5 @@ func waitForProviderProcessGroupExit(t *testing.T, pid int) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("provider process group %d remained alive after SIGTERM", pid)
+	t.Fatalf("provider process group %d remained alive after termination", pid)
 }

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -382,7 +382,7 @@ func cancelledClaimReleasable(record RunRecord) bool {
 	if record.PID == 0 && record.ProcessGroupID == 0 && record.ProcessStartIdentity == "" {
 		return true
 	}
-	return processOwnership(record) == ownershipDead
+	return processOwnership(record) == ownershipDead && providerProcessGroupDead(record.ProcessGroupID)
 }
 
 // sessionOwnerRunID resolves the explicit active claim and the compatibility


### PR DESCRIPTION
## Summary

- Preserve terminal evidence when a concurrent resume is rejected, including publication failures.
- Release prepared fanout claims even when rollback terminal publication fails.
- Bound provider process-group shutdown with identity-safe `SIGTERM` to `SIGKILL` escalation and explicit death proof.

## Changes

- Join rejected-resume claim and publication errors so recovery failures remain visible.
- Separate fanout rollback publication from claim release and cover partial preparation failures.
- Centralize process-group ownership verification, bounded termination, escalation, and claim-release rules across cancellation and provider failure paths.
- Update Agent Dispatch lifecycle documentation and retire the completed shutdown issue.

## Verification

- `GOFLAGS=-buildvcs=false make ci` — passed the full documented lane in the nested workflow worktree.
- Coverage — 3,324 tests passed; 92.01% total coverage against the 90.00% threshold.
- Race lane — passed for `internal/agentdispatch`, `internal/sync`, `internal/install`, and `internal/warnings`.
- End-to-end lane — 902 checks passed with 8 upgrade scenarios executed.

## Notes

- `-buildvcs=false` only disables Go VCS stamping; it is required locally because this workflow worktree is nested beneath the intentionally bare shared Git root. GitHub Actions runs from a normal checkout.
