### PR TITLE
Use shared website social card metadata

### DIFF
--- a/site/best-practices/cli-skill-design.header.mdx
+++ b/site/best-practices/cli-skill-design.header.mdx
@@ -1,6 +1,6 @@
 ---
-title: CLI Skill Design Best Practices for AI Coding Agents
-description: How to design CLI-focused agent skills that rely on live help, avoid stale copied manuals, and choose MCP only when it is the better interface.
+title: CLI Skill Design for AI Coding Agents
+description: Design lean CLI skills with progressive disclosure, live help, and clear guidance on when MCP is the better interface.
 keywords:
   - CLI skills
   - agent skills
@@ -8,7 +8,6 @@ keywords:
   - MCP
   - Codex skills
   - live help
-image: /img/branding/logo.svg
 ---
 
 # CLI Skill Design Guide

--- a/site/best-practices/cli-skill-design.header.mdx
+++ b/site/best-practices/cli-skill-design.header.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Skill Design for AI Coding Agents
-description: Design lean CLI skills with progressive disclosure, live help, and clear guidance on when MCP is the better interface.
+description: "For agents: design lean CLI skills with progressive disclosure, live help, and clear guidance on when MCP is the better interface."
 keywords:
   - CLI skills
   - agent skills

--- a/site/best-practices/cli-skill-design.header.mdx
+++ b/site/best-practices/cli-skill-design.header.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Skill Design for AI Coding Agents
-description: "For agents: design lean CLI skills with progressive disclosure, live help, and clear guidance on when MCP is the better interface."
+description: For agents. Design lean CLI skills with progressive disclosure, live help, and clear guidance on when MCP is the better interface.
 keywords:
   - CLI skills
   - agent skills

--- a/site/best-practices/instruction-design.header.mdx
+++ b/site/best-practices/instruction-design.header.mdx
@@ -8,7 +8,6 @@ keywords:
   - prompt engineering
   - minimal context
   - agent skills
-image: /img/branding/logo.svg
 ---
 
 # Instruction Design Guide

--- a/site/best-practices/skill-design.header.mdx
+++ b/site/best-practices/skill-design.header.mdx
@@ -8,7 +8,6 @@ keywords:
   - Claude Code skills
   - context engineering
   - skill design
-image: /img/branding/logo.svg
 ---
 
 # Skill Design Guide

--- a/site/pages/best-practices.mdx
+++ b/site/pages/best-practices.mdx
@@ -8,7 +8,6 @@ keywords:
   - MCP
   - agent instructions
   - context engineering
-image: /img/branding/logo.svg
 ---
 
 # Universal Best Practices


### PR DESCRIPTION
## Summary
- remove page-level social-image overrides from canonical public guide headers
- let Agent Layer web own one global social image instead
- shorten the CLI Skill Design title and description for link previews

## Verification
- `go test ./cmd/publish-site`
- `git diff --check`

## Paired website PR
- https://github.com/conn-castle/agent-layer-web/pull/4

The website PR supplies the shared raster image, enables large X cards, and synchronizes the currently published generated pages.