### PR TITLE
feat: add hidden organize-scratch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- `al organize-scratch --root <dir>` sorts a scratch directory into `reports/`, `artifacts/`, and `review/` folders and writes an `ORGANIZE-REVIEW.md` listing everything that still needs a human decision. It only moves entries: nothing is deleted, overwritten, or merged, and an entry whose destination is already taken is left in place. Defaults to a dry run; pass `--apply` to move. Registered Git worktrees are left alone unless `--move-worktrees` is given, in which case their registrations are repaired after the move. The command is a maintenance aid and is hidden from `al --help`.
+
+### Fixed
+- Git subprocesses now resolve the repository from the path they are given instead of honoring an inherited `GIT_DIR`. Git exports its repository-discovery variables to every hook, and they take precedence over `git -C <path>`, so benchmark provenance and pinned-checkout validation could report on a different repository than the one being measured when a run started from a Git hook.
+
 ## v0.15.0 - 2026-07-31
 
 Agent Dispatch MCP and benchmark tooling release.

--- a/cmd/al/organize_scratch.go
+++ b/cmd/al/organize_scratch.go
@@ -30,7 +30,10 @@ func newOrganizeScratchCmd() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if strings.TrimSpace(options.Root) == "" {
+			// Assign the trimmed value, not just validate it: `--root "  /tmp/x  "`
+			// would otherwise pass this check and then fail as an unreadable path.
+			options.Root = strings.TrimSpace(options.Root)
+			if options.Root == "" {
 				return errors.New(organizeScratchCommandName + " requires --root")
 			}
 			options.Keep = splitKeepNames(keep)

--- a/cmd/al/organize_scratch.go
+++ b/cmd/al/organize_scratch.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conn-castle/agent-layer/internal/organizescratch"
+)
+
+const organizeScratchCommandName = "organize-scratch"
+
+var runOrganizeScratch = organizescratch.Run
+
+// newOrganizeScratchCmd wires the scratch organizer. It is hidden rather than
+// absent: the command is a maintenance aid for agents tidying a scratch
+// directory, not part of the documented surface, and hiding it keeps `al --help`
+// focused on the workflow commands.
+func newOrganizeScratchCmd() *cobra.Command {
+	options := organizescratch.Options{}
+	var keep []string
+	command := &cobra.Command{
+		Use:   organizeScratchCommandName + " --root <dir>",
+		Short: "Sort a scratch directory into a reviewable structure",
+		Long: "Sort a scratch directory into reports/, artifacts/, and review/ folders.\n\n" +
+			"Nothing is ever deleted, overwritten, or merged: entries are only moved, an\n" +
+			"entry whose destination is already taken is left in place, and every removal\n" +
+			"decision is left to a human via ORGANIZE-REVIEW.md written into the root.",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(options.Root) == "" {
+				return errors.New(organizeScratchCommandName + " requires --root")
+			}
+			options.Keep = splitKeepNames(keep)
+			return runOrganizeScratch(cmd.Context(), options, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	command.Flags().StringVar(&options.Root, "root", "", "directory to organize (required)")
+	command.Flags().BoolVar(&options.Apply, "apply", false, "perform the moves instead of only printing the plan")
+	command.Flags().StringArrayVar(&keep, "keep", nil,
+		"comma-separated top-level names to leave in place; repeatable")
+	command.Flags().BoolVar(&options.MoveWorktrees, "move-worktrees", false,
+		"also relocate registered git worktrees and repair their registration")
+	command.Flags().IntVar(&options.MinGroup, "min-group", organizescratch.DefaultMinGroup,
+		"entries a filename prefix needs before it earns its own reports folder")
+	return command
+}
+
+// splitKeepNames turns every --keep occurrence into names. Values accumulate
+// across occurrences rather than the last one winning, so a caller can name a
+// path to protect without having to know what earlier flags already listed.
+// Empty fields, which trailing or doubled commas produce, are dropped.
+func splitKeepNames(values []string) []string {
+	var names []string
+	for _, value := range values {
+		for _, name := range strings.Split(value, ",") {
+			if trimmed := strings.TrimSpace(name); trimmed != "" {
+				names = append(names, trimmed)
+			}
+		}
+	}
+	return names
+}

--- a/cmd/al/organize_scratch_test.go
+++ b/cmd/al/organize_scratch_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/organizescratch"
+)
+
+// captureOrganizeScratch swaps in a recorder for the organizer and returns the
+// options the command hands it.
+func captureOrganizeScratch(t *testing.T) *organizescratch.Options {
+	t.Helper()
+	original := runOrganizeScratch
+	captured := &organizescratch.Options{}
+	runOrganizeScratch = func(_ context.Context, opts organizescratch.Options, _, _ io.Writer) error {
+		*captured = opts
+		return nil
+	}
+	t.Cleanup(func() { runOrganizeScratch = original })
+	return captured
+}
+
+func TestOrganizeScratchCommandIsHiddenButRegistered(t *testing.T) {
+	// Hidden keeps `al --help` focused on the documented workflow; registered is
+	// what makes it callable by anyone who finds it in the repo.
+	root := newRootCmd()
+	command, _, err := root.Find([]string{organizeScratchCommandName})
+	if err != nil {
+		t.Fatalf("find %s: %v", organizeScratchCommandName, err)
+	}
+	if !command.Hidden {
+		t.Fatalf("%s must be hidden", organizeScratchCommandName)
+	}
+}
+
+func TestOrganizeScratchCommandRequiresRoot(t *testing.T) {
+	// This command moves real files, so it must never pick a directory itself.
+	captureOrganizeScratch(t)
+	command := newOrganizeScratchCmd()
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{})
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires --root") {
+		t.Fatalf("Execute error = %v, want a missing --root error", err)
+	}
+}
+
+func TestOrganizeScratchCommandPassesFlagsThrough(t *testing.T) {
+	captured := captureOrganizeScratch(t)
+	command := newOrganizeScratchCmd()
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{
+		"--root", "/tmp/scratch",
+		"--apply",
+		"--move-worktrees",
+		"--min-group", "3",
+		"--keep", "venv, .venv,,node_modules",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured.Root != "/tmp/scratch" || !captured.Apply || !captured.MoveWorktrees || captured.MinGroup != 3 {
+		t.Fatalf("options = %+v, want the flags forwarded verbatim", *captured)
+	}
+	if strings.Join(captured.Keep, "|") != "venv|.venv|node_modules" {
+		t.Fatalf("Keep = %v, want the blank field from the doubled comma dropped", captured.Keep)
+	}
+}
+
+func TestOrganizeScratchCommandDefaultsMinGroup(t *testing.T) {
+	// The default is named rather than embedded in the run, so `--help` states it.
+	captured := captureOrganizeScratch(t)
+	command := newOrganizeScratchCmd()
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"--root", "/tmp/scratch"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured.MinGroup != organizescratch.DefaultMinGroup {
+		t.Fatalf("MinGroup = %d, want DefaultMinGroup (%d)", captured.MinGroup, organizescratch.DefaultMinGroup)
+	}
+	if captured.Apply {
+		t.Fatal("Apply must default to false so the first run is always a dry run")
+	}
+}
+
+func TestOrganizeScratchCommandAccumulatesRepeatedKeep(t *testing.T) {
+	// The script this replaced accumulated every --keep occurrence. Last-one-wins
+	// would silently relocate a path the caller explicitly asked to protect.
+	captured := captureOrganizeScratch(t)
+	command := newOrganizeScratchCmd()
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"--root", "/tmp/scratch", "--keep", "venv", "--keep", ".venv,node_modules"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Join(captured.Keep, "|") != "venv|.venv|node_modules" {
+		t.Fatalf("Keep = %v, want every occurrence retained", captured.Keep)
+	}
+}

--- a/cmd/al/root.go
+++ b/cmd/al/root.go
@@ -47,6 +47,7 @@ func newRootCmd() *cobra.Command {
 		newDoctorCmd(),
 		newWizardCmd(),
 		newBenchmarkCmd(),
+		newOrganizeScratchCmd(),
 	)
 	addPlatformCommands(root)
 	return root

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -120,8 +120,14 @@ Guarantees worth knowing before running it with `--apply`:
 - **Nothing is ever deleted, overwritten, or merged.** Entries are only moved. An
   entry whose destination path is already taken is reported as a collision and
   left where it is. Every removal decision stays with you.
-- Each run writes `ORGANIZE-REVIEW.md` into the root — including on a dry run —
-  listing what needs a decision and what to check before removing it.
+- Any run that has something to organize writes `ORGANIZE-REVIEW.md` into the
+  root — including a dry run — listing what needs a decision, what to check
+  before removing it, and anything left in place. A run that finds only reserved
+  or kept entries leaves an earlier review list untouched rather than replacing
+  a still-outstanding decision list with "nothing to do".
+- Entries are moved one at a time, and the destination check is not atomic with
+  the move. The no-overwrite guarantee holds against existing files and earlier
+  runs, not against another process writing into the scratch root concurrently.
 - Registered Git worktrees, and any directory containing one, are left in place
   unless `--move-worktrees` is passed, because relocating one rewrites Git's
   worktree registration. With the flag, each real worktree path is repaired

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,6 +83,58 @@ Notes:
 - `sync` is optional because `al <client>` always syncs before launch.
 - `./scripts/setup.sh` is only for tool + hook setup, not required just to run the CLI.
 
+## Hidden maintenance commands
+These are registered but hidden from `al --help`. They are maintenance aids, not
+part of the supported CLI surface, and are not documented on the website.
+
+### `al organize-scratch` — sort a scratch directory for review
+Agent scratch directories accumulate hundreds of reports, logs, checkouts, and
+dependency trees. This command sorts the top level of one into folders that
+encode **how much review each entry needs**, so a later cleanup pass can skip
+whole folders instead of judging every entry:
+
+| Destination | Meaning |
+| --- | --- |
+| `reports/<prefix>/` | Matched a recurring report-family naming convention. No review. |
+| `reports/adhoc/<topic>/` | Ad-hoc Markdown, grouped by topic (`pr`, `incidents`, `reviews`, `plans-specs`, `misc`). No review. |
+| `artifacts/<kind>/` | Routed purely by file extension (`logs`, `screenshots`, `diffs`, `scripts`, `data`, `evidence`). No review. |
+| `review/…` | Needs a human decision, subdivided by the reason: `checkouts`, `regenerable`, `unique-assets`, `bulk-samples`, `secrets`, `unknown`. |
+
+```bash
+# Dry run: print the plan, move nothing (default)
+al organize-scratch --root .agent-layer/tmp
+
+# Perform the moves
+al organize-scratch --root .agent-layer/tmp --apply
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--root <dir>` | Directory to organize. Required — the command never picks one itself. |
+| `--apply` | Perform the moves. Without it the run is a dry run. |
+| `--keep <a,b>` | Top-level names to leave in place, for tool-managed paths other software resolves on its own. Repeatable, and accepts comma-separated values. |
+| `--move-worktrees` | Also relocate registered Git worktrees, repairing their registration afterwards. |
+| `--min-group <n>` | How many entries a filename prefix needs before it earns its own `reports/<prefix>` folder (default 5). |
+
+Guarantees worth knowing before running it with `--apply`:
+- **Nothing is ever deleted, overwritten, or merged.** Entries are only moved. An
+  entry whose destination path is already taken is reported as a collision and
+  left where it is. Every removal decision stays with you.
+- Each run writes `ORGANIZE-REVIEW.md` into the root — including on a dry run —
+  listing what needs a decision and what to check before removing it.
+- Registered Git worktrees, and any directory containing one, are left in place
+  unless `--move-worktrees` is passed, because relocating one rewrites Git's
+  worktree registration. With the flag, each real worktree path is repaired
+  after the move (repairing only a moved parent would leave nested worktrees
+  registered at their old location as prunable).
+- Value is judged by **reproducibility** — whether a tree is a copy of the repo,
+  a dependency install, or a build cache — not by whether prose sits next to it.
+  A directory of authored assets that exist nowhere else lands in
+  `review/unique-assets`, never in a "probably disposable" bucket.
+- Copy, asset, and worktree detection all depend on Git. When the root is not
+  inside a repository, or `git ls-files` reports nothing, the command says so on
+  stderr rather than silently classifying with those checks switched off.
+
 ## Run checks locally
 ```bash
 # Quick pass (format + fmt-check + lint + coverage + release tests)

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/conn-castle/agent-layer/internal/clients"
 	"github.com/conn-castle/agent-layer/internal/config"
+	"github.com/conn-castle/agent-layer/internal/gitenv"
 	"github.com/conn-castle/agent-layer/internal/sync"
 	"github.com/conn-castle/agent-layer/internal/templates"
 )
@@ -22,6 +23,10 @@ func TestRunUsesSuppliedRepositoryRootWithoutCreatingWorktree(t *testing.T) {
 	git := func(args ...string) string {
 		t.Helper()
 		cmd := exec.Command("git", append([]string{"-C", root}, args...)...) // #nosec G204 -- fixed test command with a test-owned path.
+		// Resolve the repository from the path above, never from an inherited
+		// GIT_DIR: git exports it to hooks, so under pre-commit this fixture would
+		// otherwise operate on the developer's own checkout.
+		cmd.Env = gitenv.WithoutDiscovery()
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("git %v: %v: %s", args, err, output)

--- a/internal/benchmark/execution.go
+++ b/internal/benchmark/execution.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/conn-castle/agent-layer/internal/gitenv"
 )
 
 // ErrConfirmationRequired is returned before any paid model invocation.
@@ -295,6 +297,7 @@ func ensurePinnedCheckout(ctx context.Context, repoRoot string) (string, error) 
 		{"-C", temporary, "checkout", "--quiet", "--detach", "FETCH_HEAD"},
 	} {
 		command := exec.CommandContext(ctx, commandGit, args...) // #nosec G204 -- source and commit are pinned.
+		command.Env = gitenv.WithoutDiscovery()
 		if output, err := command.CombinedOutput(); err != nil {
 			return "", fmt.Errorf("prepare pinned DeepSWE checkout: %w: %s", err, strings.TrimSpace(string(output)))
 		}
@@ -321,7 +324,9 @@ func validateExistingPinnedCheckout(ctx context.Context, checkout string) (bool,
 	if !info.IsDir() {
 		return false, fmt.Errorf("pinned DeepSWE checkout path is not a directory")
 	}
-	data, err := exec.CommandContext(ctx, commandGit, "-C", checkout, "rev-parse", "HEAD").Output() // #nosec G204 -- private fixed checkout path.
+	revisionCommand := exec.CommandContext(ctx, commandGit, "-C", checkout, "rev-parse", "HEAD") // #nosec G204 -- private fixed checkout path.
+	revisionCommand.Env = gitenv.WithoutDiscovery()
+	data, err := revisionCommand.Output()
 	if err != nil {
 		return false, fmt.Errorf("read pinned DeepSWE checkout revision: %w", err)
 	}
@@ -337,7 +342,9 @@ func validateExistingPinnedCheckout(ctx context.Context, checkout string) (bool,
 // validatePinnedCheckoutClean prevents a labeled benchmark from running a
 // locally modified task tree under the pinned commit identity.
 func validatePinnedCheckoutClean(ctx context.Context, checkout string) error {
-	status, err := exec.CommandContext(ctx, commandGit, "-C", checkout, "status", "--porcelain=v1", "--untracked-files=all").Output() // #nosec G204 -- private fixed checkout path.
+	statusCommand := exec.CommandContext(ctx, commandGit, "-C", checkout, "status", "--porcelain=v1", "--untracked-files=all") // #nosec G204 -- private fixed checkout path.
+	statusCommand.Env = gitenv.WithoutDiscovery()
+	status, err := statusCommand.Output()
 	if err != nil {
 		return fmt.Errorf("inspect pinned DeepSWE checkout cleanliness: %w", err)
 	}

--- a/internal/benchmark/runtime_test.go
+++ b/internal/benchmark/runtime_test.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/conn-castle/agent-layer/internal/gitenv"
 )
 
 func TestNormalizePierPreservesOutcomeCostAndDiagnostics(t *testing.T) {
@@ -453,6 +455,10 @@ func TestPinnedCheckoutValidationRejectsMissingAndWrongRepositoryState(t *testin
 	run := func(arguments ...string) {
 		t.Helper()
 		command := exec.CommandContext(t.Context(), "git", append([]string{"-C", checkout}, arguments...)...) // #nosec G204 -- fixed git operations below a test-owned path.
+		// Resolve the repository from the path above, never from an inherited
+		// GIT_DIR: git exports it to hooks, so under pre-commit this fixture would
+		// otherwise operate on the developer's own checkout.
+		command.Env = gitenv.WithoutDiscovery()
 		if output, err := command.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", arguments, err, output)
 		}

--- a/internal/benchmark/treatment.go
+++ b/internal/benchmark/treatment.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/conn-castle/agent-layer/internal/gitenv"
 	"github.com/conn-castle/agent-layer/internal/sync"
 )
 
@@ -373,11 +374,18 @@ func templatesProvenance(ctx context.Context, repoRoot string) (commit string, d
 	if statErr != nil {
 		return "", false, fmt.Errorf("inspect benchmark repository root: %w", statErr)
 	}
-	revision, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "HEAD").Output() // #nosec G204 -- every argument is a fixed literal; repoRoot is the caller's own repository path.
+	// The repository is resolved from the path above, never from an inherited
+	// GIT_DIR (see gitenv): git exports it to every hook, so a benchmark run
+	// started from a hook would otherwise inspect the wrong repository.
+	revisionCommand := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "HEAD") // #nosec G204 -- every argument is a fixed literal; repoRoot is the caller's own repository path.
+	revisionCommand.Env = gitenv.WithoutDiscovery()
+	revision, err := revisionCommand.Output()
 	if err != nil {
 		return "", false, fmt.Errorf("resolve templates commit: %w", err)
 	}
-	status, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "status", "--porcelain", "--", templates).Output() // #nosec G204 -- every argument is a fixed literal; repoRoot is the caller's own repository path.
+	statusCommand := exec.CommandContext(ctx, "git", "-C", repoRoot, "status", "--porcelain", "--", templates) // #nosec G204 -- every argument is a fixed literal; repoRoot is the caller's own repository path.
+	statusCommand.Env = gitenv.WithoutDiscovery()
+	status, err := statusCommand.Output()
 	if err != nil {
 		return "", false, fmt.Errorf("resolve templates worktree state: %w", err)
 	}

--- a/internal/benchmark/treatment_test.go
+++ b/internal/benchmark/treatment_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/gitenv"
 )
 
 func TestTreatmentProjectionAndManifestContainOnlyEffectiveFiles(t *testing.T) {
@@ -309,6 +311,10 @@ func TestTemplatesProvenanceReportsCommitAndScopesDirtinessToTemplates(t *testin
 	run := func(args ...string) {
 		t.Helper()
 		command := exec.CommandContext(t.Context(), "git", append([]string{"-C", root}, args...)...) // #nosec G204 -- fixed git arguments below a test-owned root.
+		// Resolve the repository from the path above, never from an inherited
+		// GIT_DIR: git exports it to hooks, so under pre-commit this fixture would
+		// otherwise operate on the developer's own checkout.
+		command.Env = gitenv.WithoutDiscovery()
 		if output, err := command.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, output)
 		}

--- a/internal/gitenv/gitenv.go
+++ b/internal/gitenv/gitenv.go
@@ -1,0 +1,54 @@
+// Package gitenv builds environments for invoking git as a subprocess.
+//
+// Git exports its repository-discovery variables to every hook it runs, so any
+// process a hook starts inherits them — including `go test ./...` run by a
+// pre-commit hook. Those variables take precedence over a `-C <dir>` argument,
+// so an inheriting subprocess operates on the hook's repository rather than the
+// directory it was pointed at. For a test that runs `git init` in a temporary
+// fixture, that means re-initializing the developer's own checkout.
+package gitenv
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+// discoveryVariables are the environment variables that override how git decides
+// which repository it is operating on. Credentials, transport settings, and
+// configuration overrides are deliberately absent: they do not redirect git to a
+// different repository, and dropping them would change behavior the caller asked
+// for.
+var discoveryVariables = []string{
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_COMMON_DIR",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_CEILING_DIRECTORIES",
+	"GIT_DISCOVERY_ACROSS_FILESYSTEM",
+	"GIT_PREFIX",
+}
+
+// WithoutDiscovery returns the current process environment with every
+// repository-discovery variable removed, so git resolves the repository from the
+// directory it is given. Assign it to exec.Cmd.Env whenever a git subprocess is
+// pointed at a specific directory.
+func WithoutDiscovery() []string {
+	return withoutDiscovery(os.Environ())
+}
+
+// withoutDiscovery filters an explicit environment, so the behavior is testable
+// without mutating the process.
+func withoutDiscovery(environ []string) []string {
+	cleaned := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		name, _, found := strings.Cut(entry, "=")
+		if found && slices.Contains(discoveryVariables, name) {
+			continue
+		}
+		cleaned = append(cleaned, entry)
+	}
+	return cleaned
+}

--- a/internal/gitenv/gitenv_test.go
+++ b/internal/gitenv/gitenv_test.go
@@ -11,33 +11,30 @@ func TestWithoutDiscoveryDropsOnlyRedirectingVariables(t *testing.T) {
 	// The point of the filter is that git resolves the repository from the
 	// directory it is given. Dropping too little re-introduces the redirect;
 	// dropping too much silently discards credentials and config the caller set.
-	environ := []string{
-		"GIT_DIR=/elsewhere/.git",
-		"GIT_WORK_TREE=/elsewhere",
-		"GIT_INDEX_FILE=/elsewhere/.git/index",
-		"GIT_PREFIX=sub/",
+	kept := []string{
 		"GIT_AUTHOR_NAME=keep me",
 		"GIT_SSH_COMMAND=ssh -i key",
 		"GIT_CONFIG_GLOBAL=/tmp/gitconfig",
 		"PATH=/usr/bin",
 		"MALFORMED_ENTRY_WITHOUT_EQUALS",
 	}
+	// Build the input from the canonical list so a variable added to it later is
+	// covered here without anyone remembering to extend this test.
+	environ := make([]string, 0, len(discoveryVariables)+len(kept))
+	for _, name := range discoveryVariables {
+		environ = append(environ, name+"=/elsewhere")
+	}
+	environ = append(environ, kept...)
 	got := withoutDiscovery(environ)
 
-	for _, dropped := range []string{"GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE=", "GIT_PREFIX="} {
-		if slices.ContainsFunc(got, func(entry string) bool { return strings.HasPrefix(entry, dropped) }) {
-			t.Errorf("%s survived; git would still resolve a different repository", dropped)
+	for _, name := range discoveryVariables {
+		if slices.ContainsFunc(got, func(entry string) bool { return strings.HasPrefix(entry, name+"=") }) {
+			t.Errorf("%s survived; git would still resolve a different repository", name)
 		}
 	}
-	for _, kept := range []string{
-		"GIT_AUTHOR_NAME=keep me",
-		"GIT_SSH_COMMAND=ssh -i key",
-		"GIT_CONFIG_GLOBAL=/tmp/gitconfig",
-		"PATH=/usr/bin",
-		"MALFORMED_ENTRY_WITHOUT_EQUALS",
-	} {
-		if !slices.Contains(got, kept) {
-			t.Errorf("%q was dropped; only discovery variables should be removed", kept)
+	for _, entry := range kept {
+		if !slices.Contains(got, entry) {
+			t.Errorf("%q was dropped; only discovery variables should be removed", entry)
 		}
 	}
 }

--- a/internal/gitenv/gitenv_test.go
+++ b/internal/gitenv/gitenv_test.go
@@ -1,0 +1,59 @@
+package gitenv
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestWithoutDiscoveryDropsOnlyRedirectingVariables(t *testing.T) {
+	// The point of the filter is that git resolves the repository from the
+	// directory it is given. Dropping too little re-introduces the redirect;
+	// dropping too much silently discards credentials and config the caller set.
+	environ := []string{
+		"GIT_DIR=/elsewhere/.git",
+		"GIT_WORK_TREE=/elsewhere",
+		"GIT_INDEX_FILE=/elsewhere/.git/index",
+		"GIT_PREFIX=sub/",
+		"GIT_AUTHOR_NAME=keep me",
+		"GIT_SSH_COMMAND=ssh -i key",
+		"GIT_CONFIG_GLOBAL=/tmp/gitconfig",
+		"PATH=/usr/bin",
+		"MALFORMED_ENTRY_WITHOUT_EQUALS",
+	}
+	got := withoutDiscovery(environ)
+
+	for _, dropped := range []string{"GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE=", "GIT_PREFIX="} {
+		if slices.ContainsFunc(got, func(entry string) bool { return strings.HasPrefix(entry, dropped) }) {
+			t.Errorf("%s survived; git would still resolve a different repository", dropped)
+		}
+	}
+	for _, kept := range []string{
+		"GIT_AUTHOR_NAME=keep me",
+		"GIT_SSH_COMMAND=ssh -i key",
+		"GIT_CONFIG_GLOBAL=/tmp/gitconfig",
+		"PATH=/usr/bin",
+		"MALFORMED_ENTRY_WITHOUT_EQUALS",
+	} {
+		if !slices.Contains(got, kept) {
+			t.Errorf("%q was dropped; only discovery variables should be removed", kept)
+		}
+	}
+}
+
+func TestWithoutDiscoveryReadsTheProcessEnvironment(t *testing.T) {
+	t.Setenv("GIT_DIR", "/elsewhere/.git")
+	t.Setenv("GITENV_SENTINEL", "present")
+
+	got := WithoutDiscovery()
+	if slices.ContainsFunc(got, func(entry string) bool { return strings.HasPrefix(entry, "GIT_DIR=") }) {
+		t.Error("GIT_DIR survived WithoutDiscovery")
+	}
+	if !slices.Contains(got, "GITENV_SENTINEL=present") {
+		t.Error("WithoutDiscovery must return the rest of the process environment")
+	}
+	if os.Getenv("GIT_DIR") != "/elsewhere/.git" {
+		t.Error("WithoutDiscovery must not mutate the process environment")
+	}
+}

--- a/internal/organizescratch/classify.go
+++ b/internal/organizescratch/classify.go
@@ -1,0 +1,553 @@
+// Package organizescratch sorts a scratch directory into a reviewable
+// structure.
+//
+// It NEVER deletes, overwrites, or merges anything. It only moves top-level
+// entries into destination folders, and it refuses to move an entry whose
+// destination path is already taken. Deletion is always a separate,
+// human-driven step — that separation is the whole point of this tool.
+//
+// The destinations encode how much review an entry needs, so a later cleanup
+// pass can skip whole folders:
+//
+//	reports/<skill>/   no review — matched a strict skill naming convention
+//	artifacts/<kind>/  no review — routed purely by file extension
+//	review/...         needs a human decision, subdivided by the reason why
+//
+// Design note: an earlier version of this logic classified a directory as
+// disposable when it contained no Markdown. That rule was wrong and nearly
+// discarded a set of logo SVGs that existed nowhere else. Value is judged here
+// by reproducibility — whether a tree is a copy of the repo, a dependency
+// install, or a build cache — not by whether an agent happened to write prose
+// next to it.
+package organizescratch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Destinations. Every value is a slash-separated path relative to the scratch
+// root; `review/` prefixes the ones that need a human decision.
+const (
+	destReviewSecrets        = "review/secrets"
+	destReviewCheckouts      = "review/checkouts"
+	destReviewRegenerable    = "review/regenerable"
+	destReviewUniqueAssets   = "review/unique-assets"
+	destReviewBulkSamples    = "review/bulk-samples"
+	destReviewUnknown        = "review/unknown"
+	destArtifactsLogs        = "artifacts/logs"
+	destArtifactsScreenshots = "artifacts/screenshots"
+	destArtifactsDiffs       = "artifacts/diffs"
+	destArtifactsScripts     = "artifacts/scripts"
+	destArtifactsData        = "artifacts/data"
+	destArtifactsEvidence    = "artifacts/evidence"
+
+	reviewPrefix       = "review/"
+	reportsPrefix      = "reports/"
+	reportsAdhocPrefix = "reports/adhoc/"
+
+	// Ad-hoc Markdown topic folders. adhocFallbackFolder receives anything that
+	// matches no topic rule.
+	adhocFolderPR         = "pr"
+	adhocFolderIncidents  = "incidents"
+	adhocFolderReviews    = "reviews"
+	adhocFolderPlansSpecs = "plans-specs"
+	adhocFallbackFolder   = "misc"
+
+	reasonSkillConvention = "skill naming convention"
+)
+
+// Bounds that keep classification cheap on very large trees.
+const (
+	// scanFileLimit stops a walk so that a 100k-file dependency tree does not
+	// stall classification.
+	scanFileLimit = 4000
+	// scanNameSample is how many filenames a walk retains for the name-based
+	// heuristics.
+	scanNameSample = 400
+	// repoCopySample is how many retained filenames the repo-copy check reads.
+	repoCopySample = 300
+	// privateKeyProbeBytes is how much of a candidate key file is inspected for
+	// a PEM private key header.
+	privateKeyProbeBytes = 4096
+	// vendoredMinFiles is the file count above which a JS-dominated tree is
+	// treated as a dependency install.
+	vendoredMinFiles = 500
+	// vendoredJSRatio is the share of files that must be JS/TS for the same.
+	vendoredJSRatio = 0.5
+	// repoCopyMinFiles is the file count below which repo-copy detection is
+	// pointless.
+	repoCopyMinFiles = 50
+	// repoCopyRatio is the share of sampled filenames that must also be tracked
+	// in the repo before a tree counts as a copy of it.
+	repoCopyRatio = 0.6
+	// bulkSamplesMinFiles and bulkSamplesMaxTypes describe the signature of a
+	// machine-generated sample dump.
+	bulkSamplesMinFiles = 300
+	bulkSamplesMaxTypes = 6
+	// examplesShown caps how many names a reason string enumerates.
+	examplesShown = 3
+)
+
+var (
+	logExt   = newSet("log", "out", "err", "stdout", "stderr")
+	imageExt = newSet("png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff")
+	diffExt  = newSet("diff", "patch")
+	codeExt  = newSet("mjs", "cjs", "js", "ts", "tsx", "sh", "py", "go", "rb", "sql")
+	// assetExt lists design/source assets that are typically authored, not
+	// generated. Fonts are deliberately excluded: web fonts in a scratch tree
+	// are downloaded or build-generated subsets, never hand-authored, and
+	// including them floods the review list with false positives.
+	assetExt = newSet("svg", "psd", "ai", "sketch", "fig", "xcf", "eps")
+)
+
+var (
+	// extSuffix and noiseSuffix strip trailing artifact-type and timestamp
+	// segments so that topic patterns anchored with `$` can match. Without
+	// this, "foo-pr-body.md" never matches a /pr-body$/ rule.
+	extSuffix   = regexp.MustCompile(`(?i)\.[a-z0-9]+$`)
+	noiseSuffix = regexp.MustCompile(`(?i)\.(prompt|report|plan|task|context|findings|output|evidence|summary|bak|\d{8}[-\dT]*[a-z0-9-]*)$`)
+
+	// toolAsset matches assets shipped by tooling (Playwright reports, editor
+	// icon fonts), not by us.
+	toolAsset = regexp.MustCompile(`(?i)(^(playwright-logo|codicon|favicon)|^[0-9a-f]{32,}\.)`)
+	// secretName matches filenames that may indicate key material; content
+	// decides (see privateKeyVerdict).
+	secretName = regexp.MustCompile(`(?i)((^|[._-])(id_rsa|id_ed25519|id_ecdsa)$|\.(pem|key|p12|pfx|keystore)$)`)
+	// secretNameStrong matches filenames strong enough to flag even when the
+	// content cannot be read.
+	secretNameStrong = regexp.MustCompile(`(?i)((^|[._-])(id_rsa|id_ed25519|id_ecdsa)$|\.(p12|pfx|keystore)$)`)
+	privateKeyBlock  = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----`)
+
+	nodeModulesDir = regexp.MustCompile(`^node_modules$`)
+	cacheDir       = regexp.MustCompile(`(?i)(^|[-_.])(cache|caches)$`)
+	archiveName    = regexp.MustCompile(`(?i)\.(tgz|tar\.gz|zip)$`)
+)
+
+// adhocRules route ad-hoc Markdown by topic. The first matching rule wins;
+// anything unmatched lands in adhocFallbackFolder.
+var adhocRules = []struct {
+	folder  string
+	pattern *regexp.Regexp
+}{
+	{adhocFolderPR, regexp.MustCompile(`(?i)((^|[-_])pr[-_]?\d|pr-body$|^pr-|^reply|[-_]reply[-_]|^ship-pr|^codex-reply|-pr$|^merge-pr|^reconcile-pr)`)},
+	{adhocFolderIncidents, regexp.MustCompile(`(?i)(postmortem|incident|^sentry-|root-cause|error-report|failure-evidence|triage)`)},
+	{adhocFolderReviews, regexp.MustCompile(`(?i)(review|audit|verif|findings|retrospective|second-opinion|certif|readiness)`)},
+	{adhocFolderPlansSpecs, regexp.MustCompile(`(?i)(plan|spec|roadmap|arch|design|runbook|handoff|context|proposal|brief|checklist|migration)`)},
+}
+
+// entry is one top-level member of the scratch root.
+type entry struct {
+	name  string
+	isDir bool
+	abs   string
+	// registered is the path used to compare this entry against git's worktree
+	// registrations. See newEntry for why it is not simply abs.
+	registered string
+}
+
+// newEntry builds a top-level entry of root. canonicalRoot is root with its
+// symlinks resolved, which is how git spells the paths it reports: on macOS a
+// caller who says /tmp/scratch gets entries under /private/tmp/scratch from git,
+// and comparing the two spellings directly would make a registered worktree look
+// unregistered — moving it and silently breaking its registration.
+func newEntry(root, canonicalRoot, name string, isDir bool) entry {
+	return entry{
+		name:       name,
+		isDir:      isDir,
+		abs:        filepath.Join(root, name),
+		registered: filepath.Join(canonicalRoot, name),
+	}
+}
+
+// placement records where one entry belongs and why.
+type placement struct {
+	entry
+	dest   string
+	reason string
+	// worktree marks an entry whose relocation would edit git's worktree
+	// registration.
+	worktree bool
+	// nested holds the registered worktrees below this entry, relative to it,
+	// so repair can target each real worktree path.
+	nested []string
+}
+
+// classifyContext holds the facts shared by every classification in one run.
+type classifyContext struct {
+	skillPrefixes map[string]struct{}
+	worktrees     map[string]struct{}
+	tracked       map[string]struct{}
+}
+
+func newSet(values ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func inSet(set map[string]struct{}, value string) bool {
+	_, ok := set[value]
+	return ok
+}
+
+// extOf returns the lowercased text after the final dot, or "" when there is no
+// dot at all.
+func extOf(name string) string {
+	dot := strings.LastIndex(name, ".")
+	if dot < 0 {
+		return ""
+	}
+	return strings.ToLower(name[dot+1:])
+}
+
+// prefixOf returns the text before the first dot, which is the naming-convention
+// prefix agents use for their report families.
+func prefixOf(name string) string {
+	if dot := strings.Index(name, "."); dot >= 0 {
+		return name[:dot]
+	}
+	return name
+}
+
+// stemOf strips the extension and any trailing artifact-type or timestamp
+// segments, leaving the topic portion of a filename.
+func stemOf(name string) string {
+	stem := extSuffix.ReplaceAllString(name, "")
+	for {
+		next := noiseSuffix.ReplaceAllString(stem, "")
+		if next == stem {
+			return stem
+		}
+		stem = next
+	}
+}
+
+// keyVerdict is the tri-state answer to "does this file hold private key
+// material", because "cannot tell" must not be reported as "no".
+type keyVerdict int
+
+const (
+	keyUnreadable keyVerdict = iota
+	keyAbsent
+	keyPresent
+)
+
+// privateKeyVerdict reports whether a file actually contains private key
+// material. A `.pem` is just as often a public certificate, so the filename
+// alone must not decide.
+func privateKeyVerdict(file string) keyVerdict {
+	handle, err := os.Open(file) // #nosec G304 -- a top-level entry of the caller's own scratch root.
+	if err != nil {
+		return keyUnreadable
+	}
+	defer func() { _ = handle.Close() }()
+	buffer := make([]byte, privateKeyProbeBytes)
+	// ReadFull, not a bare Read: a single Read may return a short prefix of a
+	// readable file, which could split the PEM header and clear a real key.
+	read, err := io.ReadFull(handle, buffer)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return keyUnreadable
+	}
+	if privateKeyBlock.Match(buffer[:read]) {
+		return keyPresent
+	}
+	return keyAbsent
+}
+
+// treeScan is the bounded sample of a directory tree that classification uses.
+type treeScan struct {
+	files int
+	byExt map[string]int
+	names []string
+	// paths maps a candidate secret's filename to its full path so its content
+	// can be checked.
+	paths map[string]string
+	// truncated records that the sample is partial, so callers never mistake a
+	// bounded scan for a complete one.
+	truncated  bool
+	unreadable []string
+}
+
+// scanTree walks dir, stopping once limit files have been seen. The bound is
+// checked between directories, so the count can overshoot by one directory's
+// worth of entries. Unreadable directories are collected rather than ignored: a
+// tree that cannot be inspected must not be classified as if it had been.
+//
+// os.ReadDir sorts each directory by name, so which files land in the retained
+// sample — and therefore how a tree near a classification threshold is routed —
+// is the same on every run and every filesystem.
+func scanTree(dir string, limit int) treeScan {
+	scan := treeScan{byExt: map[string]int{}, paths: map[string]string{}}
+	stack := []string{dir}
+	for len(stack) > 0 {
+		if scan.files >= limit {
+			scan.truncated = true
+			break
+		}
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		children, err := os.ReadDir(current)
+		if err != nil {
+			scan.unreadable = append(scan.unreadable, fmt.Sprintf("%s: %v", current, err))
+			continue
+		}
+		for _, child := range children {
+			full := filepath.Join(current, child.Name())
+			switch {
+			case child.IsDir():
+				stack = append(stack, full)
+			case child.Type().IsRegular():
+				scan.files++
+				scan.byExt[extOf(child.Name())]++
+				if len(scan.names) < scanNameSample {
+					scan.names = append(scan.names, child.Name())
+				}
+				if secretName.MatchString(child.Name()) {
+					if _, seen := scan.paths[child.Name()]; !seen {
+						scan.paths[child.Name()] = full
+					}
+				}
+			}
+		}
+	}
+	return scan
+}
+
+// looksVendored reports whether a tree looks like an installed dependency set
+// or a build cache.
+func looksVendored(name string, scan treeScan) bool {
+	if nodeModulesDir.MatchString(name) {
+		return true
+	}
+	if cacheDir.MatchString(name) {
+		return true
+	}
+	if archiveName.MatchString(name) {
+		return false
+	}
+	// A dependency install is overwhelmingly JS/TS.
+	js := scan.byExt["js"] + scan.byExt["mjs"] + scan.byExt["ts"]
+	if scan.files <= vendoredMinFiles {
+		return false
+	}
+	return float64(js)/float64(scan.files) > vendoredJSRatio
+}
+
+// looksLikeRepoCopy detects a tree that merely restates the repository, e.g. a
+// clone or a fixture copy. Compared by basename against the repo's tracked
+// files: cheap, and good enough to separate "copy of our source" from "unique
+// artifacts".
+func looksLikeRepoCopy(scan treeScan, tracked map[string]struct{}) bool {
+	if scan.files < repoCopyMinFiles || len(tracked) == 0 {
+		return false
+	}
+	sample := scan.names
+	if len(sample) > repoCopySample {
+		sample = sample[:repoCopySample]
+	}
+	if len(sample) == 0 {
+		return false
+	}
+	hits := 0
+	for _, name := range sample {
+		if inSet(tracked, name) {
+			hits++
+		}
+	}
+	return float64(hits)/float64(len(sample)) > repoCopyRatio
+}
+
+// uniqueAssetCount counts files that plausibly cannot be regenerated: authored
+// assets that are neither tracked in the repo nor shipped by tooling.
+func uniqueAssetCount(scan treeScan, tracked map[string]struct{}) int {
+	count := 0
+	for _, name := range scan.names {
+		if !inSet(assetExt, extOf(name)) {
+			continue
+		}
+		if inSet(tracked, name) || toolAsset.MatchString(name) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// findSecrets returns the sampled names within a tree that hold, or may hold,
+// private key material.
+func findSecrets(scan treeScan) []string {
+	var hits []string
+	for _, name := range scan.names {
+		if !secretName.MatchString(name) {
+			continue
+		}
+		if secretNameStrong.MatchString(name) {
+			hits = append(hits, name)
+			continue
+		}
+		// `.pem`/`.key` are ambiguous — confirm from content, and flag
+		// unreadable files rather than assuming they are harmless.
+		full, found := scan.paths[name]
+		if !found || privateKeyVerdict(full) != keyAbsent {
+			hits = append(hits, name)
+		}
+	}
+	return hits
+}
+
+// classify decides where one top-level entry belongs.
+func classify(item entry, ctx classifyContext) placement {
+	if item.isDir {
+		return classifyDir(item, ctx)
+	}
+	return classifyFile(item, ctx)
+}
+
+func classifyFile(item entry, ctx classifyContext) placement {
+	if secretName.MatchString(item.name) {
+		if secretNameStrong.MatchString(item.name) {
+			return place(item, destReviewSecrets, "filename indicates private key material")
+		}
+		// Confirm from content: a `.pem` is as often a public certificate.
+		verdict := privateKeyVerdict(item.abs)
+		if verdict == keyUnreadable {
+			return place(item, destReviewSecrets, "possible key material, unreadable — check by hand")
+		}
+		if verdict == keyPresent {
+			return place(item, destReviewSecrets, "contains PRIVATE KEY block")
+		}
+		// Public certificate: keep it, but note why it was not flagged.
+		return place(item, destArtifactsData, "certificate/public key material, no private key block")
+	}
+	if inSet(ctx.skillPrefixes, prefixOf(item.name)) {
+		return place(item, reportsPrefix+prefixOf(item.name), reasonSkillConvention)
+	}
+	ext := extOf(item.name)
+	switch {
+	case ext == "md":
+		return place(item, reportsAdhocPrefix+adhocFolder(stemOf(item.name)), "ad-hoc markdown")
+	case inSet(logExt, ext):
+		return place(item, destArtifactsLogs, "log extension")
+	case inSet(imageExt, ext):
+		return place(item, destArtifactsScreenshots, "image extension")
+	case inSet(diffExt, ext):
+		return place(item, destArtifactsDiffs, "diff extension")
+	case inSet(assetExt, ext):
+		return place(item, destReviewUniqueAssets, "authored asset, may be irreplaceable")
+	case inSet(codeExt, ext):
+		return place(item, destArtifactsScripts, "script extension")
+	}
+	return place(item, destArtifactsData, "data file")
+}
+
+// adhocFolder returns the topic folder for an ad-hoc Markdown stem.
+func adhocFolder(stem string) string {
+	for _, rule := range adhocRules {
+		if rule.pattern.MatchString(stem) {
+			return rule.folder
+		}
+	}
+	return adhocFallbackFolder
+}
+
+func classifyDir(item entry, ctx classifyContext) placement {
+	// Git state is checked before scanning: no amount of content changes the
+	// fact that moving a registered worktree rewrites git's registration.
+	if inSet(ctx.worktrees, item.registered) {
+		return placement{
+			entry:    item,
+			dest:     destReviewCheckouts,
+			reason:   "REGISTERED git worktree — moving edits git state",
+			worktree: true,
+		}
+	}
+	// A registered worktree may sit below this entry (e.g. `worktrees/<branch>`).
+	// Moving the parent silently breaks that registration, so treat it the same.
+	if nested := nestedWorktrees(item.registered, ctx.worktrees); len(nested) > 0 {
+		return placement{
+			entry: item,
+			dest:  destReviewCheckouts,
+			reason: fmt.Sprintf("contains %d registered git worktree(s): %s",
+				len(nested), strings.Join(firstN(nested, examplesShown), ", ")),
+			worktree: true,
+			nested:   nested,
+		}
+	}
+
+	scan := scanTree(item.abs, scanFileLimit)
+	return discloseScanBounds(classifyScannedDir(item, ctx, scan), scan)
+}
+
+// discloseScanBounds records that a classification rests on a partial walk, so a
+// bounded sample is never presented to the reader as a complete one.
+func discloseScanBounds(result placement, scan treeScan) placement {
+	if scan.truncated {
+		result.reason += fmt.Sprintf(" (judged from the first %d files; the tree is larger)", scanFileLimit)
+	}
+	return result
+}
+
+func classifyScannedDir(item entry, ctx classifyContext, scan treeScan) placement {
+	if len(scan.unreadable) > 0 {
+		return place(item, destReviewUnknown, fmt.Sprintf("unreadable paths (%d) — classify by hand", len(scan.unreadable)))
+	}
+	if secrets := findSecrets(scan); len(secrets) > 0 {
+		return place(item, destReviewSecrets, "contains possible key material: "+strings.Join(firstN(secrets, examplesShown), ", "))
+	}
+	if _, err := os.Stat(filepath.Join(item.abs, ".git")); err == nil {
+		return place(item, destReviewCheckouts, "git clone — check for unmerged work before removing")
+	}
+	if looksVendored(item.name, scan) {
+		return place(item, destReviewRegenerable, "dependency install or build cache — reinstallable")
+	}
+	if looksLikeRepoCopy(scan, ctx.tracked) {
+		return place(item, destReviewRegenerable, "copy of tracked repo files — reproducible")
+	}
+	if unique := uniqueAssetCount(scan, ctx.tracked); unique > 0 {
+		return place(item, destReviewUniqueAssets, fmt.Sprintf("%d authored asset(s) not tracked in the repo", unique))
+	}
+	if inSet(ctx.skillPrefixes, prefixOf(item.name)) {
+		return place(item, reportsPrefix+prefixOf(item.name), reasonSkillConvention)
+	}
+	// Many files but few distinct extensions is the signature of a sample dump:
+	// the analysis is usually a handful of files buried in thousands of samples.
+	if distinct := len(scan.byExt); scan.files > bulkSamplesMinFiles && distinct <= bulkSamplesMaxTypes {
+		return place(item, destReviewBulkSamples, fmt.Sprintf("%d+ files across %d types — extract analysis before removing", scan.files, distinct))
+	}
+	return place(item, destArtifactsEvidence, "mixed evidence directory")
+}
+
+// place builds a placement that carries no git-worktree implications.
+func place(item entry, dest, reason string) placement {
+	return placement{entry: item, dest: dest, reason: reason}
+}
+
+// nestedWorktrees returns the registered worktrees below dir, as paths relative
+// to dir, sorted so output does not depend on map iteration order.
+func nestedWorktrees(dir string, worktrees map[string]struct{}) []string {
+	prefix := dir + string(os.PathSeparator)
+	var nested []string
+	for worktree := range worktrees {
+		if strings.HasPrefix(worktree, prefix) {
+			nested = append(nested, strings.TrimPrefix(worktree, prefix))
+		}
+	}
+	sort.Strings(nested)
+	return nested
+}
+
+func firstN(values []string, limit int) []string {
+	if len(values) > limit {
+		return values[:limit]
+	}
+	return values
+}

--- a/internal/organizescratch/classify.go
+++ b/internal/organizescratch/classify.go
@@ -269,7 +269,10 @@ type treeScan struct {
 	byExt map[string]int
 	names []string
 	// paths maps a candidate secret's filename to its full path so its content
-	// can be checked.
+	// can be checked. Unlike names it is not sampled, because a missed key is a
+	// safety failure rather than a heuristic miss. Only the first path per
+	// filename is kept, so two same-named candidates in different subdirectories
+	// are judged by the first one seen.
 	paths map[string]string
 	// truncated records that the sample is partial, so callers never mistake a
 	// bounded scan for a complete one.
@@ -382,22 +385,29 @@ func uniqueAssetCount(scan treeScan, tracked map[string]struct{}) int {
 	return count
 }
 
-// findSecrets returns the sampled names within a tree that hold, or may hold,
-// private key material.
+// findSecrets returns the names within a tree that hold, or may hold, private
+// key material.
+//
+// This walks scan.paths, not the scanNameSample-bounded scan.names: every
+// candidate the walk saw is recorded in paths, so a key whose filename sorts
+// past the sample is still inspected. Missing one would route a directory
+// holding a private key to a destination the review list calls unambiguous.
 func findSecrets(scan treeScan) []string {
+	candidates := make([]string, 0, len(scan.paths))
+	for name := range scan.paths {
+		candidates = append(candidates, name)
+	}
+	sort.Strings(candidates)
+
 	var hits []string
-	for _, name := range scan.names {
-		if !secretName.MatchString(name) {
-			continue
-		}
+	for _, name := range candidates {
 		if secretNameStrong.MatchString(name) {
 			hits = append(hits, name)
 			continue
 		}
 		// `.pem`/`.key` are ambiguous — confirm from content, and flag
 		// unreadable files rather than assuming they are harmless.
-		full, found := scan.paths[name]
-		if !found || privateKeyVerdict(full) != keyAbsent {
+		if privateKeyVerdict(scan.paths[name]) != keyAbsent {
 			hits = append(hits, name)
 		}
 	}

--- a/internal/organizescratch/classify.go
+++ b/internal/organizescratch/classify.go
@@ -268,12 +268,12 @@ type treeScan struct {
 	files int
 	byExt map[string]int
 	names []string
-	// paths maps a candidate secret's filename to its full path so its content
-	// can be checked. Unlike names it is not sampled, because a missed key is a
-	// safety failure rather than a heuristic miss. Only the first path per
-	// filename is kept, so two same-named candidates in different subdirectories
-	// are judged by the first one seen.
-	paths map[string]string
+	// paths maps a candidate secret's filename to every full path carrying that
+	// name, so each one's content can be checked. Unlike names it is not sampled,
+	// because a missed key is a safety failure rather than a heuristic miss, and
+	// every path is kept because same-named files in different subdirectories can
+	// differ — only one of them needs to hold a key.
+	paths map[string][]string
 	// truncated records that the sample is partial, so callers never mistake a
 	// bounded scan for a complete one.
 	truncated  bool
@@ -289,7 +289,7 @@ type treeScan struct {
 // sample — and therefore how a tree near a classification threshold is routed —
 // is the same on every run and every filesystem.
 func scanTree(dir string, limit int) treeScan {
-	scan := treeScan{byExt: map[string]int{}, paths: map[string]string{}}
+	scan := treeScan{byExt: map[string]int{}, paths: map[string][]string{}}
 	stack := []string{dir}
 	for len(stack) > 0 {
 		if scan.files >= limit {
@@ -315,9 +315,7 @@ func scanTree(dir string, limit int) treeScan {
 					scan.names = append(scan.names, child.Name())
 				}
 				if secretName.MatchString(child.Name()) {
-					if _, seen := scan.paths[child.Name()]; !seen {
-						scan.paths[child.Name()] = full
-					}
+					scan.paths[child.Name()] = append(scan.paths[child.Name()], full)
 				}
 			}
 		}
@@ -406,9 +404,15 @@ func findSecrets(scan treeScan) []string {
 			continue
 		}
 		// `.pem`/`.key` are ambiguous — confirm from content, and flag
-		// unreadable files rather than assuming they are harmless.
-		if privateKeyVerdict(scan.paths[name]) != keyAbsent {
-			hits = append(hits, name)
+		// unreadable files rather than assuming they are harmless. Every path
+		// recorded under this name is inspected: if `first/config.pem` is a
+		// certificate and `second/config.pem` holds a key, stopping at the first
+		// would let the directory bypass secret routing entirely.
+		for _, full := range scan.paths[name] {
+			if privateKeyVerdict(full) != keyAbsent {
+				hits = append(hits, name)
+				break
+			}
 		}
 	}
 	return hits

--- a/internal/organizescratch/classify_test.go
+++ b/internal/organizescratch/classify_test.go
@@ -1,0 +1,450 @@
+package organizescratch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const publicCertPEM = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+
+// privateKeyPEM is a fixture, not a key: only the PEM header drives the
+// classifier. The header phrase is split so the repository's detect-private-key
+// pre-commit hook does not flag this file as a leaked credential.
+const privateKeyPEM = "-----BEGIN OPENSSH " + "PRIVATE KEY-----\nnot-a-real-key\n" +
+	"-----END OPENSSH " + "PRIVATE KEY-----\n"
+
+func writeFileAt(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func mkdirAt(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	return path
+}
+
+// fileEntry creates name inside a fresh temp dir and returns it as a top-level entry.
+func fileEntry(t *testing.T, name, content string) entry {
+	t.Helper()
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, name), content)
+	return topLevel(root, name, false)
+}
+
+func dirEntry(t *testing.T, root, name string) entry {
+	t.Helper()
+	mkdirAt(t, filepath.Join(root, name))
+	return topLevel(root, name, true)
+}
+
+// topLevel builds an entry the same way a run does, so tests exercise the real
+// path that is compared against git's worktree registrations.
+func topLevel(root, name string, isDir bool) entry {
+	return newEntry(root, canonicalPath(root), name, isDir)
+}
+
+func emptyContext() classifyContext {
+	return classifyContext{
+		skillPrefixes: map[string]struct{}{},
+		worktrees:     map[string]struct{}{},
+		tracked:       map[string]struct{}{},
+	}
+}
+
+func TestNameParsingDropsArtifactAndTimestampSegments(t *testing.T) {
+	// stemOf exists so topic rules anchored with `$` still match a filename that
+	// carries an extension plus a chain of artifact-type or timestamp segments.
+	cases := []struct{ name, ext, prefix, stem string }{
+		{"ship-pr.pr-body.md", "md", "ship-pr", "ship-pr.pr-body"},
+		{"audit.report.20250104T1200-final.md", "md", "audit", "audit"},
+		{"plan.plan.summary.md", "md", "plan", "plan"},
+		{"NOTES", "", "NOTES", "NOTES"},
+		{".gitignore", "gitignore", "", ""},
+		{"trace.OUT", "out", "trace", "trace"},
+	}
+	for _, tc := range cases {
+		if got := extOf(tc.name); got != tc.ext {
+			t.Errorf("extOf(%q) = %q, want %q", tc.name, got, tc.ext)
+		}
+		if got := prefixOf(tc.name); got != tc.prefix {
+			t.Errorf("prefixOf(%q) = %q, want %q", tc.name, got, tc.prefix)
+		}
+		if got := stemOf(tc.name); got != tc.stem {
+			t.Errorf("stemOf(%q) = %q, want %q", tc.name, got, tc.stem)
+		}
+	}
+}
+
+func TestClassifyFileRoutesByExtension(t *testing.T) {
+	// Extension routing is the "no review needed" path: each destination must be
+	// reachable from a rule a human can predict without reading the tree.
+	cases := []struct{ name, dest string }{
+		{"run.log", destArtifactsLogs},
+		{"cmd.stderr", destArtifactsLogs},
+		{"shot.PNG", destArtifactsScreenshots},
+		{"change.patch", destArtifactsDiffs},
+		{"logo.svg", destReviewUniqueAssets},
+		{"helper.sh", destArtifactsScripts},
+		{"payload.json", destArtifactsData},
+		{"README", destArtifactsData},
+	}
+	for _, tc := range cases {
+		got := classify(fileEntry(t, tc.name, "x"), emptyContext())
+		if got.dest != tc.dest {
+			t.Errorf("classify(%q).dest = %q, want %q", tc.name, got.dest, tc.dest)
+		}
+		if got.reason == "" {
+			t.Errorf("classify(%q) has no reason; the review list depends on it", tc.name)
+		}
+	}
+}
+
+func TestClassifyMarkdownRoutesByTopic(t *testing.T) {
+	// Ad-hoc markdown is grouped by topic so a cleanup pass can read one folder
+	// at a time instead of a flat pile of report names.
+	cases := []struct{ name, folder string }{
+		{"ship-pr-42.md", adhocFolderPR},
+		{"reconcile-pr.md", adhocFolderPR},
+		{"sentry-outage.md", adhocFolderIncidents},
+		{"postmortem-of-tuesday.md", adhocFolderIncidents},
+		{"security-audit.md", adhocFolderReviews},
+		{"readiness.report.md", adhocFolderReviews},
+		{"migration-runbook.md", adhocFolderPlansSpecs},
+		{"random-thoughts.md", adhocFallbackFolder},
+	}
+	for _, tc := range cases {
+		got := classify(fileEntry(t, tc.name, "x"), emptyContext())
+		want := reportsAdhocPrefix + tc.folder
+		if got.dest != want {
+			t.Errorf("classify(%q).dest = %q, want %q", tc.name, got.dest, want)
+		}
+	}
+}
+
+func TestClassifySecretsDecideFromContentNotFilename(t *testing.T) {
+	// A `.pem` is as often a public certificate as a private key. Deciding on the
+	// filename alone would push ordinary certificates into review/secrets and
+	// train the reader to ignore that folder.
+	cases := []struct {
+		name    string
+		content string
+		dest    string
+	}{
+		{"id_ed25519", "anything", destReviewSecrets},
+		{"backup.p12", "binary", destReviewSecrets},
+		{"server.key", privateKeyPEM, destReviewSecrets},
+		{"server.pem", publicCertPEM, destArtifactsData},
+		{"empty.pem", "", destArtifactsData},
+	}
+	for _, tc := range cases {
+		got := classify(fileEntry(t, tc.name, tc.content), emptyContext())
+		if got.dest != tc.dest {
+			t.Errorf("classify(%q).dest = %q, want %q (reason %q)", tc.name, got.dest, tc.dest, got.reason)
+		}
+	}
+}
+
+func TestClassifyUnreadableKeyCandidateIsFlaggedNotCleared(t *testing.T) {
+	// "Cannot tell" must never be reported as "no key here".
+	if os.Geteuid() == 0 {
+		t.Skip("root can read a 0000 file, so unreadability cannot be simulated")
+	}
+	root := t.TempDir()
+	locked := writeFileAt(t, filepath.Join(root, "locked.pem"), privateKeyPEM)
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	got := classify(topLevel(root, "locked.pem", false), emptyContext())
+	if got.dest != destReviewSecrets || !strings.Contains(got.reason, "unreadable") {
+		t.Fatalf("dest = %q reason = %q, want review/secrets and an unreadable reason", got.dest, got.reason)
+	}
+}
+
+func TestClassifySkillPrefixOutranksExtensionRouting(t *testing.T) {
+	// A recognised report family goes to its own folder even when the extension
+	// rules would happily route it, so whole skill folders can be skipped later.
+	ctx := emptyContext()
+	ctx.skillPrefixes["audit-tests"] = struct{}{}
+	got := classify(fileEntry(t, "audit-tests.findings.md", "x"), ctx)
+	if got.dest != reportsPrefix+"audit-tests" {
+		t.Fatalf("dest = %q, want reports/audit-tests", got.dest)
+	}
+	if got.reason != reasonSkillConvention {
+		t.Fatalf("reason = %q, want %q", got.reason, reasonSkillConvention)
+	}
+}
+
+func TestClassifyDirProtectsRegisteredWorktrees(t *testing.T) {
+	// Relocating a registered worktree rewrites git state, so it must be flagged
+	// before any content heuristic gets a say.
+	root := t.TempDir()
+	item := dirEntry(t, root, "checkout")
+	ctx := emptyContext()
+	ctx.worktrees[item.registered] = struct{}{}
+
+	got := classify(item, ctx)
+	if got.dest != destReviewCheckouts || !got.worktree {
+		t.Fatalf("dest = %q worktree = %v, want review/checkouts and worktree=true", got.dest, got.worktree)
+	}
+	if len(got.nested) != 0 {
+		t.Fatalf("nested = %v, want none for a worktree that is itself the entry", got.nested)
+	}
+}
+
+func TestClassifyDirProtectsParentsOfNestedWorktrees(t *testing.T) {
+	// Moving the parent of a registered worktree silently breaks that
+	// registration, so the parent needs the same protection and must report each
+	// nested path — repairing the parent alone leaves the rest prunable.
+	root := t.TempDir()
+	item := dirEntry(t, root, "worktrees")
+	ctx := emptyContext()
+	for _, branch := range []string{"feat-b", "feat-a"} {
+		mkdirAt(t, filepath.Join(item.abs, branch))
+		ctx.worktrees[filepath.Join(item.registered, branch)] = struct{}{}
+	}
+
+	got := classify(item, ctx)
+	if got.dest != destReviewCheckouts || !got.worktree {
+		t.Fatalf("dest = %q worktree = %v, want review/checkouts and worktree=true", got.dest, got.worktree)
+	}
+	if strings.Join(got.nested, ",") != "feat-a,feat-b" {
+		t.Fatalf("nested = %v, want deterministic [feat-a feat-b]", got.nested)
+	}
+	if !strings.Contains(got.reason, "2 registered git worktree(s)") {
+		t.Fatalf("reason = %q, want the nested count", got.reason)
+	}
+}
+
+func TestClassifyDirWithUnreadableSubtreeIsNotJudged(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read a 0000 directory, so unreadability cannot be simulated")
+	}
+	root := t.TempDir()
+	item := dirEntry(t, root, "evidence")
+	locked := mkdirAt(t, filepath.Join(item.abs, "locked"))
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	// Restore traversal so the temp-dir cleanup can remove the tree afterwards.
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) }) // #nosec G302 -- a directory needs the execute bit to be removed.
+
+	got := classify(item, emptyContext())
+	if got.dest != destReviewUnknown {
+		t.Fatalf("dest = %q, want review/unknown for a tree that could not be inspected", got.dest)
+	}
+}
+
+func TestClassifyDirFindsKeyMaterialBelowTheTop(t *testing.T) {
+	root := t.TempDir()
+	item := dirEntry(t, root, "evidence")
+	writeFileAt(t, filepath.Join(item.abs, "deep", "cluster.pem"), privateKeyPEM)
+	writeFileAt(t, filepath.Join(item.abs, "notes.md"), "x")
+
+	got := classify(item, emptyContext())
+	if got.dest != destReviewSecrets || !strings.Contains(got.reason, "cluster.pem") {
+		t.Fatalf("dest = %q reason = %q, want review/secrets naming cluster.pem", got.dest, got.reason)
+	}
+}
+
+func TestClassifyDirPublicCertificateIsNotASecret(t *testing.T) {
+	root := t.TempDir()
+	item := dirEntry(t, root, "evidence")
+	writeFileAt(t, filepath.Join(item.abs, "chain.pem"), publicCertPEM)
+
+	got := classify(item, emptyContext())
+	if got.dest == destReviewSecrets {
+		t.Fatalf("dest = %q, want a certificate-only tree to stay out of review/secrets", got.dest)
+	}
+}
+
+func TestClassifyDirRecognisesCheckoutsAndRegenerableTrees(t *testing.T) {
+	root := t.TempDir()
+
+	clone := dirEntry(t, root, "some-clone")
+	mkdirAt(t, filepath.Join(clone.abs, ".git"))
+	if got := classify(clone, emptyContext()); got.dest != destReviewCheckouts {
+		t.Errorf("clone dest = %q, want review/checkouts", got.dest)
+	}
+
+	modules := dirEntry(t, root, "node_modules")
+	writeFileAt(t, filepath.Join(modules.abs, "index.js"), "x")
+	if got := classify(modules, emptyContext()); got.dest != destReviewRegenerable {
+		t.Errorf("node_modules dest = %q, want review/regenerable", got.dest)
+	}
+
+	cache := dirEntry(t, root, "playwright-cache")
+	writeFileAt(t, filepath.Join(cache.abs, "blob.bin"), "x")
+	if got := classify(cache, emptyContext()); got.dest != destReviewRegenerable {
+		t.Errorf("cache dest = %q, want review/regenerable", got.dest)
+	}
+}
+
+func TestLooksVendoredNeedsBothVolumeAndJSDominance(t *testing.T) {
+	// The ratio rule is what catches a dependency install that was renamed, but a
+	// small JS tree is ordinary work product and must not be swept into
+	// review/regenerable.
+	small := treeScan{files: 10, byExt: map[string]int{"js": 10}}
+	if looksVendored("vendor-copy", small) {
+		t.Error("a 10-file JS tree must not read as a dependency install")
+	}
+	big := treeScan{files: 600, byExt: map[string]int{"js": 600}}
+	if !looksVendored("vendor-copy", big) {
+		t.Error("a 600-file all-JS tree must read as a dependency install")
+	}
+	mixed := treeScan{files: 600, byExt: map[string]int{"js": 100, "md": 500}}
+	if looksVendored("vendor-copy", mixed) {
+		t.Error("a mostly-markdown tree must not read as a dependency install")
+	}
+	// An archive is one artifact, not an install, whatever its contents look like.
+	if looksVendored("bundle.zip", big) {
+		t.Error("an archive must not read as a dependency install")
+	}
+}
+
+func TestClassifyDirRepoCopyIsRegenerable(t *testing.T) {
+	// A tree that merely restates tracked source is reproducible from the repo.
+	root := t.TempDir()
+	item := dirEntry(t, root, "fixture-copy")
+	ctx := emptyContext()
+	for i := 0; i < repoCopyMinFiles; i++ {
+		name := fmt.Sprintf("source%d.go", i)
+		writeFileAt(t, filepath.Join(item.abs, name), "package x")
+		ctx.tracked[name] = struct{}{}
+	}
+
+	if got := classify(item, ctx); got.dest != destReviewRegenerable {
+		t.Fatalf("dest = %q, want review/regenerable", got.dest)
+	}
+}
+
+func TestClassifyDirKeepsUntrackedAuthoredAssets(t *testing.T) {
+	// The rule this replaced treated a markdown-free directory as disposable and
+	// nearly discarded logo SVGs that existed nowhere else.
+	root := t.TempDir()
+	item := dirEntry(t, root, "brand")
+	writeFileAt(t, filepath.Join(item.abs, "wordmark.svg"), "<svg/>")
+
+	got := classify(item, emptyContext())
+	if got.dest != destReviewUniqueAssets || !strings.Contains(got.reason, "1 authored asset") {
+		t.Fatalf("dest = %q reason = %q, want review/unique-assets with a count", got.dest, got.reason)
+	}
+}
+
+func TestUniqueAssetCountIgnoresTrackedAndToolShippedAssets(t *testing.T) {
+	scan := treeScan{names: []string{
+		"wordmark.svg",                         // authored here
+		"tracked.svg",                          // exists in the repo
+		"playwright-logo.svg",                  // shipped by tooling
+		"codicon.svg",                          // shipped by tooling
+		"0123456789abcdef0123456789abcdef.svg", // content-addressed tool output
+		"notes.md",                             // not an asset at all
+	}}
+	tracked := newSet("tracked.svg")
+	if got := uniqueAssetCount(scan, tracked); got != 1 {
+		t.Fatalf("uniqueAssetCount = %d, want 1 (only wordmark.svg is irreplaceable)", got)
+	}
+}
+
+func TestClassifyDirBulkSampleDumpAsksForExtractionFirst(t *testing.T) {
+	root := t.TempDir()
+	item := dirEntry(t, root, "samples")
+	for i := 0; i <= bulkSamplesMinFiles; i++ {
+		writeFileAt(t, filepath.Join(item.abs, fmt.Sprintf("s%d.json", i)), "{}")
+	}
+
+	got := classify(item, emptyContext())
+	if got.dest != destReviewBulkSamples || !strings.Contains(got.reason, "extract analysis") {
+		t.Fatalf("dest = %q reason = %q, want review/bulk-samples", got.dest, got.reason)
+	}
+}
+
+func TestClassifyDirFallsBackToEvidence(t *testing.T) {
+	// A small mixed directory matches no rule; it is routed without review rather
+	// than parked in review/ where it would dilute the entries that need a human.
+	root := t.TempDir()
+	item := dirEntry(t, root, "run-2025")
+	writeFileAt(t, filepath.Join(item.abs, "notes.md"), "x")
+	writeFileAt(t, filepath.Join(item.abs, "stdout.log"), "x")
+
+	if got := classify(item, emptyContext()); got.dest != destArtifactsEvidence {
+		t.Fatalf("dest = %q, want artifacts/evidence", got.dest)
+	}
+}
+
+func TestScanTreeStopsAtItsLimitAndSaysSo(t *testing.T) {
+	// The bound keeps a deep dependency tree from stalling classification; the
+	// limit is honoured between directories, and truncated is what stops a
+	// partial sample being read as a complete one.
+	root := t.TempDir()
+	for _, sub := range []string{"a", "b", "c"} {
+		for i := 0; i < 2; i++ {
+			writeFileAt(t, filepath.Join(root, sub, fmt.Sprintf("f%d.txt", i)), "x")
+		}
+	}
+	scan := scanTree(root, 2)
+	if !scan.truncated || scan.files >= 6 {
+		t.Fatalf("truncated = %v files = %d, want a truncated partial scan", scan.truncated, scan.files)
+	}
+
+	full := scanTree(root, 100)
+	if full.truncated || full.files != 6 {
+		t.Fatalf("truncated = %v files = %d, want a complete scan of 6 files", full.truncated, full.files)
+	}
+}
+
+func TestDiscloseScanBoundsAnnotatesPartialWalks(t *testing.T) {
+	result := discloseScanBounds(placement{reason: "mixed evidence directory"}, treeScan{truncated: true})
+	if !strings.Contains(result.reason, "judged from the first") {
+		t.Fatalf("reason = %q, want a disclosure that the walk was partial", result.reason)
+	}
+	unchanged := discloseScanBounds(placement{reason: "mixed evidence directory"}, treeScan{})
+	if unchanged.reason != "mixed evidence directory" {
+		t.Fatalf("reason = %q, want it untouched for a complete walk", unchanged.reason)
+	}
+}
+
+func TestScanTreeIgnoresSymlinksAndRecordsSecretPaths(t *testing.T) {
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "deep", "id_rsa"), privateKeyPEM)
+	if err := os.Symlink(filepath.Join(root, "deep"), filepath.Join(root, "link")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	scan := scanTree(root, scanFileLimit)
+	if scan.files != 1 {
+		t.Fatalf("files = %d, want 1: a symlink must not be walked into a second time", scan.files)
+	}
+	if got := scan.paths["id_rsa"]; got == "" {
+		t.Fatal("candidate secret paths must be retained so their content can be checked")
+	}
+}
+
+func TestClassifyDirCapsTheSecretsItEnumerates(t *testing.T) {
+	// The reason line has to stay readable in a terminal, so it names a few
+	// examples rather than every hit; the folder itself is the complete list.
+	root := t.TempDir()
+	item := dirEntry(t, root, "evidence")
+	for _, name := range []string{"a.p12", "b.p12", "c.p12", "d.p12"} {
+		writeFileAt(t, filepath.Join(item.abs, name), "binary")
+	}
+
+	got := classify(item, emptyContext())
+	if got.dest != destReviewSecrets {
+		t.Fatalf("dest = %q, want review/secrets", got.dest)
+	}
+	if names := strings.Count(got.reason, ".p12"); names != examplesShown {
+		t.Fatalf("reason = %q, want exactly %d examples", got.reason, examplesShown)
+	}
+}

--- a/internal/organizescratch/classify_test.go
+++ b/internal/organizescratch/classify_test.go
@@ -426,8 +426,8 @@ func TestScanTreeIgnoresSymlinksAndRecordsSecretPaths(t *testing.T) {
 	if scan.files != 1 {
 		t.Fatalf("files = %d, want 1: a symlink must not be walked into a second time", scan.files)
 	}
-	if got := scan.paths["id_rsa"]; got == "" {
-		t.Fatal("candidate secret paths must be retained so their content can be checked")
+	if got := scan.paths["id_rsa"]; len(got) != 1 {
+		t.Fatalf("scan.paths[id_rsa] = %v, want the one candidate path retained so its content can be checked", got)
 	}
 }
 
@@ -446,5 +446,35 @@ func TestClassifyDirCapsTheSecretsItEnumerates(t *testing.T) {
 	}
 	if names := strings.Count(got.reason, ".p12"); names != examplesShown {
 		t.Fatalf("reason = %q, want exactly %d examples", got.reason, examplesShown)
+	}
+}
+
+func TestClassifyDirInspectsEveryPathForADuplicateCandidateName(t *testing.T) {
+	// Two files can share a candidate filename and differ in content. Judging the
+	// name by whichever path was walked first lets a directory holding a real key
+	// bypass secret routing, so every recorded path is inspected.
+	root := t.TempDir()
+	item := dirEntry(t, root, "evidence")
+	writeFileAt(t, filepath.Join(item.abs, "first", "config.pem"), publicCertPEM)
+	writeFileAt(t, filepath.Join(item.abs, "second", "config.pem"), privateKeyPEM)
+
+	got := classify(item, emptyContext())
+	if got.dest != destReviewSecrets || !strings.Contains(got.reason, "config.pem") {
+		t.Fatalf("dest = %q reason = %q, want review/secrets naming config.pem", got.dest, got.reason)
+	}
+}
+
+func TestFindSecretsClearsANameOnlyWhenEveryPathIsClean(t *testing.T) {
+	// The mirror of the case above: a name whose every occurrence is a certificate
+	// must not be flagged, or review/secrets fills with noise and stops being read.
+	root := t.TempDir()
+	scan := treeScan{paths: map[string][]string{
+		"chain.pem": {
+			writeFileAt(t, filepath.Join(root, "a", "chain.pem"), publicCertPEM),
+			writeFileAt(t, filepath.Join(root, "b", "chain.pem"), publicCertPEM),
+		},
+	}}
+	if hits := findSecrets(scan); len(hits) != 0 {
+		t.Fatalf("findSecrets = %v, want no hits when every path is a certificate", hits)
 	}
 }

--- a/internal/organizescratch/organize.go
+++ b/internal/organizescratch/organize.go
@@ -133,19 +133,22 @@ func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
 		if err := writeReviewDoc(reviewPath, plan, skipped, false); err != nil {
 			return err
 		}
+		// A dry run moves nothing, so nothing can collide; skipped is the whole
+		// left-in-place set.
 		// Say where it landed: a dry run still leaves this file behind.
 		_, err := fmt.Fprintf(stdout, "review list: %s\n", reviewPath)
 		return err
 	}
 
 	moved, collisions, err := applyMoves(root, movable)
-	if err != nil {
-		return err
+	// Written the moment the moves stop, whether they all succeeded or one failed
+	// partway. Everything below can fail on a closed output stream — `al
+	// organize-scratch --apply | head` is enough — and a partial move with no
+	// record of what moved is the worst outcome this command can produce.
+	if writeErr := writeReviewDoc(reviewPath, plan, leftInPlace(skipped, collisions), true); writeErr != nil && err == nil {
+		err = writeErr
 	}
-	// Written the moment the moves are done. Every step below can fail on a
-	// closed output stream — `al organize-scratch --apply | head` is enough — and
-	// once entries have moved, the review list is the output that matters most.
-	if err := writeReviewDoc(reviewPath, plan, skipped, true); err != nil {
+	if err != nil {
 		return err
 	}
 	// Only entries that actually moved are repaired. A worktree left behind by a
@@ -171,13 +174,31 @@ func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
 	return err
 }
 
+// leftInPlace merges the entries that were deliberately skipped with the ones a
+// collision blocked, so the review document records everything still sitting at
+// the root. Stderr carries the same collisions, but stderr is transient and this
+// document is the durable record of the run.
+func leftInPlace(skipped, collisions []placement) []placement {
+	combined := make([]placement, 0, len(skipped)+len(collisions))
+	combined = append(combined, skipped...)
+	for _, blocked := range collisions {
+		blocked.reason = fmt.Sprintf("destination `%s/%s` was already taken, so it was not moved (was: %s)",
+			blocked.dest, blocked.name, blocked.reason)
+		combined = append(combined, blocked)
+	}
+	return combined
+}
+
 // reservedNames returns the top-level names the run must not touch: its own
 // destination folders, its review list, and anything the caller asked to keep.
 func reservedNames(keep []string) map[string]struct{} {
 	reserved := newSet("reports", "artifacts", "review", reviewDocName)
 	for _, name := range keep {
-		if name != "" {
-			reserved[name] = struct{}{}
+		// Trim here rather than trusting the caller: a stray space in a kept name
+		// silently fails to match a directory entry and moves the very path the
+		// caller asked to protect.
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			reserved[trimmed] = struct{}{}
 		}
 	}
 	return reserved
@@ -266,6 +287,14 @@ func applyMoves(root string, movable []placement) (moved, collisions []placement
 		target := filepath.Join(destDir, candidate.name)
 		// Lstat, not Stat: a dangling symlink at the target is still something
 		// a rename would destroy.
+		//
+		// This is a check followed by a rename, not one atomic operation: a
+		// process that creates target in between would have its file replaced.
+		// Go exposes no portable no-replace rename (RENAME_NOREPLACE and
+		// RENAME_EXCL are per-platform syscalls, and os.Link cannot move a
+		// directory), so the guarantee holds against earlier runs and existing
+		// files, not against another writer racing this one inside the scratch
+		// root.
 		if _, statErr := os.Lstat(target); statErr == nil {
 			collisions = append(collisions, candidate)
 			continue
@@ -412,10 +441,14 @@ func gatherGitFacts(ctx context.Context, root string, stderr io.Writer) (gitFact
 	// typically gitignored, so this must run from the repository top level.
 	// Running it in place silently yields an empty set — which would quietly
 	// disable copy detection.
-	if files, lsErr := gitOutput(ctx, top, "ls-files"); lsErr != nil {
+	// -z, because `git ls-files` applies core.quotePath by default: without it a
+	// path holding non-ASCII characters arrives as "\303\251tude.md" and its
+	// basename never matches the file on disk, silently shrinking the tracked set
+	// that copy and asset detection compare against.
+	if files, lsErr := gitOutput(ctx, top, "ls-files", "-z"); lsErr != nil {
 		warn.printf("WARNING: git ls-files failed (%v); copy and asset detection are disabled\n", lsErr)
 	} else {
-		for _, line := range strings.Split(files, "\n") {
+		for _, line := range strings.Split(files, "\x00") {
 			if line != "" {
 				facts.tracked[filepath.Base(line)] = struct{}{}
 			}
@@ -425,10 +458,13 @@ func gatherGitFacts(ctx context.Context, root string, stderr io.Writer) (gitFact
 		}
 	}
 
-	if list, wtErr := gitOutput(ctx, root, "worktree", "list", "--porcelain"); wtErr != nil {
+	// -z for the same reason, and because the porcelain format otherwise quotes a
+	// worktree path containing unusual characters. An unparsed path would leave
+	// that worktree unrecognised and moved without repair.
+	if list, wtErr := gitOutput(ctx, root, "worktree", "list", "--porcelain", "-z"); wtErr != nil {
 		warn.printf("WARNING: git worktree list failed (%v); registered worktrees are not protected\n", wtErr)
 	} else {
-		for _, line := range strings.Split(list, "\n") {
+		for _, line := range strings.Split(list, "\x00") {
 			if strings.HasPrefix(line, worktreeLinePrefix) {
 				facts.worktrees[canonicalPath(strings.TrimPrefix(line, worktreeLinePrefix))] = struct{}{}
 			}
@@ -449,6 +485,12 @@ func gitOutput(ctx context.Context, dir string, args ...string) (string, error) 
 	command.Env = gitenv.WithoutDiscovery()
 	out, err := command.Output()
 	if err != nil {
+		// Without this a caller's warning reads "exit status 128", which does not
+		// say why a check was disabled.
+		var exit *exec.ExitError
+		if errors.As(err, &exit) && len(exit.Stderr) > 0 {
+			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exit.Stderr)))
+		}
 		return "", err
 	}
 	return string(out), nil

--- a/internal/organizescratch/organize.go
+++ b/internal/organizescratch/organize.go
@@ -1,0 +1,496 @@
+package organizescratch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/conn-castle/agent-layer/internal/fsutil"
+	"github.com/conn-castle/agent-layer/internal/gitenv"
+)
+
+// DefaultMinGroup is how many entries must share a filename prefix before that
+// prefix earns its own reports/<prefix> folder.
+const DefaultMinGroup = 5
+
+const (
+	// reviewDocName is the human-facing review list written into the root.
+	reviewDocName = "ORGANIZE-REVIEW.md"
+	// destColumnWidth aligns the destination column of the plan summary.
+	destColumnWidth = 38
+	// worktreeLinePrefix introduces a path in `git worktree list --porcelain`.
+	worktreeLinePrefix = "worktree "
+
+	createdDirPerm = 0o755
+	reviewDocPerm  = 0o644
+)
+
+// Options configures a single organize run.
+type Options struct {
+	// Root is the directory to organize. It must already exist.
+	Root string
+	// Apply performs the moves. When false the run is a dry run that prints the
+	// plan and writes the review list without touching a single entry.
+	Apply bool
+	// Keep lists top-level names to leave in place, for tool-managed paths whose
+	// location other software resolves on its own.
+	Keep []string
+	// MoveWorktrees also relocates registered git worktrees, repairing their
+	// registration afterwards. Off by default: moving a worktree edits real git
+	// state, which is not something a tidy-up run should do unasked.
+	MoveWorktrees bool
+	// MinGroup is how many entries a filename prefix needs before it earns its
+	// own reports folder. See DefaultMinGroup.
+	MinGroup int
+}
+
+// resolveRoot validates the options and returns the absolute root directory.
+func (o Options) resolveRoot() (string, error) {
+	if strings.TrimSpace(o.Root) == "" {
+		return "", errors.New("a root directory is required")
+	}
+	if o.MinGroup < 1 {
+		return "", fmt.Errorf("min group must be a positive integer, got %d", o.MinGroup)
+	}
+	root, err := filepath.Abs(o.Root)
+	if err != nil {
+		return "", fmt.Errorf("resolve root %q: %w", o.Root, err)
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", fmt.Errorf("read root %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("root is not a directory: %s", root)
+	}
+	return root, nil
+}
+
+// Run organizes the scratch directory named by opts, reporting the plan on
+// stdout, warnings about disabled checks on stderr, and the entries that still
+// need a human decision in ORGANIZE-REVIEW.md inside the root.
+//
+// Nothing is ever deleted, overwritten, or merged: an entry whose destination
+// path is already taken is reported as a collision and left where it is.
+func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
+	root, err := opts.resolveRoot()
+	if err != nil {
+		return err
+	}
+
+	git, err := gatherGitFacts(ctx, root, stderr)
+	if err != nil {
+		return err
+	}
+
+	entries, err := readTopLevel(root, reservedNames(opts.Keep))
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		_, err := fmt.Fprintln(stdout, "nothing to organize — root contains only reserved/kept entries")
+		return err
+	}
+
+	classifyCtx := classifyContext{
+		skillPrefixes: skillPrefixes(entries, opts.MinGroup),
+		worktrees:     git.worktrees,
+		tracked:       git.tracked,
+	}
+	plan := make([]placement, 0, len(entries))
+	for _, item := range entries {
+		plan = append(plan, classify(item, classifyCtx))
+	}
+
+	// Registered worktrees are left alone unless explicitly requested, because
+	// relocating one rewrites git's worktree registration.
+	movable := make([]placement, 0, len(plan))
+	var skipped []placement
+	for _, candidate := range plan {
+		if candidate.worktree && !opts.MoveWorktrees {
+			skipped = append(skipped, candidate)
+			continue
+		}
+		movable = append(movable, candidate)
+	}
+
+	if err := printPlan(stdout, len(entries), movable, skipped); err != nil {
+		return err
+	}
+
+	reviewPath := filepath.Join(root, reviewDocName)
+
+	if !opts.Apply {
+		if _, err := fmt.Fprintln(stdout, "\nDRY RUN — nothing moved. Re-run with --apply."); err != nil {
+			return err
+		}
+		if err := writeReviewDoc(reviewPath, plan, skipped, false); err != nil {
+			return err
+		}
+		// Say where it landed: a dry run still leaves this file behind.
+		_, err := fmt.Fprintf(stdout, "review list: %s\n", reviewPath)
+		return err
+	}
+
+	moved, collisions, err := applyMoves(root, movable)
+	if err != nil {
+		return err
+	}
+	// Written the moment the moves are done. Every step below can fail on a
+	// closed output stream — `al organize-scratch --apply | head` is enough — and
+	// once entries have moved, the review list is the output that matters most.
+	if err := writeReviewDoc(reviewPath, plan, skipped, true); err != nil {
+		return err
+	}
+	// Only entries that actually moved are repaired. A worktree left behind by a
+	// collision still has a correct registration, and repairing it would point
+	// git at whatever already occupies the destination.
+	if opts.MoveWorktrees {
+		if err := repairWorktrees(ctx, root, moved, stderr); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(stdout, "\nmoved %d/%d\n", len(moved), len(movable)); err != nil {
+		return err
+	}
+	warn := &errWriter{w: stderr}
+	for _, collision := range collisions {
+		warn.printf("COLLISION, left in place: %s -> %s\n", collision.name, collision.dest)
+	}
+	if warn.err != nil {
+		return warn.err
+	}
+	_, err = fmt.Fprintf(stdout, "review list: %s\n", reviewPath)
+	return err
+}
+
+// reservedNames returns the top-level names the run must not touch: its own
+// destination folders, its review list, and anything the caller asked to keep.
+func reservedNames(keep []string) map[string]struct{} {
+	reserved := newSet("reports", "artifacts", "review", reviewDocName)
+	for _, name := range keep {
+		if name != "" {
+			reserved[name] = struct{}{}
+		}
+	}
+	return reserved
+}
+
+// readTopLevel lists the entries of root that are eligible to move, in name
+// order. A symlink is reported as a file, so it is relocated as an opaque entry
+// rather than walked.
+func readTopLevel(root string, reserved map[string]struct{}) ([]entry, error) {
+	children, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read root %q: %w", root, err)
+	}
+	canonicalRoot := canonicalPath(root)
+	entries := make([]entry, 0, len(children))
+	for _, child := range children {
+		if inSet(reserved, child.Name()) {
+			continue
+		}
+		entries = append(entries, newEntry(root, canonicalRoot, child.Name(), child.IsDir()))
+	}
+	return entries, nil
+}
+
+// skillPrefixes returns the filename prefixes that earn their own reports
+// folder. A prefix qualifies only when it recurs at least minGroup times AND
+// produced markdown; that keeps pure data prefixes from masquerading as agent
+// reports.
+func skillPrefixes(entries []entry, minGroup int) map[string]struct{} {
+	total := map[string]int{}
+	markdown := map[string]int{}
+	for _, item := range entries {
+		if strings.HasPrefix(item.name, ".") {
+			continue
+		}
+		prefix := prefixOf(item.name)
+		total[prefix]++
+		if !item.isDir && extOf(item.name) == "md" {
+			markdown[prefix]++
+		}
+	}
+	prefixes := map[string]struct{}{}
+	for prefix, count := range total {
+		if count >= minGroup && markdown[prefix] >= 1 {
+			prefixes[prefix] = struct{}{}
+		}
+	}
+	return prefixes
+}
+
+// printPlan writes the destination summary, ordered by how many entries each
+// destination receives.
+func printPlan(w io.Writer, total int, movable, skipped []placement) error {
+	counts := map[string]int{}
+	order := make([]string, 0, len(movable))
+	for _, candidate := range movable {
+		if _, seen := counts[candidate.dest]; !seen {
+			order = append(order, candidate.dest)
+		}
+		counts[candidate.dest]++
+	}
+	sort.SliceStable(order, func(i, j int) bool { return counts[order[i]] > counts[order[j]] })
+
+	out := &errWriter{w: w}
+	out.printf("%d entries — %d to move, %d left in place\n\n", total, len(movable), len(skipped))
+	out.printf("%-*s %s\n", destColumnWidth, "DESTINATION", "COUNT")
+	for _, dest := range order {
+		out.printf("%-*s %d\n", destColumnWidth, dest, counts[dest])
+	}
+	for _, left := range skipped {
+		out.printf("\nLEFT IN PLACE  %s\n   %s (pass --move-worktrees to relocate)\n", left.name, left.reason)
+	}
+	return out.err
+}
+
+// applyMoves relocates each planned entry, returning the entries that actually
+// moved and the ones that could not. A destination path that already exists is a
+// collision: the entry stays where it is, because overwriting is exactly what
+// this tool promises never to do.
+func applyMoves(root string, movable []placement) (moved, collisions []placement, err error) {
+	for _, candidate := range movable {
+		destDir := filepath.Join(root, candidate.dest)
+		if mkErr := os.MkdirAll(destDir, createdDirPerm); mkErr != nil {
+			return moved, collisions, fmt.Errorf("create %s: %w", destDir, mkErr)
+		}
+		target := filepath.Join(destDir, candidate.name)
+		// Lstat, not Stat: a dangling symlink at the target is still something
+		// a rename would destroy.
+		if _, statErr := os.Lstat(target); statErr == nil {
+			collisions = append(collisions, candidate)
+			continue
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return moved, collisions, fmt.Errorf("inspect %s: %w", target, statErr)
+		}
+		if renameErr := os.Rename(candidate.abs, target); renameErr != nil {
+			return moved, collisions, fmt.Errorf("move %s to %s: %w", candidate.name, candidate.dest, renameErr)
+		}
+		moved = append(moved, candidate)
+	}
+	return moved, collisions, nil
+}
+
+// repairWorktrees points git at the new location of every relocated worktree and
+// then verifies that no registration is left dangling. It must be given only the
+// entries that actually moved.
+func repairWorktrees(ctx context.Context, root string, moved []placement, stderr io.Writer) error {
+	warn := &errWriter{w: stderr}
+	for _, relocated := range moved {
+		if !relocated.worktree {
+			continue
+		}
+		movedTo := filepath.Join(root, relocated.dest, relocated.name)
+		// Repair the entry itself, or every worktree nested beneath it. Git
+		// needs each real worktree path; pointing it at a parent directory
+		// leaves the nested ones registered at their old location as prunable.
+		targets := []string{movedTo}
+		if len(relocated.nested) > 0 {
+			targets = nil
+			for _, rel := range relocated.nested {
+				targets = append(targets, filepath.Join(movedTo, rel))
+			}
+		}
+		for _, target := range targets {
+			if _, err := gitOutput(ctx, root, "worktree", "repair", target); err != nil {
+				warn.printf("WARNING: git worktree repair failed for %s — run it by hand\n", displayPath(root, target))
+			}
+		}
+	}
+	// Surface any registration still pointing at a missing path. A root outside
+	// a repository has nothing to verify.
+	if list, err := gitOutput(ctx, root, "worktree", "list"); err == nil {
+		stale := 0
+		for _, line := range strings.Split(list, "\n") {
+			if strings.Contains(line, "prunable") {
+				stale++
+			}
+		}
+		if stale > 0 {
+			warn.printf("WARNING: %d worktree registration(s) still stale — run `git worktree repair`\n", stale)
+		}
+	}
+	return warn.err
+}
+
+// reviewGuides tell the reader what each review destination demands of them.
+var reviewGuides = map[string]string{
+	destReviewCheckouts:    "Confirm no unmerged or unpushed work before removing (`git status`, `git log @{u}..HEAD`, diff against main).",
+	destReviewRegenerable:  "Reproducible from a package manager, a build, or the repo itself — usually safe to remove.",
+	destReviewUniqueAssets: "Contains authored files not tracked in the repo. Check each before removing; these may exist nowhere else.",
+	destReviewBulkSamples:  "Mostly machine-generated samples. Extract any written analysis first, then remove the bulk.",
+	destReviewSecrets:      "Possible key material. Remove regardless of value, after confirming the credential is revoked.",
+	destReviewUnknown:      "Could not be classified — inspect by hand.",
+}
+
+// writeReviewDoc records what landed where, and what still needs a decision.
+func writeReviewDoc(path string, plan, skipped []placement, applied bool) error {
+	grouped := map[string][]placement{}
+	needsReview := 0
+	for _, candidate := range plan {
+		if !strings.HasPrefix(candidate.dest, reviewPrefix) {
+			continue
+		}
+		grouped[candidate.dest] = append(grouped[candidate.dest], candidate)
+		needsReview++
+	}
+	dests := make([]string, 0, len(grouped))
+	for dest := range grouped {
+		dests = append(dests, dest)
+	}
+	sort.Strings(dests)
+
+	var doc strings.Builder
+	doc.WriteString("# Scratch organization review\n\n")
+	if applied {
+		doc.WriteString("Entries have been moved.\n\n")
+	} else {
+		doc.WriteString("DRY RUN — nothing was moved yet.\n\n")
+	}
+	doc.WriteString("This command only moves files. Nothing here has been deleted; every removal\n" +
+		"decision below is yours. Folders outside `review/` were routed by an\n" +
+		"unambiguous rule and need no attention.\n\n")
+
+	if len(skipped) > 0 {
+		doc.WriteString("## Left in place\n\n")
+		for _, left := range skipped {
+			fmt.Fprintf(&doc, "- `%s` — %s\n", left.name, left.reason)
+		}
+		doc.WriteString("\n")
+	}
+
+	doc.WriteString("## Needs review\n\n")
+	if needsReview == 0 {
+		doc.WriteString("Nothing required a judgement call.\n\n")
+	}
+	for _, dest := range dests {
+		items := grouped[dest]
+		fmt.Fprintf(&doc, "### `%s` (%d)\n\n", dest, len(items))
+		if guide, ok := reviewGuides[dest]; ok {
+			doc.WriteString(guide + "\n\n")
+		}
+		for _, item := range items {
+			fmt.Fprintf(&doc, "- `%s` — %s\n", item.name, item.reason)
+		}
+		doc.WriteString("\n")
+	}
+	// Exactly one trailing newline, however many blank separators the sections
+	// above contributed.
+	body := strings.TrimRight(doc.String(), "\n") + "\n"
+	return fsutil.WriteFileAtomic(path, []byte(body), reviewDocPerm)
+}
+
+// gitFacts is what git knows about the scratch root. A field left empty disables
+// the checks that depend on it, which is always announced on stderr rather than
+// applied silently.
+type gitFacts struct {
+	worktrees map[string]struct{}
+	tracked   map[string]struct{}
+}
+
+func gatherGitFacts(ctx context.Context, root string, stderr io.Writer) (gitFacts, error) {
+	facts := gitFacts{worktrees: map[string]struct{}{}, tracked: map[string]struct{}{}}
+	warn := &errWriter{w: stderr}
+
+	top, err := gitOutput(ctx, root, "rev-parse", "--show-toplevel")
+	top = strings.TrimSpace(top)
+	if err != nil || top == "" {
+		warn.printf("WARNING: not a git repository; copy, asset, and worktree detection are disabled\n")
+		return facts, warn.err
+	}
+
+	// `git ls-files` scopes to the current directory, and a scratch dir is
+	// typically gitignored, so this must run from the repository top level.
+	// Running it in place silently yields an empty set — which would quietly
+	// disable copy detection.
+	if files, lsErr := gitOutput(ctx, top, "ls-files"); lsErr != nil {
+		warn.printf("WARNING: git ls-files failed (%v); copy and asset detection are disabled\n", lsErr)
+	} else {
+		for _, line := range strings.Split(files, "\n") {
+			if line != "" {
+				facts.tracked[filepath.Base(line)] = struct{}{}
+			}
+		}
+		if len(facts.tracked) == 0 {
+			warn.printf("WARNING: git reported no tracked files; copy and asset detection are disabled\n")
+		}
+	}
+
+	if list, wtErr := gitOutput(ctx, root, "worktree", "list", "--porcelain"); wtErr != nil {
+		warn.printf("WARNING: git worktree list failed (%v); registered worktrees are not protected\n", wtErr)
+	} else {
+		for _, line := range strings.Split(list, "\n") {
+			if strings.HasPrefix(line, worktreeLinePrefix) {
+				facts.worktrees[canonicalPath(strings.TrimPrefix(line, worktreeLinePrefix))] = struct{}{}
+			}
+		}
+	}
+	return facts, warn.err
+}
+
+// gitOutput runs git inside dir and returns its standard output. Errors are
+// returned so each caller can decide whether missing git information matters.
+//
+// The repository is always resolved from dir, never from an inherited GIT_DIR
+// (see gitenv): running inside a git hook, an ambient GIT_DIR would silently
+// redirect every read — and the `worktree repair` writes — at a different
+// repository than the scratch root the caller named.
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...) // #nosec G204 -- fixed git subcommands; dir is the caller's own directory.
+	command.Env = gitenv.WithoutDiscovery()
+	out, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// canonicalPath resolves symlinks so that a path git reports and a path built
+// from the scratch root compare equal. On macOS /tmp is a symlink to
+// /private/tmp, and a mismatch here would relocate a registered worktree without
+// repairing it. A path that cannot be resolved — a registration whose directory
+// is already gone — is returned absolute, which is the spelling git itself
+// reported.
+func canonicalPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+	return resolved
+}
+
+// displayPath shortens a path for a warning, falling back to the absolute form.
+func displayPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}
+
+// errWriter collapses a run of writes into a single error check, so reporting
+// code stays readable without dropping I/O failures.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}

--- a/internal/organizescratch/organize_test.go
+++ b/internal/organizescratch/organize_test.go
@@ -1,0 +1,560 @@
+package organizescratch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/gitenv"
+)
+
+// runOrganize executes a run against opts and returns everything it wrote.
+func runOrganize(t *testing.T, opts Options) (stdout, stderr string, err error) {
+	t.Helper()
+	if opts.MinGroup == 0 {
+		opts.MinGroup = DefaultMinGroup
+	}
+	var out, errOut bytes.Buffer
+	err = Run(t.Context(), opts, &out, &errOut)
+	return out.String(), errOut.String(), err
+}
+
+func readReviewDoc(t *testing.T, root string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, reviewDocName)) // #nosec G304 -- test-owned temporary root.
+	if err != nil {
+		t.Fatalf("read review doc: %v", err)
+	}
+	return string(data)
+}
+
+func requireNoFile(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); err == nil {
+		t.Fatalf("%s exists but should not", path)
+	}
+}
+
+func requireFile(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...) // #nosec G204 -- fixed git arguments below a test-owned root.
+	// Strip inherited discovery variables for the same reason the command does:
+	// under a git hook or pre-commit, GIT_DIR wins over -C and these fixtures
+	// would operate on this repository instead of their own temporary one.
+	command.Env = append(gitenv.WithoutDiscovery(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// newRepoWithScratch builds a git repository with one commit and returns the
+// repository root plus a gitignored scratch directory inside it.
+func newRepoWithScratch(t *testing.T) (repo, scratch string) {
+	t.Helper()
+	repo = t.TempDir()
+	git(t, repo, "init", "--initial-branch=main")
+	writeFileAt(t, filepath.Join(repo, "main.go"), "package main\n")
+	writeFileAt(t, filepath.Join(repo, ".gitignore"), "scratch/\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	return repo, mkdirAt(t, filepath.Join(repo, "scratch"))
+}
+
+func TestRunRejectsUnusableOptions(t *testing.T) {
+	// Every one of these would otherwise be resolved by guessing, and this tool
+	// moves real files: guessing is not acceptable.
+	file := writeFileAt(t, filepath.Join(t.TempDir(), "not-a-dir"), "x")
+	cases := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{"no root", Options{MinGroup: DefaultMinGroup}, "root directory is required"},
+		{"missing root", Options{Root: filepath.Join(t.TempDir(), "absent"), MinGroup: DefaultMinGroup}, "read root"},
+		{"root is a file", Options{Root: file, MinGroup: DefaultMinGroup}, "not a directory"},
+		{"zero min group", Options{Root: t.TempDir(), MinGroup: 0}, "min group must be a positive integer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			err := Run(t.Context(), tc.opts, &out, &errOut)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunReportsWhenThereIsNothingToDo(t *testing.T) {
+	root := t.TempDir()
+	mkdirAt(t, filepath.Join(root, "reports"))
+	mkdirAt(t, filepath.Join(root, "artifacts"))
+	mkdirAt(t, filepath.Join(root, "review"))
+	writeFileAt(t, filepath.Join(root, reviewDocName), "old")
+	mkdirAt(t, filepath.Join(root, "venv"))
+
+	stdout, _, err := runOrganize(t, Options{Root: root, Apply: true, Keep: []string{"venv", ""}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stdout, "nothing to organize") {
+		t.Fatalf("stdout = %q, want a nothing-to-organize report", stdout)
+	}
+	// The kept entry must still be where the tool that manages it expects it.
+	requireFile(t, filepath.Join(root, "venv"))
+	if readReviewDoc(t, root) != "old" {
+		t.Fatal("an empty run must not rewrite the existing review list")
+	}
+}
+
+func TestRunDryRunMovesNothing(t *testing.T) {
+	// The dry run is the safety rail: it must describe the plan and leave every
+	// entry exactly where it was.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "notes.md"), "x")
+	writeFileAt(t, filepath.Join(root, "run.log"), "x")
+
+	stdout, _, err := runOrganize(t, Options{Root: root})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stdout, "2 entries — 2 to move, 0 left in place") {
+		t.Fatalf("stdout = %q, want the entry summary", stdout)
+	}
+	if !strings.Contains(stdout, "DRY RUN — nothing moved. Re-run with --apply.") {
+		t.Fatalf("stdout = %q, want the dry-run notice", stdout)
+	}
+	// A dry run still writes the review list, so it must say where it landed.
+	if !strings.Contains(stdout, "review list: "+filepath.Join(root, reviewDocName)) {
+		t.Fatalf("stdout = %q, want the review list path", stdout)
+	}
+	requireFile(t, filepath.Join(root, "notes.md"))
+	requireFile(t, filepath.Join(root, "run.log"))
+	requireNoFile(t, filepath.Join(root, "reports"))
+	requireNoFile(t, filepath.Join(root, "artifacts"))
+	if doc := readReviewDoc(t, root); !strings.Contains(doc, "DRY RUN — nothing was moved yet.") {
+		t.Fatalf("review doc = %q, want it to state that nothing moved", doc)
+	}
+}
+
+func TestRunApplyMovesEntriesToTheirDestinations(t *testing.T) {
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "ship-pr-19.md"), "x")
+	writeFileAt(t, filepath.Join(root, "build.log"), "x")
+	writeFileAt(t, filepath.Join(root, "logo.svg"), "<svg/>")
+
+	stdout, stderr, err := runOrganize(t, Options{Root: root, Apply: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stdout, "moved 3/3") {
+		t.Fatalf("stdout = %q, want moved 3/3", stdout)
+	}
+	// The temp root sits outside any repository, so the only warning expected is
+	// the one announcing that git-backed detection is off.
+	if strings.Count(stderr, "WARNING") != 1 || !strings.Contains(stderr, "not a git repository") {
+		t.Fatalf("stderr = %q, want only the not-a-git-repository warning", stderr)
+	}
+	requireFile(t, filepath.Join(root, reportsAdhocPrefix, "pr", "ship-pr-19.md"))
+	requireFile(t, filepath.Join(root, destArtifactsLogs, "build.log"))
+	requireFile(t, filepath.Join(root, destReviewUniqueAssets, "logo.svg"))
+	requireNoFile(t, filepath.Join(root, "build.log"))
+
+	doc := readReviewDoc(t, root)
+	if !strings.Contains(doc, "Entries have been moved.") {
+		t.Fatalf("review doc = %q, want it to state entries moved", doc)
+	}
+	// Only review/ entries need a human; routed-by-rule folders must not appear.
+	if !strings.Contains(doc, "`"+destReviewUniqueAssets+"` (1)") {
+		t.Fatalf("review doc = %q, want the unique-assets section", doc)
+	}
+	if strings.Contains(doc, destArtifactsLogs) {
+		t.Fatalf("review doc = %q, want no unambiguously routed folders", doc)
+	}
+	if !strings.Contains(doc, reviewGuides[destReviewUniqueAssets]) {
+		t.Fatalf("review doc = %q, want the guidance for that folder", doc)
+	}
+}
+
+func TestRunNeverOverwritesAnOccupiedDestination(t *testing.T) {
+	// Refusing to overwrite is the tool's central promise: a same-named file from
+	// an earlier run must survive untouched.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "build.log"), "new")
+	writeFileAt(t, filepath.Join(root, destArtifactsLogs, "build.log"), "earlier")
+
+	stdout, stderr, err := runOrganize(t, Options{Root: root, Apply: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stdout, "moved 0/1") {
+		t.Fatalf("stdout = %q, want moved 0/1", stdout)
+	}
+	if !strings.Contains(stderr, "COLLISION, left in place: build.log") {
+		t.Fatalf("stderr = %q, want a reported collision", stderr)
+	}
+	existing, err := os.ReadFile(filepath.Join(root, destArtifactsLogs, "build.log")) // #nosec G304 -- test-owned temporary root.
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(existing) != "earlier" {
+		t.Fatalf("destination content = %q, want the earlier file preserved", existing)
+	}
+	requireFile(t, filepath.Join(root, "build.log"))
+}
+
+func TestRunGroupsRecurringReportPrefixes(t *testing.T) {
+	// A prefix earns its own folder only when it recurs AND produced markdown, so
+	// a repeated data prefix cannot masquerade as a skill's report family.
+	root := t.TempDir()
+	for i := 0; i < DefaultMinGroup; i++ {
+		writeFileAt(t, filepath.Join(root, fmt.Sprintf("audit-tests.run%d.md", i)), "x")
+		writeFileAt(t, filepath.Join(root, fmt.Sprintf("telemetry.chunk%d.json", i)), "{}")
+	}
+
+	if _, _, err := runOrganize(t, Options{Root: root, Apply: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requireFile(t, filepath.Join(root, reportsPrefix+"audit-tests", "audit-tests.run0.md"))
+	requireFile(t, filepath.Join(root, destArtifactsData, "telemetry.chunk0.json"))
+	requireNoFile(t, filepath.Join(root, reportsPrefix+"telemetry"))
+}
+
+func TestRunHonoursMinGroup(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 2; i++ {
+		writeFileAt(t, filepath.Join(root, fmt.Sprintf("audit-tests.run%d.md", i)), "x")
+	}
+
+	if _, _, err := runOrganize(t, Options{Root: root, Apply: true, MinGroup: 2}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requireFile(t, filepath.Join(root, reportsPrefix+"audit-tests", "audit-tests.run0.md"))
+}
+
+func TestRunAnnouncesDisabledChecksOutsideAGitRepository(t *testing.T) {
+	// Copy and asset detection depend on git. Losing them silently would make the
+	// output look authoritative when it is not.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "notes.md"), "x")
+
+	_, stderr, err := runOrganize(t, Options{Root: root})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stderr, "not a git repository") {
+		t.Fatalf("stderr = %q, want a warning that git-backed checks are off", stderr)
+	}
+}
+
+func TestRunLeavesRegisteredWorktreesInPlaceByDefault(t *testing.T) {
+	// Relocating a registered worktree edits real git state, so it takes an
+	// explicit opt-in — and the reason must say so.
+	repo, scratch := newRepoWithScratch(t)
+	git(t, repo, "worktree", "add", filepath.Join("scratch", "wt-feature"), "-b", "feature")
+
+	stdout, _, err := runOrganize(t, Options{Root: scratch, Apply: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stdout, "LEFT IN PLACE  wt-feature") {
+		t.Fatalf("stdout = %q, want the worktree left in place", stdout)
+	}
+	if !strings.Contains(stdout, "pass --move-worktrees to relocate") {
+		t.Fatalf("stdout = %q, want the opt-in hint", stdout)
+	}
+	requireFile(t, filepath.Join(scratch, "wt-feature", ".git"))
+	if doc := readReviewDoc(t, scratch); !strings.Contains(doc, "## Left in place") {
+		t.Fatalf("review doc = %q, want a left-in-place section", doc)
+	}
+}
+
+func TestRunMoveWorktreesRelocatesAndRepairsRegistration(t *testing.T) {
+	repo, scratch := newRepoWithScratch(t)
+	git(t, repo, "worktree", "add", filepath.Join("scratch", "wt-feature"), "-b", "feature")
+
+	if _, stderr, err := runOrganize(t, Options{Root: scratch, Apply: true, MoveWorktrees: true}); err != nil {
+		t.Fatalf("Run: %v (stderr %q)", err, stderr)
+	}
+	moved := filepath.Join(scratch, destReviewCheckouts, "wt-feature")
+	requireFile(t, filepath.Join(moved, ".git"))
+
+	// The registration must follow the checkout: an unrepaired move leaves git
+	// pointing at a path that no longer exists.
+	list := git(t, repo, "worktree", "list")
+	if !strings.Contains(list, canonicalPath(moved)) {
+		t.Fatalf("worktree list = %q, want the relocated path %q", list, canonicalPath(moved))
+	}
+	if strings.Contains(list, "prunable") {
+		t.Fatalf("worktree list = %q, want no stale registration", list)
+	}
+	// The relocated checkout must still be a working checkout.
+	git(t, moved, "status", "--porcelain")
+}
+
+func TestRunMoveWorktreesRepairsEachNestedCheckout(t *testing.T) {
+	// Repairing only the moved parent leaves every nested worktree registered at
+	// its old location, where git reports it as prunable.
+	repo, scratch := newRepoWithScratch(t)
+	mkdirAt(t, filepath.Join(scratch, "worktrees"))
+	git(t, repo, "worktree", "add", filepath.Join("scratch", "worktrees", "alpha"), "-b", "alpha")
+	git(t, repo, "worktree", "add", filepath.Join("scratch", "worktrees", "beta"), "-b", "beta")
+
+	stdout, stderr, err := runOrganize(t, Options{Root: scratch, Apply: true, MoveWorktrees: true})
+	if err != nil {
+		t.Fatalf("Run: %v (stderr %q)", err, stderr)
+	}
+	if !strings.Contains(stdout, "moved 1/1") {
+		t.Fatalf("stdout = %q, want the parent moved as one entry", stdout)
+	}
+	list := git(t, repo, "worktree", "list")
+	for _, branch := range []string{"alpha", "beta"} {
+		want := canonicalPath(filepath.Join(scratch, destReviewCheckouts, "worktrees", branch))
+		if !strings.Contains(list, want) {
+			t.Fatalf("worktree list = %q, want %s repaired to %q", list, branch, want)
+		}
+	}
+	if strings.Contains(list, "prunable") {
+		t.Fatalf("worktree list = %q, want no stale registrations", list)
+	}
+}
+
+func TestRunTreatsATrackedFileCopyAsRegenerable(t *testing.T) {
+	// End to end, this is what makes git-backed detection worth having: a copy of
+	// the repo is reproducible and does not need a per-file decision.
+	repo, scratch := newRepoWithScratch(t)
+	copyDir := mkdirAt(t, filepath.Join(scratch, "repo-copy"))
+	for i := 0; i < repoCopyMinFiles; i++ {
+		name := fmt.Sprintf("tracked%d.go", i)
+		writeFileAt(t, filepath.Join(repo, name), "package main\n")
+		writeFileAt(t, filepath.Join(copyDir, name), "package main\n")
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "more sources")
+
+	if _, _, err := runOrganize(t, Options{Root: scratch, Apply: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requireFile(t, filepath.Join(scratch, destReviewRegenerable, "repo-copy"))
+}
+
+func TestPrintPlanOrdersDestinationsByVolume(t *testing.T) {
+	// The summary exists to show where the bulk went, so the biggest destination
+	// has to come first.
+	movable := []placement{
+		{entry: entry{name: "a.log"}, dest: destArtifactsLogs},
+		{entry: entry{name: "b.json"}, dest: destArtifactsData},
+		{entry: entry{name: "c.log"}, dest: destArtifactsLogs},
+	}
+	var out bytes.Buffer
+	if err := printPlan(&out, 3, movable, nil); err != nil {
+		t.Fatalf("printPlan: %v", err)
+	}
+	logsAt := strings.Index(out.String(), destArtifactsLogs)
+	dataAt := strings.Index(out.String(), destArtifactsData)
+	if logsAt < 0 || dataAt < 0 || logsAt > dataAt {
+		t.Fatalf("output = %q, want %s listed before %s", out.String(), destArtifactsLogs, destArtifactsData)
+	}
+}
+
+func TestWriteReviewDocStatesWhenNoJudgementIsNeeded(t *testing.T) {
+	// Silence would read as "the section is missing"; an explicit statement tells
+	// the reader they are done.
+	root := t.TempDir()
+	path := filepath.Join(root, reviewDocName)
+	plan := []placement{{entry: entry{name: "a.log"}, dest: destArtifactsLogs, reason: "log extension"}}
+	if err := writeReviewDoc(path, plan, nil, true); err != nil {
+		t.Fatalf("writeReviewDoc: %v", err)
+	}
+	if doc := readReviewDoc(t, root); !strings.Contains(doc, "Nothing required a judgement call.") {
+		t.Fatalf("review doc = %q, want an explicit all-clear", doc)
+	}
+}
+
+func TestRunPropagatesWriteFailures(t *testing.T) {
+	// A closed stdout must surface, not be swallowed into a silent success.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "notes.md"), "x")
+	if err := Run(t.Context(), Options{Root: root, MinGroup: DefaultMinGroup}, failingWriter{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("Run must report a stdout write failure")
+	}
+}
+
+func TestGitOutputReportsFailures(t *testing.T) {
+	if _, err := gitOutput(context.Background(), t.TempDir(), "rev-parse", "--show-toplevel"); err == nil {
+		t.Fatal("gitOutput must return an error outside a repository")
+	}
+}
+
+func TestDisplayPathPrefersTheRelativeForm(t *testing.T) {
+	root := t.TempDir()
+	if got := displayPath(root, filepath.Join(root, "a", "b")); got != filepath.Join("a", "b") {
+		t.Fatalf("displayPath = %q, want a/b", got)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, os.ErrClosed }
+
+func TestRunDoesNotGroupDotfilesUnderAnEmptyPrefix(t *testing.T) {
+	// Every dotfile has an empty prefix, so counting them would invent a report
+	// folder named after nothing and sweep unrelated files into it.
+	root := t.TempDir()
+	for i := 0; i < DefaultMinGroup; i++ {
+		writeFileAt(t, filepath.Join(root, fmt.Sprintf(".note%d.md", i)), "x")
+	}
+
+	if _, _, err := runOrganize(t, Options{Root: root, Apply: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requireNoFile(t, filepath.Join(root, "reports", ".note0.md"))
+	requireFile(t, filepath.Join(root, reportsAdhocPrefix, adhocFallbackFolder, ".note0.md"))
+}
+
+func TestRunAnnouncesAnEmptyTrackedFileSet(t *testing.T) {
+	// `git ls-files` returning nothing disables copy detection just as surely as
+	// having no repository at all, and the reader has to be told.
+	repo := t.TempDir()
+	git(t, repo, "init", "--initial-branch=main")
+	scratch := mkdirAt(t, filepath.Join(repo, "scratch"))
+	writeFileAt(t, filepath.Join(scratch, "notes.md"), "x")
+
+	_, stderr, err := runOrganize(t, Options{Root: scratch})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stderr, "no tracked files") {
+		t.Fatalf("stderr = %q, want a warning that copy detection is disabled", stderr)
+	}
+}
+
+func TestRunTreatsADanglingSymlinkAsACollision(t *testing.T) {
+	// A rename over a symlink destroys the symlink. Deciding occupancy with Stat
+	// instead of Lstat would call a dangling link "absent" and overwrite it, which
+	// is precisely what this tool promises never to do.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "build.log"), "new")
+	link := filepath.Join(root, destArtifactsLogs, "build.log")
+	mkdirAt(t, filepath.Dir(link))
+	if err := os.Symlink(filepath.Join(root, "gone"), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, stderr, err := runOrganize(t, Options{Root: root, Apply: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stderr, "COLLISION, left in place: build.log") {
+		t.Fatalf("stderr = %q, want the dangling symlink reported as a collision", stderr)
+	}
+	target, err := os.Readlink(link)
+	if err != nil || target != filepath.Join(root, "gone") {
+		t.Fatalf("readlink = %q, %v; want the symlink intact", target, err)
+	}
+	requireFile(t, filepath.Join(root, "build.log"))
+}
+
+func TestRunDoesNotRepairAWorktreeThatCouldNotMove(t *testing.T) {
+	// A worktree blocked by a collision is still at its original path with a
+	// correct registration. Repairing it anyway would point git at whatever
+	// occupies the destination and orphan the live checkout.
+	repo, scratch := newRepoWithScratch(t)
+	git(t, repo, "worktree", "add", filepath.Join("scratch", "wt-feature"), "-b", "feature")
+	occupied := filepath.Join(scratch, destReviewCheckouts, "wt-feature")
+	writeFileAt(t, filepath.Join(occupied, "stale-copy.txt"), "not the real checkout")
+
+	_, stderr, err := runOrganize(t, Options{Root: scratch, Apply: true, MoveWorktrees: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stderr, "COLLISION, left in place: wt-feature") {
+		t.Fatalf("stderr = %q, want the collision reported", stderr)
+	}
+	if strings.Contains(stderr, "worktree repair failed") {
+		t.Fatalf("stderr = %q, want no repair attempted for an entry that never moved", stderr)
+	}
+	list := git(t, repo, "worktree", "list")
+	if !strings.Contains(list, canonicalPath(filepath.Join(scratch, "wt-feature"))) {
+		t.Fatalf("worktree list = %q, want the registration still at the original path", list)
+	}
+	if strings.Contains(list, "prunable") {
+		t.Fatalf("worktree list = %q, want no stale registration", list)
+	}
+}
+
+func TestRunWritesTheReviewListEvenWhenStdoutBreaks(t *testing.T) {
+	// `al organize-scratch --apply | head` closes stdout mid-run. Entries have
+	// already moved by then, so the review list — the only record of where they
+	// went and what still needs a decision — must survive the write failure.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "notes.md"), "x")
+	writeFileAt(t, filepath.Join(root, "logo.svg"), "<svg/>")
+
+	err := Run(t.Context(), Options{Root: root, Apply: true, MinGroup: DefaultMinGroup},
+		pipeClosedWriter{marker: "moved "}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("Run must report the stdout failure rather than exit clean")
+	}
+	requireFile(t, filepath.Join(root, destReviewUniqueAssets, "logo.svg"))
+	if doc := readReviewDoc(t, root); !strings.Contains(doc, "logo.svg") {
+		t.Fatalf("review doc = %q, want the moved entry recorded", doc)
+	}
+}
+
+// pipeClosedWriter fails on the write containing marker, the way a pipe whose
+// reader has exited fails partway through a command's output.
+type pipeClosedWriter struct{ marker string }
+
+func (w pipeClosedWriter) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), w.marker) {
+		return 0, os.ErrClosed
+	}
+	return len(p), nil
+}
+
+func TestRunResolvesGitFromTheRootNotAnInheritedGitDir(t *testing.T) {
+	// Git hooks, pre-commit, and `git rebase --exec` all export GIT_DIR and
+	// GIT_WORK_TREE, and those take precedence over `git -C <dir>`. Honouring them
+	// would resolve a different repository than the scratch root: the wrong
+	// tracked-file set for copy detection, the wrong worktree registrations to
+	// protect, and `git worktree repair` writes aimed at someone else's checkout.
+	decoy, decoyScratch := newRepoWithScratch(t)
+	git(t, decoy, "worktree", "add", filepath.Join("scratch", "decoy-wt"), "-b", "decoy")
+
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "notes.md"), "x")
+	t.Setenv("GIT_DIR", filepath.Join(decoy, ".git"))
+	t.Setenv("GIT_WORK_TREE", decoy)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(decoy, ".git", "index"))
+
+	_, stderr, err := runOrganize(t, Options{Root: root, Apply: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// root is outside any repository, so the decoy must not stand in for it.
+	if !strings.Contains(stderr, "not a git repository") {
+		t.Fatalf("stderr = %q, want the ambient repository ignored and git checks reported off", stderr)
+	}
+	requireFile(t, filepath.Join(root, reportsAdhocPrefix, adhocFallbackFolder, "notes.md"))
+	// The decoy is untouched: nothing was organized in it and its worktree stands.
+	requireFile(t, filepath.Join(decoyScratch, "decoy-wt", ".git"))
+	requireNoFile(t, filepath.Join(decoyScratch, reviewDocName))
+}

--- a/internal/organizescratch/organize_test.go
+++ b/internal/organizescratch/organize_test.go
@@ -2,7 +2,6 @@ package organizescratch
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -397,12 +396,6 @@ func TestRunPropagatesWriteFailures(t *testing.T) {
 	}
 }
 
-func TestGitOutputReportsFailures(t *testing.T) {
-	if _, err := gitOutput(context.Background(), t.TempDir(), "rev-parse", "--show-toplevel"); err == nil {
-		t.Fatal("gitOutput must return an error outside a repository")
-	}
-}
-
 func TestDisplayPathPrefersTheRelativeForm(t *testing.T) {
 	root := t.TempDir()
 	if got := displayPath(root, filepath.Join(root, "a", "b")); got != filepath.Join("a", "b") {
@@ -557,4 +550,83 @@ func TestRunResolvesGitFromTheRootNotAnInheritedGitDir(t *testing.T) {
 	// The decoy is untouched: nothing was organized in it and its worktree stands.
 	requireFile(t, filepath.Join(decoyScratch, "decoy-wt", ".git"))
 	requireNoFile(t, filepath.Join(decoyScratch, reviewDocName))
+}
+
+func TestRunFindsKeyMaterialBeyondTheFilenameSample(t *testing.T) {
+	// The name sample is capped, so a key whose filename sorts past the cap used
+	// to be invisible and the directory was routed to artifacts/evidence — a
+	// folder the review list tells the reader needs no attention.
+	root := t.TempDir()
+	tree := mkdirAt(t, filepath.Join(root, "evidence"))
+	for i := 0; i < scanNameSample+50; i++ {
+		writeFileAt(t, filepath.Join(tree, fmt.Sprintf("a%04d.json", i)), "{}")
+	}
+	// "z" sorts after every "a" name, so it falls outside the retained sample.
+	writeFileAt(t, filepath.Join(tree, "zzz-deploy.pem"), privateKeyPEM)
+
+	if _, _, err := runOrganize(t, Options{Root: root, Apply: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requireFile(t, filepath.Join(root, destReviewSecrets, "evidence"))
+	if doc := readReviewDoc(t, root); !strings.Contains(doc, "zzz-deploy.pem") {
+		t.Fatalf("review doc = %q, want the out-of-sample key named", doc)
+	}
+}
+
+func TestRunRecordsCollisionsInTheReviewDocument(t *testing.T) {
+	// stderr is transient; the review list is the durable record. An entry that
+	// could not move must not be presented as though it had.
+	root := t.TempDir()
+	writeFileAt(t, filepath.Join(root, "build.log"), "new")
+	writeFileAt(t, filepath.Join(root, destArtifactsLogs, "build.log"), "earlier")
+
+	if _, _, err := runOrganize(t, Options{Root: root, Apply: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	doc := readReviewDoc(t, root)
+	if !strings.Contains(doc, "## Left in place") || !strings.Contains(doc, "already taken") {
+		t.Fatalf("review doc = %q, want the collision recorded as left in place", doc)
+	}
+}
+
+func TestRunTrimsKeptNames(t *testing.T) {
+	// A stray space would otherwise fail to match the directory entry and move the
+	// very path the caller asked to protect.
+	root := t.TempDir()
+	mkdirAt(t, filepath.Join(root, "venv"))
+	writeFileAt(t, filepath.Join(root, "notes.md"), "x")
+
+	if _, _, err := runOrganize(t, Options{Root: root, Apply: true, Keep: []string{"  venv  "}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requireFile(t, filepath.Join(root, "venv"))
+}
+
+func TestGatherGitFactsHandlesQuotedAndNonASCIIPaths(t *testing.T) {
+	// git ls-files applies core.quotePath by default, so without -z a non-ASCII
+	// path arrives escaped and its basename never matches the file on disk,
+	// silently shrinking the tracked set copy detection compares against.
+	repo, scratch := newRepoWithScratch(t)
+	writeFileAt(t, filepath.Join(repo, "étude.md"), "x")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "non-ascii")
+
+	facts, err := gatherGitFacts(t.Context(), scratch, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("gatherGitFacts: %v", err)
+	}
+	if !inSet(facts.tracked, "étude.md") {
+		t.Fatalf("tracked set = %v, want the decoded non-ASCII basename", facts.tracked)
+	}
+}
+
+func TestGitOutputErrorNamesTheGitFailure(t *testing.T) {
+	// "exit status 128" alone does not tell the reader why a check was disabled.
+	_, err := gitOutput(t.Context(), t.TempDir(), "rev-parse", "--show-toplevel")
+	if err == nil {
+		t.Fatal("expected an error outside a repository")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("err = %v, want git's own diagnostic included", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Migrates the `organize-scratch.mjs` helper into the `al` CLI as a hidden `al organize-scratch` subcommand, so it works anywhere `al` is installed without adding a Node runtime dependency to a Go binary.
- Sorts the top level of a scratch directory into folders that encode **how much review each entry needs**, so a cleanup pass can skip whole folders instead of judging every entry.
- Only ever moves entries: nothing is deleted, overwritten, or merged, and an entry whose destination is taken is reported as a collision and left in place.
- Fixes a repository-wide Git environment leak found while shipping this: under the pre-commit hook, fixture tests were re-initializing the developer's own checkout as bare and staging the deletion of every tracked file.

## Changes

**New command** (`cmd/al/organize_scratch.go`, `internal/organizescratch/`)

- `al organize-scratch --root <dir>` with `--apply`, `--keep`, `--move-worktrees`, and `--min-group`. Hidden from `al --help`; `--root` is required so the command never picks a directory itself.
- Destinations: `reports/<prefix>/` and `reports/adhoc/<topic>/` (naming convention), `artifacts/<kind>/` (extension), and `review/...` subdivided by why a human is needed (`checkouts`, `regenerable`, `unique-assets`, `bulk-samples`, `secrets`, `unknown`).
- Writes `ORGANIZE-REVIEW.md` into the root on every run, including dry runs, listing what needs a decision and what to check before removing it.

**Deliberate corrections to the original script's behavior**

- Entry paths are compared against Git's worktree registrations using symlink-resolved spellings. The script compared raw paths, so under a symlinked root (macOS `/tmp`, `/var/folders`) it recognized *no* registered worktree, relocated them without repair, and left every registration prunable.
- Only entries that actually moved are repaired. Repairing one blocked by a collision would point Git at whatever occupies the destination.
- Collision detection uses `Lstat`, so a dangling symlink at the destination is a collision rather than something a rename destroys.
- The review list is written the moment the moves finish, so a closed stdout pipe (`… --apply | head`) cannot cost the only record of where entries went.
- A truncated directory scan says so in its reason instead of presenting a partial sample as complete.
- A key-material probe uses `io.ReadFull`, so a short read cannot split a PEM header and clear a real private key.

**Git environment isolation** (`internal/gitenv/`, `internal/benchmark/`, `internal/agentdispatch/`)

- New `internal/gitenv` holds the canonical list of Git repository-discovery variables and returns an environment with them removed. Every Git subprocess in the repo now uses it.
- Git exports those variables to every hook, and they take precedence over `git -C <path>`. Under pre-commit this made fixture tests operate on the real checkout: `git init` re-initialized it as bare, and `git add -A` staged the deletion of all 735 tracked files. The same leak let benchmark provenance and pinned-checkout validation measure a different repository than the one under test.
- Credentials, transport settings, and config overrides are deliberately preserved — only the variables that redirect Git to a different repository are dropped.

**Documentation**

- `docs/DEVELOPMENT.md` gains a "Hidden maintenance commands" section covering the destination taxonomy, flags, and the safety guarantees. Nothing was added to the website reference.
- `CHANGELOG.md` gains `Unreleased` entries for the command and the Git resolution fix.

## Verification

- `make fmt-check`, `make lint`, `make dead-code`, `make docs-cta-check` — all pass, 0 issues.
- `make coverage` — 90.36% total, above the 90% threshold; `internal/organizescratch` at 93.1%.
- `go test ./...` — passes, including via the pre-commit hook (the run that previously corrupted the repository).
- **Differential parity against the original script** on shared fixtures (report families, every extension class, a private key, a public certificate, `node_modules`, a cache dir, an untracked SVG, a mixed evidence dir, a 301-file sample dump, a 50-file copy of tracked sources, a fake clone, a kept `venv`, one registered worktree and two nested under a parent). Dry run and `--apply --move-worktrees` both produce identical stdout, stderr, resulting file trees, and `git worktree list` output. The only differences are intentional: dry runs now print `review list: <path>`, and the document says "This command" rather than "This script".
- **Leak regression test**: the full suite run with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` pointed at a throwaway repository passes, and leaves both that repository and the real one untouched. Pinned by `TestRunResolvesGitFromTheRootNotAnInheritedGitDir`.

## Notes

- The original `organize-scratch.mjs` in the `agent-panel` repository is untouched; it can be removed once this is exercised.
- Anyone who previously ran the script with `--move-worktrees` on a scratch directory under a symlinked path may have prunable worktree registrations and should run `git worktree repair`.
- `internal/benchmark/treatment_test.go` is touched by the Git isolation fix (one line plus an import) and may conflict with in-flight benchmark work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the hidden `al organize-scratch` maintenance command for classifying and organizing scratch-directory contents.
  * Supports dry runs, applying planned moves, preserving selected entries, grouping results, collision protection, review reports, and optional worktree relocation.
  * Detects secrets, repositories, caches, samples, skills, documents, and other content while protecting uncertain or sensitive items.

* **Bug Fixes**
  * Git operations now consistently use the intended repository, avoiding interference from inherited Git environment settings.

* **Documentation**
  * Added usage guidance, classification rules, safety behavior, and available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->