### PR TITLE
fix: persist dispatch session target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
 ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+CACHE_ROOT ?= $(if $(GIT_COMMON_DIR),$(abspath $(GIT_COMMON_DIR)/../.cache),$(ROOT_DIR)/.cache)
 TOOL_BIN ?= $(ROOT_DIR)/.tools/bin
 GOLANGCI_LINT_VERSION := v2.12.2
-GO_CACHE ?= $(ROOT_DIR)/.cache/go-build
-GO_MOD_CACHE ?= $(ROOT_DIR)/.cache/go-mod
+GO_CACHE ?= $(CACHE_ROOT)/go-build
+GO_MOD_CACHE ?= $(CACHE_ROOT)/go-mod
+GOLANGCI_LINT_CACHE ?= $(ROOT_DIR)/.cache/golangci-lint
 
 GO_FILES_FIND_CMD := find . -type f -name '*.go' -not -path './.tools/*' -not -path './.cache/*' -not -path './.claude/*' -not -path './.codex/*' -not -path './.gemini/*' -not -path './.agy/*' -not -path './.antigravitycli/*' -not -path './.agents/*' -not -path './.agent-layer/*' -not -path './tmp/*'
 
@@ -107,7 +110,8 @@ fmt-check: check-goimports ## Check Go formatting (gofmt + goimports)
 
 .PHONY: lint
 lint: check-golangci-lint ## Run golangci-lint
-	@GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" "$(TOOL_BIN)/golangci-lint" run ./...
+	@mkdir -p "$(GOLANGCI_LINT_CACHE)"
+	@GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" "$(TOOL_BIN)/golangci-lint" run ./...
 
 .PHONY: lint-ci-local
 lint-ci-local: check-golangci-lint ## Run fresh-cache Linux-targeted and native-host lint
@@ -157,8 +161,14 @@ tidy: ## Run go mod tidy
 .PHONY: tidy-check
 tidy-check: ## Verify go.mod/go.sum are tidy
 	@mkdir -p "$(GO_CACHE)" "$(GO_MOD_CACHE)"
-	@GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" go mod tidy
-	@git diff --exit-code
+	@before_mod="$$(git hash-object go.mod)"; before_sum="$$(git hash-object go.sum)"; \
+	  GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" go mod tidy; \
+	  after_mod="$$(git hash-object go.mod)"; after_sum="$$(git hash-object go.sum)"; \
+	  if [[ "$$before_mod" != "$$after_mod" || "$$before_sum" != "$$after_sum" ]]; then \
+	    echo "go mod tidy changed go.mod or go.sum" >&2; \
+	    git diff -- go.mod go.sum >&2; \
+	    exit 1; \
+	  fi
 
 .PHONY: coverage
 coverage: check-gotestsum ## Enforce coverage threshold (>= $(COVERAGE_THRESHOLD)) and write coverage.out

--- a/Makefile
+++ b/Makefile
@@ -161,12 +161,14 @@ tidy: ## Run go mod tidy
 .PHONY: tidy-check
 tidy-check: ## Verify go.mod/go.sum are tidy
 	@mkdir -p "$(GO_CACHE)" "$(GO_MOD_CACHE)"
-	@before_mod="$$(git hash-object go.mod)"; before_sum="$$(git hash-object go.sum)"; \
-	  GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" go mod tidy; \
-	  after_mod="$$(git hash-object go.mod)"; after_sum="$$(git hash-object go.sum)"; \
-	  if [[ "$$before_mod" != "$$after_mod" || "$$before_sum" != "$$after_sum" ]]; then \
+	@tmp_mod="$$(mktemp)" && tmp_sum="$$(mktemp)" && \
+	  cp go.mod "$$tmp_mod" && cp go.sum "$$tmp_sum" && \
+	  trap 'cp "$$tmp_mod" go.mod 2>/dev/null || true; cp "$$tmp_sum" go.sum 2>/dev/null || true; rm -f "$$tmp_mod" "$$tmp_sum"' EXIT && \
+	  GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" go mod tidy && \
+	  if ! cmp -s "$$tmp_mod" go.mod || ! cmp -s "$$tmp_sum" go.sum; then \
 	    echo "go mod tidy changed go.mod or go.sum" >&2; \
-	    git diff -- go.mod go.sum >&2; \
+	    diff -u "$$tmp_mod" go.mod >&2 || true; \
+	    diff -u "$$tmp_sum" go.sum >&2 || true; \
 	    exit 1; \
 	  fi
 

--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -45,9 +45,10 @@ al dispatch options --json
 
 Ordinary calls are always fresh. Resume resolves the provider conversation
 exclusively from the named durable mapping. New mappings also retain the exact
-resolved model and reasoning effort so later configuration changes cannot alter
-the target used by a resumed conversation; mappings created by older releases
-continue to use current configured defaults until their next attempted turn.
+resolved model and reasoning effort, including an intentionally empty
+provider-default target, so later configuration changes cannot alter the target
+used by a resumed conversation; mappings created by older releases continue to
+use current configured defaults until their next attempted turn.
 
 ## Internal coordinator and completion
 

--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -44,7 +44,10 @@ al dispatch options --json
 ```
 
 Ordinary calls are always fresh. Resume resolves the provider conversation
-exclusively from the named durable mapping.
+exclusively from the named durable mapping. New mappings also retain the exact
+resolved model and reasoning effort so later configuration changes cannot alter
+the target used by a resumed conversation; mappings created by older releases
+continue to use current configured defaults until their next attempted turn.
 
 ## Internal coordinator and completion
 

--- a/docs/agent-layer/COMMANDS.md
+++ b/docs/agent-layer/COMMANDS.md
@@ -225,7 +225,7 @@ make ci
 ```
 Run from: repo root
 Prerequisites: Go 1.26.0+, `make tools` has been run
-Notes: Includes `make tidy-check`, `make test-race` (race detector on concurrency-critical packages), `make test-release`, `make test-e2e-ci` (online e2e with required upgrade scenarios), and `make docs-cta-check`; requires network access for upgrade binary downloads. `tidy-check` permits an existing intended diff and fails only when `go mod tidy` changes the module files.
+Notes: Includes `make tidy-check`, `make test-race` (race detector on concurrency-critical packages), `make test-release`, `make test-e2e-ci` (online e2e with required upgrade scenarios), and `make docs-cta-check`; requires network access for upgrade binary downloads. `tidy-check` permits an existing intended diff, reports a validation failure when `go mod tidy` changes the module files, and propagates dependency, toolchain, network, and filesystem errors.
 GitHub Actions also runs a separate website build job using `make website-build-check` against `conn-castle/agent-layer-web`.
 The release workflow runs this target on macOS before importing signing credentials.
 

--- a/docs/agent-layer/COMMANDS.md
+++ b/docs/agent-layer/COMMANDS.md
@@ -174,6 +174,8 @@ make tidy-check
 Run from: repo root  
 Prerequisites: Go 1.26.0+  
 Notes: Fails if `go.mod`/`go.sum` would change.
+Pre-existing intended working-tree changes are allowed; the command compares
+the module files immediately before and after `go mod tidy`.
 
 ### Coverage
 
@@ -223,7 +225,7 @@ make ci
 ```
 Run from: repo root
 Prerequisites: Go 1.26.0+, `make tools` has been run
-Notes: Includes `make tidy-check`, `make test-race` (race detector on concurrency-critical packages), `make test-release`, `make test-e2e-ci` (online e2e with required upgrade scenarios), and `make docs-cta-check`; requires a clean working tree and network access for upgrade binary downloads.
+Notes: Includes `make tidy-check`, `make test-race` (race detector on concurrency-critical packages), `make test-release`, `make test-e2e-ci` (online e2e with required upgrade scenarios), and `make docs-cta-check`; requires network access for upgrade binary downloads. `tidy-check` permits an existing intended diff and fails only when `go mod tidy` changes the module files.
 GitHub Actions also runs a separate website build job using `make website-build-check` against `conn-castle/agent-layer-web`.
 The release workflow runs this target on macOS before importing signing credentials.
 

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -182,6 +182,8 @@ func resume(opts ResumeOptions, writeRejectedRunRecord func(string, *RunRecord) 
 		Stderr:        stderr,
 		Env:           env,
 		Depth:         depth + 1,
+		Model:         session.Model,
+		Effort:        session.ReasoningEffort,
 		Skill:         opts.Skill,
 		NewCommand:    opts.NewCommand,
 		VersionLookup: opts.VersionLookup,
@@ -293,6 +295,13 @@ func executeDispatch(request dispatchExecution) error {
 		command, err := buildProviderCommand(request.Target, request.Project, childEnv, request.Prompt, request.Model, request.Effort, request.Mode, session.ProviderSessionID, request.Run, request.Stderr)
 		if err != nil {
 			return finishDispatchFailure(request, &preStartFailure{err: err})
+		}
+		session.Model = command.Model
+		session.ReasoningEffort = command.Effort
+		if session.State == sessionStateDurable {
+			if err := persistSession(request.Root, session); err != nil {
+				return finishDispatchFailure(request, &preStartFailure{err: err})
+			}
 		}
 		command.WorkDir = request.WorkDir
 		request.Run.Record.ProviderLogPath = command.LogPath

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -184,6 +184,7 @@ func resume(opts ResumeOptions, writeRejectedRunRecord func(string, *RunRecord) 
 		Depth:         depth + 1,
 		Model:         session.Model,
 		Effort:        session.ReasoningEffort,
+		TargetPinned:  session.TargetPinned,
 		Skill:         opts.Skill,
 		NewCommand:    opts.NewCommand,
 		VersionLookup: opts.VersionLookup,
@@ -222,6 +223,7 @@ type dispatchExecution struct {
 	Depth         int
 	Model         string
 	Effort        string
+	TargetPinned  bool
 	Skill         string
 	NewCommand    CommandFactory
 	VersionLookup func(path string, agent string) (string, error)
@@ -292,13 +294,14 @@ func executeDispatch(request dispatchExecution) error {
 			}
 		}
 		childEnv := dispatchEnvironment(request.Env, request.Project, request.Run, request.Depth, request.Target.Name)
-		command, err := buildProviderCommand(request.Target, request.Project, childEnv, request.Prompt, request.Model, request.Effort, request.Mode, session.ProviderSessionID, request.Run, request.Stderr)
+		command, err := buildProviderCommand(request.Target, request.Project, childEnv, request.Prompt, request.Model, request.Effort, request.TargetPinned, request.Mode, session.ProviderSessionID, request.Run, request.Stderr)
 		if err != nil {
 			return finishDispatchFailure(request, &preStartFailure{err: err})
 		}
 		session.Model = command.Model
 		session.ReasoningEffort = command.Effort
 		if session.State == sessionStateDurable {
+			session.TargetPinned = true
 			if err := persistSession(request.Root, session); err != nil {
 				return finishDispatchFailure(request, &preStartFailure{err: err})
 			}

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -153,6 +153,7 @@ func buildProviderCommand(
 	prompt []byte,
 	model string,
 	effort string,
+	targetPinned bool,
 	mode string,
 	sessionID string,
 	run *dispatchRun,
@@ -177,14 +178,14 @@ func buildProviderCommand(
 			args = append(args, "--session-id", sessionID)
 		}
 		resolvedModel := strings.TrimSpace(model)
-		if resolvedModel == "" {
+		if resolvedModel == "" && !targetPinned {
 			resolvedModel = strings.TrimSpace(project.Config.Agents.Claude.Model)
 		}
 		if resolvedModel != "" {
 			args = append(args, "--model", resolvedModel)
 		}
 		resolvedEffort := strings.TrimSpace(effort)
-		if resolvedEffort == "" && !config.HasProviderPassthroughKey(project.Config.Agents.Claude.AgentSpecific, "effortLevel") {
+		if resolvedEffort == "" && !targetPinned && !config.HasProviderPassthroughKey(project.Config.Agents.Claude.AgentSpecific, "effortLevel") {
 			resolvedEffort = strings.TrimSpace(project.Config.Agents.Claude.ReasoningEffort)
 		}
 		if resolvedEffort != "" {
@@ -211,14 +212,14 @@ func buildProviderCommand(
 			args = append(args, sessionID)
 		}
 		resolvedModel := strings.TrimSpace(model)
-		if resolvedModel == "" && !config.HasProviderPassthroughKey(project.Config.Agents.Codex.AgentSpecific, config.CodexModelKey) {
+		if resolvedModel == "" && !targetPinned && !config.HasProviderPassthroughKey(project.Config.Agents.Codex.AgentSpecific, config.CodexModelKey) {
 			resolvedModel = strings.TrimSpace(project.Config.Agents.Codex.Model)
 		}
 		if resolvedModel != "" {
 			args = append(args, "--model", resolvedModel)
 		}
 		resolvedEffort := strings.TrimSpace(effort)
-		if resolvedEffort == "" && !config.HasProviderPassthroughKey(project.Config.Agents.Codex.AgentSpecific, config.CodexReasoningEffortKey) {
+		if resolvedEffort == "" && !targetPinned && !config.HasProviderPassthroughKey(project.Config.Agents.Codex.AgentSpecific, config.CodexReasoningEffortKey) {
 			resolvedEffort = strings.TrimSpace(project.Config.Agents.Codex.ReasoningEffort)
 		}
 		if resolvedEffort != "" {

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -31,7 +31,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 	if !ok {
 		t.Fatal("Claude target missing from registry")
 	}
-	claudeCommand, err := buildProviderCommand(claudeTarget, project, []string{}, []byte("prompt"), "override", "high", "fresh", runtimeSessionID, run, io.Discard)
+	claudeCommand, err := buildProviderCommand(claudeTarget, project, []string{}, []byte("prompt"), "override", "high", false, "fresh", runtimeSessionID, run, io.Discard)
 	if err != nil {
 		t.Fatalf("build Claude command: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 	if !ok {
 		t.Fatal("Codex target missing from registry")
 	}
-	codexCommand, err := buildProviderCommand(codexTarget, project, []string{}, []byte("prompt"), "", "high", "resume", runtimeSessionID, run, io.Discard)
+	codexCommand, err := buildProviderCommand(codexTarget, project, []string{}, []byte("prompt"), "", "high", false, "resume", runtimeSessionID, run, io.Discard)
 	if err != nil {
 		t.Fatalf("build Codex command: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 	project.Config.Agents.Codex.Model = "configured-codex"
 	project.Config.Agents.Codex.ReasoningEffort = "medium"
 	project.Config.Approvals.Mode = config.ApprovalModeYOLO
-	codexDefaults, err := buildProviderCommand(codexTarget, project, []string{}, []byte("prompt"), "", "", dispatchModeFresh, "", run, io.Discard)
+	codexDefaults, err := buildProviderCommand(codexTarget, project, []string{}, []byte("prompt"), "", "", false, dispatchModeFresh, "", run, io.Discard)
 	if err != nil {
 		t.Fatalf("build Codex defaults command: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 	if !ok {
 		t.Fatal("Antigravity target missing from registry")
 	}
-	if _, err := buildProviderCommand(antigravityTarget, project, []string{}, bytes.Repeat([]byte("x"), AntigravityPromptMaxBytes+1), "", "", "fresh", "", run, io.Discard); err == nil {
+	if _, err := buildProviderCommand(antigravityTarget, project, []string{}, bytes.Repeat([]byte("x"), AntigravityPromptMaxBytes+1), "", "", false, "fresh", "", run, io.Discard); err == nil {
 		t.Fatal("Antigravity accepted an argv-sized prompt")
 	} else {
 		requireDispatchExitCode(t, err, ExitUsage)
@@ -121,7 +121,7 @@ func TestClaudeDispatchPrintBackgroundWaitCeilingIsAuthoritative(t *testing.T) {
 			if got := len(envValues(childEnv, claudePrintBackgroundWaitCeilingEnv)); got != tt.inputKeyCount {
 				t.Fatalf("dispatch environment %q entries = %d, want %d: %#v", claudePrintBackgroundWaitCeilingEnv, got, tt.inputKeyCount, childEnv)
 			}
-			command, err := buildProviderCommand(claudeTarget, project, childEnv, []byte("prompt"), "", "", tt.mode, runtimeSessionID, run, io.Discard)
+			command, err := buildProviderCommand(claudeTarget, project, childEnv, []byte("prompt"), "", "", false, tt.mode, runtimeSessionID, run, io.Discard)
 			if err != nil {
 				t.Fatalf("build Claude command: %v", err)
 			}
@@ -141,7 +141,7 @@ func TestClaudeDispatchPrintBackgroundWaitCeilingIsAuthoritative(t *testing.T) {
 			if err != nil {
 				t.Fatalf("new dispatch run: %v", err)
 			}
-			command, err := buildProviderCommand(target, project, []string{"KEEP=1"}, []byte("prompt"), "", "", dispatchModeFresh, "", run, io.Discard)
+			command, err := buildProviderCommand(target, project, []string{"KEEP=1"}, []byte("prompt"), "", "", false, dispatchModeFresh, "", run, io.Discard)
 			if err != nil {
 				t.Fatalf("build %s command: %v", agent, err)
 			}

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -54,6 +54,7 @@ type Session struct {
 	Agent             string    `json:"agent"`
 	Model             string    `json:"model,omitempty"`
 	ReasoningEffort   string    `json:"reasoning_effort,omitempty"`
+	TargetPinned      bool      `json:"target_pinned,omitempty"`
 	ProviderSessionID string    `json:"provider_session_id,omitempty"`
 	CreatedAt         time.Time `json:"created_at"`
 	LastUsedAt        time.Time `json:"last_used_at"`

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -52,6 +52,8 @@ var errDispatchRunNotFound = errors.New("dispatch run record not found")
 type Session struct {
 	Name              string    `json:"name"`
 	Agent             string    `json:"agent"`
+	Model             string    `json:"model,omitempty"`
+	ReasoningEffort   string    `json:"reasoning_effort,omitempty"`
 	ProviderSessionID string    `json:"provider_session_id,omitempty"`
 	CreatedAt         time.Time `json:"created_at"`
 	LastUsedAt        time.Time `json:"last_used_at"`

--- a/internal/agentdispatch/v013_test.go
+++ b/internal/agentdispatch/v013_test.go
@@ -80,6 +80,66 @@ func TestFreshCodexThenResumeUsesOnlyDurableMapping(t *testing.T) {
 	}
 }
 
+func TestClaudeResumeKeepsFreshTargetAfterConfigurationChanges(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{ClaudeModel: "configured-model", ClaudeReasoningEffort: "medium"})
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "claude.log")
+	writeDispatchStub(t, binDir, "claude", "")
+	env := []string{"PATH=" + testPath(binDir), "AL_TEST_LOG=" + logPath}
+
+	var stderr bytes.Buffer
+	if err := Run(RunOptions{
+		Root:            root,
+		Agent:           AgentClaude,
+		Model:           "fable",
+		ReasoningEffort: "medium",
+		PromptArgs:      []string{"fresh"},
+		Env:             env,
+		Stderr:          &stderr,
+		LookPath:        mockLookPath(binDir),
+	}); err != nil {
+		t.Fatalf("fresh Claude Run: %v", err)
+	}
+	name := identityName(t, stderr.String())
+	session, err := loadSession(root, name)
+	if err != nil {
+		t.Fatalf("load Claude session: %v", err)
+	}
+	if session.Model != "fable" || session.ReasoningEffort != "medium" {
+		t.Fatalf("fresh target metadata = %#v", session)
+	}
+
+	configPath := filepath.Join(root, ".agent-layer", "config.toml")
+	configData, err := os.ReadFile(configPath) // #nosec G304 -- path is inside the test-owned temporary repository.
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	changedConfig := strings.ReplaceAll(string(configData), `model = "configured-model"`, `model = "opus"`)
+	changedConfig = strings.ReplaceAll(changedConfig, `reasoning_effort = "medium"`, `reasoning_effort = "high"`)
+	if err := os.WriteFile(configPath, []byte(changedConfig), 0o600); err != nil { // #nosec G703 -- path is inside the test-owned temporary repository.
+		t.Fatalf("change config: %v", err)
+	}
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatalf("reset provider log: %v", err)
+	}
+
+	if err := Resume(ResumeOptions{
+		Root:       root,
+		Name:       name,
+		PromptArgs: []string{"resume"},
+		Env:        env,
+		LookPath:   mockLookPath(binDir),
+	}); err != nil {
+		t.Fatalf("Resume Claude: %v", err)
+	}
+	assertFileContains(t, logPath, "ARG_7=--model")
+	assertFileContains(t, logPath, "ARG_8=fable")
+	assertFileContains(t, logPath, "ARG_9=--effort")
+	assertFileContains(t, logPath, "ARG_10=medium")
+	assertFileDoesNotContain(t, logPath, "opus")
+	assertFileDoesNotContain(t, logPath, "high")
+}
+
 func identityName(t *testing.T, stderr string) string {
 	t.Helper()
 	trimmed := strings.TrimSpace(stderr)

--- a/internal/agentdispatch/v013_test.go
+++ b/internal/agentdispatch/v013_test.go
@@ -143,6 +143,65 @@ func TestClaudeResumeKeepsFreshTargetAfterConfigurationChanges(t *testing.T) {
 	assertFileDoesNotContain(t, logPath, "high")
 }
 
+func TestClaudeResumeKeepsProviderDefaultsAfterConfigurationChanges(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "claude.log")
+	writeDispatchStub(t, binDir, "claude", "")
+	env := []string{"PATH=" + testPath(binDir), "AL_TEST_LOG=" + logPath}
+
+	var stderr bytes.Buffer
+	if err := Run(RunOptions{
+		Root:       root,
+		Agent:      AgentClaude,
+		PromptArgs: []string{"fresh"},
+		Env:        env,
+		Stderr:     &stderr,
+		LookPath:   mockLookPath(binDir),
+	}); err != nil {
+		t.Fatalf("fresh Claude Run: %v", err)
+	}
+	name := identityName(t, stderr.String())
+	session, err := loadSession(root, name)
+	if err != nil {
+		t.Fatalf("load Claude session: %v", err)
+	}
+	if !session.TargetPinned || session.Model != "" || session.ReasoningEffort != "" {
+		t.Fatalf("fresh default target metadata = %#v", session)
+	}
+
+	configPath := filepath.Join(root, ".agent-layer", "config.toml")
+	configData, err := os.ReadFile(configPath) // #nosec G304 -- path is inside the test-owned temporary repository.
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	changedConfig := strings.ReplaceAll(string(configData), `model = ""`, `model = "opus"`)
+	changedConfig = strings.ReplaceAll(changedConfig, `reasoning_effort = ""`, `reasoning_effort = "high"`)
+	if changedConfig == string(configData) {
+		t.Fatal("test config rewrite made no changes")
+	}
+	if err := os.WriteFile(configPath, []byte(changedConfig), 0o600); err != nil { // #nosec G703 -- path is inside the test-owned temporary repository.
+		t.Fatalf("change config: %v", err)
+	}
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatalf("reset provider log: %v", err)
+	}
+
+	if err := Resume(ResumeOptions{
+		Root:       root,
+		Name:       name,
+		PromptArgs: []string{"resume"},
+		Env:        env,
+		LookPath:   mockLookPath(binDir),
+	}); err != nil {
+		t.Fatalf("Resume Claude: %v", err)
+	}
+	assertFileDoesNotContain(t, logPath, "--model")
+	assertFileDoesNotContain(t, logPath, "--effort")
+	assertFileDoesNotContain(t, logPath, "opus")
+	assertFileDoesNotContain(t, logPath, "high")
+}
+
 func identityName(t *testing.T, stderr string) string {
 	t.Helper()
 	trimmed := strings.TrimSpace(stderr)

--- a/internal/agentdispatch/v013_test.go
+++ b/internal/agentdispatch/v013_test.go
@@ -116,6 +116,9 @@ func TestClaudeResumeKeepsFreshTargetAfterConfigurationChanges(t *testing.T) {
 	}
 	changedConfig := strings.ReplaceAll(string(configData), `model = "configured-model"`, `model = "opus"`)
 	changedConfig = strings.ReplaceAll(changedConfig, `reasoning_effort = "medium"`, `reasoning_effort = "high"`)
+	if changedConfig == string(configData) {
+		t.Fatal("test config rewrite made no changes")
+	}
 	if err := os.WriteFile(configPath, []byte(changedConfig), 0o600); err != nil { // #nosec G703 -- path is inside the test-owned temporary repository.
 		t.Fatalf("change config: %v", err)
 	}

--- a/internal/templates/skills/auto-skill-loop/references/modes/improve-codebase.md
+++ b/internal/templates/skills/auto-skill-loop/references/modes/improve-codebase.md
@@ -13,7 +13,7 @@ require `plan_reviewers` or the common plan flow.
 ## Initialize
 
 Map repository-native components, cross-cutting boundaries, and relevant quality
-lenses incrementally. Rank them using concrete risk signals such as data,
+lenses incrementally. Prioritize them using concrete risk signals such as data,
 security, or reliability criticality; complex state or ownership; recurring
 failures; concentrated change or staleness; and weak tests or verification.
 Retain enough progress to cover all of them before declaring exhaustion.

--- a/scripts/test-release/tool_tests.sh
+++ b/scripts/test-release/tool_tests.sh
@@ -10,7 +10,9 @@ run_go_tool_tests_extractchecksum() {
   if [[ ! -f "$ROOT_DIR/$extract_tool/main.go" ]]; then
     fail "extractchecksum tool not found"
   else
-    if (cd "$ROOT_DIR" && go build -tags tools -o "$extract_bin" "$extract_tool"); then
+    # These test-only binaries do not consume VCS metadata. Disabling stamping
+    # also keeps the lane valid in linked worktrees nested below another Git root.
+    if (cd "$ROOT_DIR" && go build -buildvcs=false -tags tools -o "$extract_bin" "$extract_tool"); then
       pass "extractchecksum tool built"
     else
       fail "extractchecksum tool build failed"
@@ -110,7 +112,7 @@ run_go_tool_tests_updateformula() {
   if [[ ! -f "$ROOT_DIR/$update_tool/main.go" ]]; then
     fail "updateformula tool not found"
   else
-    if (cd "$ROOT_DIR" && go build -tags tools -o "$update_bin" "$update_tool"); then
+    if (cd "$ROOT_DIR" && go build -buildvcs=false -tags tools -o "$update_bin" "$update_tool"); then
       pass "updateformula tool built"
     else
       fail "updateformula tool build failed"


### PR DESCRIPTION
## Summary

- Keeps resumed durable agent-dispatch conversations on the model and reasoning effort selected for their initial turn.
- Makes linked-worktree cache paths reliable and lets CI tidy checks validate module changes without requiring an otherwise clean worktree.

## Changes

- Persist the resolved dispatch target in durable sessions and reuse it on resume, with a regression test and compatibility documentation.
- Derive shared Go build/module caches from Git's common directory, isolate the linter cache, and make release-tool builds independent of nested Git-root VCS stamping.

## Verification

- `make ci` — passed.
- `git diff --cached --check` — passed before commit.
- Pre-commit hooks, including `make test` — passed during commit.

## Notes

- Existing durable mappings without saved target metadata keep their configured defaults until their next attempted turn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resumed conversations now consistently use the model and reasoning settings established when the durable session was created, even after configuration changes.
  - Improved module tidiness checks to detect unintended changes more reliably and provide clearer differences.

- **Documentation**
  - Clarified conversation resume behavior, including version transitions and configuration handling.
  - Updated CI and tidiness guidance to allow pre-existing working-tree changes.

- **Developer Experience**
  - Improved build and lint cache handling across repository clones.
  - Made release-tool tests more reliable in environments without version-control metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->