### PR TITLE
test: cover untested behavior to build coverage margin

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -29,6 +29,12 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
+- Issue 2026-08-05 coverage-remainder-is-error-injection-only: Coverage above ~91.4% requires failure-injection tests
+    Priority: Low. Area: test suite / coverage
+    Description: After a behavior-focused pass raised total coverage from 90.02% to 91.42%, every remaining uncovered region is a block of 1–5 statements. They are overwhelmingly `if err != nil` wrappers around filesystem, git, and process calls, plus platform-unreachable branches (device/socket nodes in skilltree.describeNode, non-finite floats that `encoding/json` cannot decode, and defensive duplicate-selector checks that config validation already rejects). No untested feature-level behavior remains in a single block larger than 5 statements.
+    Open question: whether a higher coverage threshold is worth adding fault-injection seams (an injectable filesystem or forced-error hooks) to the packages that currently call `os` directly.
+    Notes: `internal/agentdispatch` (~430 missed) and `internal/benchmark` (~300 missed) hold most of the remainder; both are dominated by provider/Docker orchestration failure paths.
+
 - Issue 2026-08-04 permission-based-test-fixtures-assume-non-root: chmod-driven failure fixtures silently pass under root
     Priority: Low. Area: test suite
     Description: Pre-existing tests in internal/install and internal/clients drive production error paths by removing a directory's write bit. A process with CAP_DAC_OVERRIDE — root in many containers — writes anyway, so the operation under test succeeds and the assertion fails for an environment reason. CI runs on ubuntu-latest as a non-root user, so nothing currently fails.

--- a/internal/agentdispatch/async_worker_test.go
+++ b/internal/agentdispatch/async_worker_test.go
@@ -1,0 +1,148 @@
+package agentdispatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPublishedInvocationIsExecutedExactlyOnceByItsWorker covers the async
+// handoff that every background dispatch depends on: Start publishes a prepared
+// invocation and hands the detached worker the authorization to run it, and the
+// worker replays that published request — not a re-derived one — to completion.
+// The request is consumed in the process, so a worker that runs again cannot
+// bill the provider a second time for the same invocation.
+func TestPublishedInvocationIsExecutedExactlyOnceByItsWorker(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	binDir := filepath.Join(t.TempDir(), "bin")
+	providerLog := filepath.Join(t.TempDir(), "codex.log")
+	writeDispatchStub(t, binDir, "codex", `printf '{"type":"item.completed","item":{"type":"agent_message","text":"worker answer"}}\n'`)
+	t.Setenv("PATH", testPath(binDir))
+	t.Setenv("AL_TEST_LOG", providerLog)
+
+	var gate *os.File
+	launcher := func(string, string, string) (launchedWorker, error) {
+		read, write, err := os.Pipe()
+		if err != nil {
+			return launchedWorker{}, err
+		}
+		gate = read
+		return launchedWorker{gate: write, pid: os.Getpid(), startIdentity: processStartIdentity(os.Getpid())}, nil
+	}
+	var stdout bytes.Buffer
+	if err := Start(StartOptions{
+		Root: root, WorkDir: root, Agent: AgentCodex, Prompt: "Review this",
+		Stdout: &stdout, Env: []string{"PATH=" + testPath(binDir)}, LookPath: alwaysFound,
+		VersionLookup: func(string, string) (string, error) { return supportedProviderVersions[AgentCodex], nil },
+		launchWorker:  launcher,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = gate.Close() })
+
+	var response Result
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	session, err := loadSession(root, response.Handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runID := session.RunID
+	requestPath := filepath.Join(dispatchRunPath(root), runID, workerRequestFile)
+	if _, err := os.Stat(requestPath); err != nil {
+		t.Fatalf("Start did not publish a worker request for the handle it returned: %v", err)
+	}
+
+	if err := RunWorker(root, runID, gate); err != nil {
+		t.Fatalf("authorized worker failed to execute its published invocation: %v", err)
+	}
+	record, err := loadRunRecord(root, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != dispatchStateCompleted {
+		t.Fatalf("worker run state = %q, want the invocation to complete", record.State)
+	}
+	answer, err := os.ReadFile(record.AnswerPath) // #nosec G304 -- Agent Layer-owned run directory in a test repository.
+	if err != nil || string(answer) != "worker answer" {
+		t.Fatalf("worker answer = %q, %v", answer, err)
+	}
+	if _, err := os.Stat(requestPath); !os.IsNotExist(err) {
+		t.Fatalf("worker request survived execution and could be replayed: %v", err)
+	}
+
+	// A second worker for the same invocation must not reach the provider again.
+	before, err := os.ReadFile(providerLog) // #nosec G304 -- test-owned path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayGateRead, replayGateWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = replayGateRead.Close() }()
+	if _, err := replayGateWrite.Write([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := replayGateWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunWorker(root, runID, replayGateRead); err == nil {
+		t.Fatal("a consumed invocation was executed a second time")
+	}
+	after, err := os.ReadFile(providerLog) // #nosec G304 -- test-owned path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("replayed worker invoked the provider again")
+	}
+}
+
+// TestWorkerRejectsAnInvocationItWasNotPreparedFor covers the identity check on
+// the published request. A worker that executed a request belonging to another
+// root or invocation would run a prompt against the wrong project, so the
+// mismatch must terminalize the run as failed instead of proceeding.
+func TestWorkerRejectsAnInvocationItWasNotPreparedFor(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	run, _ := newWaitTestRun(t, root)
+	run.Record.State = dispatchStateRunning
+	run.Record.SupervisorPID = os.Getpid()
+	run.Record.SupervisorStartIdentity = processStartIdentity(os.Getpid())
+	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+		t.Fatal(err)
+	}
+	request := workerRequest{Root: filepath.Join(root, "other-project"), RunID: run.Record.ID, Prompt: []byte("Review this")}
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(run.Dir, workerRequestFile), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	gateRead, gateWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gateRead.Close() }()
+	if _, err := gateWrite.Write([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := gateWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunWorker(root, run.Record.ID, gateRead); err == nil {
+		t.Fatal("worker executed a request prepared for another project")
+	}
+	record, err := loadRunRecord(root, run.Record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != dispatchStateFailed {
+		t.Fatalf("run state = %q, want the mismatched invocation to fail", record.State)
+	}
+}

--- a/internal/agentdispatch/structured_json_test.go
+++ b/internal/agentdispatch/structured_json_test.go
@@ -1,0 +1,106 @@
+package agentdispatch
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// readTestStructuredLines drives the production structured-event reader over a
+// raw JSONL stream and returns every event it emitted.
+func readTestStructuredLines(t *testing.T, stream string) []providerEvent {
+	t.Helper()
+	var events []providerEvent
+	if err := readStructuredEventsWithLineage(strings.NewReader(stream), io.Discard, AgentCodex, "", false, func(event providerEvent) error {
+		events = append(events, event)
+		return nil
+	}, nil); err != nil {
+		t.Fatalf("reading structured events failed: %v", err)
+	}
+	return events
+}
+
+// TestMalformedStructuredEventsAreRejectedAndSkipped covers the contract that
+// makes a dispatch survive a misbehaving provider: a record the parser cannot
+// prove well-formed is never reduced into an event, its rejection is reported
+// with a diagnostic reason, and the next record on the stream is still
+// delivered. A provider that emits one bad line must not cost the run its
+// remaining output.
+func TestMalformedStructuredEventsAreRejectedAndSkipped(t *testing.T) {
+	deepObject := strings.Repeat(`{"a":`, structuredJSONMaxDepth+2) + "1" + strings.Repeat("}", structuredJSONMaxDepth+2)
+	deepArray := `{"a":` + strings.Repeat("[", structuredJSONMaxDepth+2) + strings.Repeat("]", structuredJSONMaxDepth+2) + "}"
+	oversizedMetadata := `{"thread_id":"` + strings.Repeat("t", structuredJSONKeyBytes+1) + `"}`
+
+	tests := []struct {
+		name       string
+		record     string
+		wantReason string
+	}{
+		{"top-level array", `["type"]`, "must be a JSON object"},
+		{"unquoted key", `{type:"turn.failed"}`, "object key must be a string"},
+		{"missing colon", `{"type" "turn.failed"}`, `must be followed by ':'`},
+		{"missing object separator", `{"type":"a" "id":"b"}`, "object values must be separated"},
+		{"missing array separator", `{"a":["x" "y"]}`, "array values must be separated"},
+		{"invalid value token", `{"type":@}`, "invalid JSON value"},
+		{"invalid literal", `{"type":tru}`, "invalid JSON literal"},
+		{"unescaped control character", "{\"type\":\"a\tb\"}", "unescaped control character"},
+		{"invalid string escape", `{"type":"a\qb"}`, "invalid escape"},
+		{"invalid unicode escape", `{"type":"a\u00zz"}`, "invalid unicode escape"},
+		{"malformed number", `{"type":1.2.3}`, "invalid JSON number"},
+		{"oversized number", `{"type":-` + strings.Repeat("9", 80) + `}`, "invalid JSON number"},
+		{"object nested past depth limit", deepObject, "maximum JSON nesting depth"},
+		{"array nested past depth limit", deepArray, "maximum JSON nesting depth"},
+		{"unterminated string", `{"type":"turn.failed`, "unexpected EOF"},
+		{"truncated object", `{"type":"turn.failed"`, "unexpected EOF"},
+		{"oversized retained metadata", oversizedMetadata, "metadata exceeded"},
+		{"multiple values on one line", `{"type":"turn.completed"}{"type":"turn.completed"}`, "multiple values"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			events := readTestStructuredLines(t, test.record+"\n"+`{"type":"turn.completed"}`+"\n")
+			if len(events) != 2 {
+				t.Fatalf("events = %#v, want one rejection followed by one recovered event", events)
+			}
+			if events[0].Kind != eventProgress || events[0].Activity != invalidStructuredEvent {
+				t.Fatalf("rejection event = %#v", events[0])
+			}
+			if !strings.Contains(events[0].Reason, test.wantReason) {
+				t.Fatalf("rejection reason = %q, want it to explain %q", events[0].Reason, test.wantReason)
+			}
+			if events[1].Kind != eventComplete {
+				t.Fatalf("recovered event = %#v, want the following record to still be delivered", events[1])
+			}
+		})
+	}
+}
+
+// TestStructuredEventsAcceptFullJSONValueGrammar covers provider records whose
+// well-formed JSON uses the parts of the grammar the reducers never read.
+// The selective parser validates the entire record, so a number, literal, or
+// escape it mishandles would reject an event the provider considers valid.
+func TestStructuredEventsAcceptFullJSONValueGrammar(t *testing.T) {
+	tests := []struct {
+		name   string
+		record string
+		want   string
+	}{
+		{"numeric fields", `{"type":"agent_message","usage":{"cost":-1.5e-3,"tokens":42},"message":"numbers parsed"}`, "numbers parsed"},
+		{"literal fields", `{"type":"agent_message","done":true,"cached":false,"parent":null,"message":"literals parsed"}`, "literals parsed"},
+		{"unicode escapes", `{"type":"agent_message","message":"café ✓"}`, "café ✓"},
+		{"control escapes", `{"type":"agent_message","message":"line\nbreak\ttab\\slash\"quote\""}`, "line\nbreak\ttab\\slash\"quote\""},
+		{"insignificant whitespace", "{ \"type\" : \"agent_message\" ,\t\"message\" :\r \"whitespace parsed\" }", "whitespace parsed"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			events := readTestStructuredLines(t, test.record+"\n")
+			if len(events) != 1 {
+				t.Fatalf("events = %#v, want exactly one reduced event", events)
+			}
+			if events[0].Kind != eventAnswer || events[0].Answer != test.want {
+				t.Fatalf("event = %#v, want answer %q", events[0], test.want)
+			}
+		})
+	}
+}

--- a/internal/agentdispatch/structured_json_test.go
+++ b/internal/agentdispatch/structured_json_test.go
@@ -87,7 +87,9 @@ func TestStructuredEventsAcceptFullJSONValueGrammar(t *testing.T) {
 	}{
 		{"numeric fields", `{"type":"agent_message","usage":{"cost":-1.5e-3,"tokens":42},"message":"numbers parsed"}`, "numbers parsed"},
 		{"literal fields", `{"type":"agent_message","done":true,"cached":false,"parent":null,"message":"literals parsed"}`, "literals parsed"},
-		{"unicode escapes", `{"type":"agent_message","message":"café ✓"}`, "café ✓"},
+		{"literal multi-byte UTF-8", `{"type":"agent_message","message":"café ✓"}`, "café ✓"},
+		{"unicode escapes", `{"type":"agent_message","message":"caf\u00e9 \u2713"}`, "café ✓"},
+		{"uppercase unicode escape digits", `{"type":"agent_message","message":"caf\u00E9"}`, "café"},
 		{"control escapes", `{"type":"agent_message","message":"line\nbreak\ttab\\slash\"quote\""}`, "line\nbreak\ttab\\slash\"quote\""},
 		{"insignificant whitespace", "{ \"type\" : \"agent_message\" ,\t\"message\" :\r \"whitespace parsed\" }", "whitespace parsed"},
 	}

--- a/internal/benchmark/campaign_guard_test.go
+++ b/internal/benchmark/campaign_guard_test.go
@@ -65,6 +65,11 @@ func newCampaignFixture(t *testing.T) campaignFixture {
 // stubCampaignPreflight replaces the environment probes a treatment performs
 // before it is allowed to spend money. Each returns nil unless a test overrides
 // it, so a single failing probe can be isolated.
+//
+// These are package-level function variables restored with t.Cleanup, so every
+// test in this package must run sequentially. Do not call t.Parallel() in a test
+// that uses this helper, or in any test that could run beside one: a parallel
+// test would observe another test's stub.
 func stubCampaignPreflight(t *testing.T) {
 	t.Helper()
 	originalPreflight := preflightBenchmark

--- a/internal/benchmark/campaign_guard_test.go
+++ b/internal/benchmark/campaign_guard_test.go
@@ -1,0 +1,190 @@
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// campaignFixture is a plan whose baseline arm is complete, so a treatment can
+// legitimately be checked against it.
+type campaignFixture struct {
+	root        string
+	planPath    string
+	loaded      loadedBenchmarkPlan
+	baselineDir string
+	checksums   map[string]string
+}
+
+func newCampaignFixture(t *testing.T) campaignFixture {
+	t.Helper()
+	root := t.TempDir()
+	planPath := filepath.Join(root, "plan.json")
+	writeBenchmarkPlanFixture(t, planPath)
+	addCostAxisToPlanFixture(t, planPath)
+	raw, err := os.ReadFile(planPath) // #nosec G304 -- planPath is test-owned.
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadBenchmarkPlanJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checksums := map[string]string{
+		"first-benchmark-task":  strings.Repeat("b", 64),
+		"second-benchmark-task": strings.Repeat("c", 64),
+	}
+	baselineDir := baselineStateDir(root, loaded.ID)
+	if err := writeJSON(filepath.Join(baselineDir, "manifest.json"), baselineManifest{
+		SchemaVersion: baselineStateSchema,
+		PlanID:        loaded.ID,
+		PlanSnapshot:  loaded.Plan.Snapshot.SHA256,
+		Model:         loaded.Plan.Target.Model,
+		Reasoning:     loaded.Plan.Target.Reasoning,
+		DeepSWECommit: DeepSWECommit,
+		PierVersion:   PierVersion,
+		TaskChecksums: checksums,
+		Repetitions:   repetitionsForPlan(loaded.Plan),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for task, scores := range map[string][]float64{
+		"first-benchmark-task":  {.2, .4},
+		"second-benchmark-task": {.6, .8},
+	} {
+		for index, score := range scores {
+			writeCampaignAttemptFixture(t, baselineDir, loaded, task, index+1, score, .1, 0, 0, true, false, checksums[task])
+		}
+	}
+	return campaignFixture{root: root, planPath: planPath, loaded: loaded, baselineDir: baselineDir, checksums: checksums}
+}
+
+// stubCampaignPreflight replaces the environment probes a treatment performs
+// before it is allowed to spend money. Each returns nil unless a test overrides
+// it, so a single failing probe can be isolated.
+func stubCampaignPreflight(t *testing.T) {
+	t.Helper()
+	originalPreflight := preflightBenchmark
+	originalPier := verifyBenchmarkPier
+	originalAuth := validateBenchmarkAuthentication
+	originalBundle := buildCampaignTreatmentBundle
+	preflightBenchmark = func([]parsedSelection) error { return nil }
+	verifyBenchmarkPier = func(context.Context) error { return nil }
+	validateBenchmarkAuthentication = func(string, []parsedSelection) error { return nil }
+	buildCampaignTreatmentBundle = func(_ string, _ string, mode string, _ Model, _ string) (*TreatmentBundle, error) {
+		return &TreatmentBundle{
+			Root:          t.TempDir(),
+			ManifestHash:  strings.Repeat("d", 64),
+			AdapterSHA256: strings.Repeat("e", 64),
+			Manifest: TreatmentManifest{
+				SchemaVersion:          TreatmentSchemaVersion,
+				Mode:                   mode,
+				AgentTimeoutMultiplier: skillsAgentTimeoutFactor,
+				RequiredRoles:          []string{requiredRolePlanReviewer, requiredRoleImplementer, requiredRoleCodeReviewer},
+			},
+		}, nil
+	}
+	t.Cleanup(func() {
+		preflightBenchmark = originalPreflight
+		verifyBenchmarkPier = originalPier
+		validateBenchmarkAuthentication = originalAuth
+		buildCampaignTreatmentBundle = originalBundle
+	})
+}
+
+// TestTreatmentRefusesToRunAgainstAnUnusableBaseline covers the precondition
+// every published comparison rests on: a treatment arm is only meaningful next
+// to a complete baseline collected under the same plan, model, and repetition
+// counts. Each case makes the comparison invalid in a different way, and none of
+// them may reach a provider call.
+func TestTreatmentRefusesToRunAgainstAnUnusableBaseline(t *testing.T) {
+	probeFailure := errors.New("probe failed")
+
+	tests := []struct {
+		name    string
+		breakIt func(t *testing.T, fixture *campaignFixture, options *TreatmentOptions)
+	}{
+		{"task concurrency beyond the supported range", func(_ *testing.T, _ *campaignFixture, options *TreatmentOptions) {
+			options.TaskConcurrency = 9
+		}},
+		{"no plan", func(_ *testing.T, _ *campaignFixture, options *TreatmentOptions) {
+			options.PlanPath = ""
+		}},
+		{"no repository root", func(_ *testing.T, _ *campaignFixture, options *TreatmentOptions) {
+			options.RepoRoot = ""
+		}},
+		{"baseline was never completed", func(t *testing.T, fixture *campaignFixture, _ *TreatmentOptions) {
+			if err := os.Remove(filepath.Join(fixture.baselineDir, "manifest.json")); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"baseline was collected for another model", func(t *testing.T, fixture *campaignFixture, _ *TreatmentOptions) {
+			manifest := readBaselineManifestFixture(t, fixture)
+			manifest.Model = "some-other-model"
+			writeBaselineManifestFixture(t, fixture, manifest)
+		}},
+		{"baseline used different repetition counts", func(t *testing.T, fixture *campaignFixture, _ *TreatmentOptions) {
+			manifest := readBaselineManifestFixture(t, fixture)
+			manifest.Repetitions["first-benchmark-task"] = 5
+			writeBaselineManifestFixture(t, fixture, manifest)
+		}},
+		{"baseline task checksum no longer matches its evidence", func(t *testing.T, fixture *campaignFixture, _ *TreatmentOptions) {
+			manifest := readBaselineManifestFixture(t, fixture)
+			manifest.TaskChecksums["first-benchmark-task"] = strings.Repeat("9", 64)
+			writeBaselineManifestFixture(t, fixture, manifest)
+		}},
+		{"required tooling is missing", func(t *testing.T, _ *campaignFixture, _ *TreatmentOptions) {
+			preflightBenchmark = func([]parsedSelection) error { return probeFailure }
+		}},
+		{"the pinned Pier version cannot be verified", func(t *testing.T, _ *campaignFixture, _ *TreatmentOptions) {
+			verifyBenchmarkPier = func(context.Context) error { return probeFailure }
+		}},
+		{"provider authentication is unusable", func(t *testing.T, _ *campaignFixture, _ *TreatmentOptions) {
+			validateBenchmarkAuthentication = func(string, []parsedSelection) error { return probeFailure }
+		}},
+		{"the treatment bundle cannot be built", func(t *testing.T, _ *campaignFixture, _ *TreatmentOptions) {
+			buildCampaignTreatmentBundle = func(string, string, string, Model, string) (*TreatmentBundle, error) {
+				return nil, probeFailure
+			}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newCampaignFixture(t)
+			stubCampaignPreflight(t)
+			options := TreatmentOptions{
+				RepoRoot: fixture.root, PlanPath: fixture.planPath,
+				Label: "Iteration 1", TaskConcurrency: 2, Confirmed: true,
+			}
+			test.breakIt(t, &fixture, &options)
+
+			executor := &baselineFakeExecutor{}
+			if _, err := RunTreatment(context.Background(), options, executor); err == nil {
+				t.Fatal("treatment proceeded against an unusable baseline")
+			}
+			if len(executor.calls) != 0 {
+				t.Fatalf("treatment made %d provider calls before failing", len(executor.calls))
+			}
+		})
+	}
+}
+
+func readBaselineManifestFixture(t *testing.T, fixture *campaignFixture) baselineManifest {
+	t.Helper()
+	var manifest baselineManifest
+	if err := readCampaignJSON(filepath.Join(fixture.baselineDir, "manifest.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func writeBaselineManifestFixture(t *testing.T, fixture *campaignFixture, manifest baselineManifest) {
+	t.Helper()
+	if err := writeJSON(filepath.Join(fixture.baselineDir, "manifest.json"), manifest); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/benchmark/evidence_test.go
+++ b/internal/benchmark/evidence_test.go
@@ -96,8 +96,14 @@ func TestAttemptResultRejectsIncompleteEvidence(t *testing.T) {
 		{"coordinator cost falls outside its own range", func(r *AttemptResult) {
 			r.CoordinatorCostUSD = floatPointer(.9)
 		}},
+		// The whole child range moves together so it stays internally valid and
+		// only its reconciliation with the reported total is broken. Lowering the
+		// midpoint alone would be rejected by the range check first, leaving the
+		// reconciliation rule unproven.
 		{"components do not sum to the reported cost", func(r *AttemptResult) {
 			r.ChildCostUSD = floatPointer(.9)
+			r.ChildCostMinUSD = floatPointer(.8)
+			r.ChildCostMaxUSD = floatPointer(.9)
 		}},
 	}
 

--- a/internal/benchmark/evidence_test.go
+++ b/internal/benchmark/evidence_test.go
@@ -1,0 +1,113 @@
+package benchmark
+
+import (
+	"testing"
+	"time"
+)
+
+func floatPointer(value float64) *float64 {
+	return &value
+}
+
+// validAttemptResult returns a successful provider-usage attempt whose score,
+// duration, and component costs all reconcile.
+func validAttemptResult() AttemptResult {
+	return AttemptResult{
+		SchemaVersion:         StorageSchemaVersion,
+		EventID:               "0123456789abcdef0123456789abcdef",
+		Attempt:               1,
+		Task:                  "example-benchmark-task",
+		Status:                statusSuccess,
+		F2PPassed:             3,
+		F2PTotal:              4,
+		F2PScore:              .75,
+		CostUSD:               floatPointer(1.5),
+		CostMinUSD:            floatPointer(1.4),
+		CostMaxUSD:            floatPointer(1.6),
+		CostKind:              costKindProviderTotal,
+		DurationSeconds:       floatPointer(12),
+		TaskChecksum:          "checksum",
+		StartedAt:             time.Date(2026, 7, 27, 15, 0, 0, 0, time.UTC),
+		FinishedAt:            time.Date(2026, 7, 27, 15, 5, 0, 0, time.UTC),
+		Provider:              "openai",
+		PublishedModel:        "gpt-5-6-luna",
+		RuntimeModel:          "gpt-5-6-luna-2026-07-01",
+		ReasoningEffort:       effortLow,
+		ProviderClientVersion: "1.2.3",
+		DispatchConformant:    true,
+		InvocationCount:       4,
+		CoordinatorCostUSD:    floatPointer(.5),
+		CoordinatorCostMinUSD: floatPointer(.4),
+		CoordinatorCostMaxUSD: floatPointer(.6),
+		ChildCostUSD:          floatPointer(1),
+		ChildCostMinUSD:       floatPointer(1),
+		ChildCostMaxUSD:       floatPointer(1),
+	}
+}
+
+func TestValidAttemptResultIsAcceptedAsEvidence(t *testing.T) {
+	if err := validAttemptResult().Validate(); err != nil {
+		t.Fatalf("complete attempt evidence was rejected: %v", err)
+	}
+	failed := validAttemptResult()
+	failed.Status = statusFailed
+	failed.Error = "provider returned a non-zero exit status"
+	if err := failed.Validate(); err != nil {
+		t.Fatalf("failed attempt evidence with a recorded error was rejected: %v", err)
+	}
+}
+
+// TestAttemptResultRejectsIncompleteEvidence covers the boundary that keeps a
+// benchmark comparison honest: an attempt is written into the immutable store
+// and later averaged into a published verdict, so evidence that is incomplete,
+// self-contradictory, or silently missing a cost component must never be
+// accepted. Each case breaks one requirement a real provider run satisfies.
+func TestAttemptResultRejectsIncompleteEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		broken func(*AttemptResult)
+	}{
+		{"stored under a different schema version", func(r *AttemptResult) {
+			r.SchemaVersion = "benchmark-store-v0"
+		}},
+		{"no event identity", func(r *AttemptResult) { r.EventID = "" }},
+		{"attempt is not numbered from one", func(r *AttemptResult) { r.Attempt = 0 }},
+		{"task name is not a catalog identifier", func(r *AttemptResult) { r.Task = "Example Task" }},
+		{"status is neither success nor failure", func(r *AttemptResult) { r.Status = "cancelled" }},
+		{"no task checksum ties the run to its task", func(r *AttemptResult) { r.TaskChecksum = "" }},
+		{"runtime model is unrecorded", func(r *AttemptResult) { r.RuntimeModel = "" }},
+		{"reasoning effort is not a supported level", func(r *AttemptResult) { r.ReasoningEffort = "turbo" }},
+		{"provider client version is unrecorded", func(r *AttemptResult) { r.ProviderClientVersion = "" }},
+		{"run has no finish time", func(r *AttemptResult) { r.FinishedAt = time.Time{} }},
+		{"failure records no error", func(r *AttemptResult) {
+			r.Status = statusFailed
+			r.Error = ""
+		}},
+		{"success also records an error", func(r *AttemptResult) { r.Error = "partially failed" }},
+		{"score has no tests to pass", func(r *AttemptResult) { r.F2PTotal = 0 }},
+		{"more tests passed than exist", func(r *AttemptResult) { r.F2PPassed = 5 }},
+		{"score contradicts the pass counts", func(r *AttemptResult) { r.F2PScore = 1 }},
+		{"duration is unrecorded", func(r *AttemptResult) { r.DurationSeconds = nil }},
+		{"cost midpoint is unrecorded", func(r *AttemptResult) { r.CostUSD = nil }},
+		{"cost range is missing its upper bound", func(r *AttemptResult) { r.CostMaxUSD = nil }},
+		{"cost midpoint falls outside its range", func(r *AttemptResult) { r.CostUSD = floatPointer(2) }},
+		{"component costs carry no invocation count", func(r *AttemptResult) { r.InvocationCount = 0 }},
+		{"child cost component is missing", func(r *AttemptResult) { r.ChildCostUSD = nil }},
+		{"coordinator cost falls outside its own range", func(r *AttemptResult) {
+			r.CoordinatorCostUSD = floatPointer(.9)
+		}},
+		{"components do not sum to the reported cost", func(r *AttemptResult) {
+			r.ChildCostUSD = floatPointer(.9)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := validAttemptResult()
+			test.broken(&result)
+			if err := result.Validate(); err == nil {
+				t.Fatal("incomplete attempt evidence was accepted into benchmark analysis")
+			}
+		})
+	}
+}

--- a/internal/benchmark/execution_run_test.go
+++ b/internal/benchmark/execution_run_test.go
@@ -61,6 +61,19 @@ func fakePierArgv(t *testing.T, argvPath string) []string {
 	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 }
 
+// stubPinnedCheckout points benchmark execution at a fixed checkout path.
+//
+// This replaces a package-level function variable and restores it with
+// t.Cleanup, so every test in this package must run sequentially. Do not call
+// t.Parallel() in a test that uses this helper, or in any test that could run
+// beside one: a parallel test would observe another test's stub.
+func stubPinnedCheckout(t *testing.T, checkout string) {
+	t.Helper()
+	original := ensurePinnedBenchmarkCheckout
+	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) { return checkout, nil }
+	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = original })
+}
+
 func argvContainsPair(argv []string, flag, value string) bool {
 	for index := range argv {
 		if argv[index] == flag && index+1 < len(argv) && argv[index+1] == value {
@@ -78,9 +91,7 @@ func argvContainsPair(argv []string, flag, value string) bool {
 func TestPierExecutionPinsTheRunAndNormalizesItsEvidence(t *testing.T) {
 	repository := t.TempDir()
 	checkout := filepath.Join(repository, "pinned-checkout")
-	originalCheckout := ensurePinnedBenchmarkCheckout
-	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) { return checkout, nil }
-	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = originalCheckout })
+	stubPinnedCheckout(t, checkout)
 
 	argvPath := installFakePier(t, "task-checksum")
 	model, effort, err := ParseModelSelection("fable:high")
@@ -157,11 +168,7 @@ func TestPierTreatmentExecutionRunsTheImmutableBundle(t *testing.T) {
 	if err := os.WriteFile(credentials, []byte(`{"accessToken":"secret"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	originalCheckout := ensurePinnedBenchmarkCheckout
-	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) {
-		return filepath.Join(repository, "pinned-checkout"), nil
-	}
-	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = originalCheckout })
+	stubPinnedCheckout(t, filepath.Join(repository, "pinned-checkout"))
 
 	argvPath := installFakePier(t, "task-checksum")
 	model, effort, err := ParseModelSelection("fable:high")
@@ -226,7 +233,12 @@ func TestPierTreatmentExecutionRunsTheImmutableBundle(t *testing.T) {
 	}
 }
 
+// TestPierExecutionRejectsIncompleteRequests covers the request contract that
+// runs before any provider is reached. Each case names the rejection it expects,
+// so a case cannot pass because of unrelated setup, and the baseline request is
+// asserted to clear this gate so no case can pass vacuously.
 func TestPierExecutionRejectsIncompleteRequests(t *testing.T) {
+	const invalidRequest = "invalid Pier execution request"
 	valid := ExecutionRequest{
 		RepoRoot: t.TempDir(), EvidenceDir: t.TempDir(), EventID: "event",
 		Attempt: 1, Task: "example-task", Arm: ArmBaseline,
@@ -234,27 +246,39 @@ func TestPierExecutionRejectsIncompleteRequests(t *testing.T) {
 	tests := []struct {
 		name   string
 		broken func(*ExecutionRequest)
+		want   string
 	}{
-		{"no repository root", func(r *ExecutionRequest) { r.RepoRoot = "" }},
-		{"no evidence directory", func(r *ExecutionRequest) { r.EvidenceDir = "" }},
-		{"no event identity", func(r *ExecutionRequest) { r.EventID = "" }},
-		{"unnumbered attempt", func(r *ExecutionRequest) { r.Attempt = 0 }},
-		{"task is not a catalog identifier", func(r *ExecutionRequest) { r.Task = "../escape" }},
-		{"arm is neither baseline nor treatment", func(r *ExecutionRequest) { r.Arm = "control" }},
-		{"treatment without a bundle", func(r *ExecutionRequest) { r.Arm = ArmTreatment }},
+		{"no repository root", func(r *ExecutionRequest) { r.RepoRoot = "" }, invalidRequest},
+		{"no evidence directory", func(r *ExecutionRequest) { r.EvidenceDir = "" }, invalidRequest},
+		{"no event identity", func(r *ExecutionRequest) { r.EventID = "" }, invalidRequest},
+		{"unnumbered attempt", func(r *ExecutionRequest) { r.Attempt = 0 }, invalidRequest},
+		{"task is not a catalog identifier", func(r *ExecutionRequest) { r.Task = "../escape" }, invalidRequest},
+		{"arm is neither baseline nor treatment", func(r *ExecutionRequest) { r.Arm = "control" }, invalidRequest},
+		{"treatment without a bundle", func(r *ExecutionRequest) { r.Arm = ArmTreatment }, "requires an immutable treatment bundle"},
 	}
-	originalCheckout := ensurePinnedBenchmarkCheckout
-	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) {
-		return "", nil
+	stubPinnedCheckout(t, "")
+	// The fake runner keeps the baseline probe below offline; without it the
+	// real `uvx` would be invoked and would try to resolve Pier from the network.
+	installFakePier(t, "task-checksum")
+
+	// The baseline request must clear request validation, otherwise every case
+	// below would be rejected for the same reason no matter what it broke. It
+	// still fails afterwards because it records no task checksum to match.
+	if _, err := (PierExecutor{}).Execute(context.Background(), valid); err == nil ||
+		strings.Contains(err.Error(), invalidRequest) {
+		t.Fatalf("baseline request did not clear request validation: %v", err)
 	}
-	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = originalCheckout })
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			request := valid
 			test.broken(&request)
-			if _, err := (PierExecutor{}).Execute(context.Background(), request); err == nil {
+			_, err := PierExecutor{}.Execute(context.Background(), request)
+			if err == nil {
 				t.Fatal("a paid run was started from an incomplete request")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("rejection = %v, want it to name %q", err, test.want)
 			}
 		})
 	}

--- a/internal/benchmark/execution_run_test.go
+++ b/internal/benchmark/execution_run_test.go
@@ -1,0 +1,261 @@
+package benchmark
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFakePier puts a `uvx` stand-in on PATH that records the exact command
+// line it was invoked with and materializes the job output a real Pier run
+// would leave behind, so an execution can be driven end to end without paying
+// a provider.
+func installFakePier(t *testing.T, checksum string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	argvPath := filepath.Join(binDir, "argv.txt")
+	script := `#!/bin/sh
+: > "` + argvPath + `"
+jobs_dir=""
+job_name=""
+while [ "$#" -gt 0 ]; do
+  printf '%s\n' "$1" >> "` + argvPath + `"
+  case "$1" in
+    --jobs-dir) jobs_dir="$2" ;;
+    --job-name) job_name="$2" ;;
+  esac
+  shift
+done
+job="$jobs_dir/$job_name"
+mkdir -p "$job/verifier" "$job/artifacts"
+printf 'diff --git a/a b/a\n' > "$job/artifacts/model.patch"
+printf 'verifier passed\n' > "$job/verifier/run.log"
+cat > "$job/result.json" <<'RESULT'
+{
+  "task_checksum": "` + checksum + `",
+  "started_at": "2026-07-27T15:00:00Z",
+  "finished_at": "2026-07-27T15:04:00Z",
+  "agent_info": {"model_info": {"provider": "anthropic"}},
+  "agent_result": {"cost_usd": 2.5},
+  "verifier_result": {"rewards": {"reward": 0.8, "f2p_total": 10, "f2p_passed": 8, "f2p": 0.8, "partial": 0.8}},
+  "exception_info": null
+}
+RESULT
+`
+	path := filepath.Join(binDir, commandUVX)
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil { // #nosec G306 -- the fake Pier runner must be executable.
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argvPath
+}
+
+func fakePierArgv(t *testing.T, argvPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(argvPath) // #nosec G304 -- test-owned path.
+	if err != nil {
+		t.Fatalf("the fake Pier runner was never invoked: %v", err)
+	}
+	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+}
+
+func argvContainsPair(argv []string, flag, value string) bool {
+	for index := range argv {
+		if argv[index] == flag && index+1 < len(argv) && argv[index+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPierExecutionPinsTheRunAndNormalizesItsEvidence covers the boundary where
+// money is spent: every paid Pier run must be pinned to the checked-out task
+// set and the requested model, must run the requested arm's agent, and must
+// come back as validated, sanitized evidence rather than raw output. A wrong
+// flag here silently measures something other than what the campaign claims.
+func TestPierExecutionPinsTheRunAndNormalizesItsEvidence(t *testing.T) {
+	repository := t.TempDir()
+	checkout := filepath.Join(repository, "pinned-checkout")
+	originalCheckout := ensurePinnedBenchmarkCheckout
+	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) { return checkout, nil }
+	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = originalCheckout })
+
+	argvPath := installFakePier(t, "task-checksum")
+	model, effort, err := ParseModelSelection("fable:high")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ExecutionRequest{
+		RepoRoot:     repository,
+		EvidenceDir:  filepath.Join(repository, "evidence"),
+		EventID:      "event-one",
+		Attempt:      1,
+		Task:         "example-task",
+		Model:        model,
+		Effort:       effort,
+		Arm:          ArmBaseline,
+		TaskChecksum: "task-checksum",
+	}
+
+	result, err := PierExecutor{}.Execute(context.Background(), request)
+	if err != nil {
+		t.Fatalf("baseline execution failed: %v", err)
+	}
+
+	argv := fakePierArgv(t, argvPath)
+	for _, pair := range [][2]string{
+		{"--from", "datacurve-pier==" + PierVersion},
+		{"--path", filepath.Join(checkout, "tasks")},
+		{"--model", model.RuntimeIdentifier},
+		{"--include-task-name", "example-task"},
+		{"--job-name", "event-one"},
+		{"--n-attempts", "1"},
+		{"--max-retries", "0"},
+		{"--agent", model.Adapter},
+		{pierAgentKwarg, "reasoning_effort=" + effort},
+		{pierAgentKwarg, "version=" + model.ProviderClientVersion},
+	} {
+		if !argvContainsPair(argv, pair[0], pair[1]) {
+			t.Fatalf("paid run did not pin %s %s; argv = %#v", pair[0], pair[1], argv)
+		}
+	}
+
+	if result.Status != statusSuccess || result.F2PScore != .8 || *result.CostUSD != 2.5 ||
+		result.Provider != "anthropic" || result.TaskChecksum != "task-checksum" ||
+		result.PatchBytes == 0 || result.VerifierBuildFailed {
+		t.Fatalf("normalized result = %#v", result)
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("execution returned evidence that does not validate: %v", err)
+	}
+	promoted := filepath.Join(request.EvidenceDir, "attempts", "1", "tasks", "example-task", "artifacts", "event-one")
+	for _, artifact := range []string{
+		filepath.Join(promoted, "pier-command.log"),
+		filepath.Join(promoted, "jobs", "event-one", "result.json"),
+	} {
+		if _, err := os.Stat(artifact); err != nil {
+			t.Fatalf("execution did not promote %s: %v", artifact, err)
+		}
+	}
+	if entries, err := os.ReadDir(filepath.Join(repository, ".agent-layer", "tmp")); err != nil || len(entries) != 0 {
+		t.Fatalf("execution left its staging directory behind: %#v, %v", entries, err)
+	}
+}
+
+// TestPierTreatmentExecutionRunsTheImmutableBundle covers the treatment arm's
+// distinguishing contract: the run must load the Agent Layer adapter and carry
+// the bundle's identity and execution policy, because that bundle is the only
+// thing separating the treatment from the baseline it is compared against.
+func TestPierTreatmentExecutionRunsTheImmutableBundle(t *testing.T) {
+	repository := t.TempDir()
+	credentials := filepath.Join(repository, ".claude-config", ".credentials.json")
+	if err := os.MkdirAll(filepath.Dir(credentials), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentials, []byte(`{"accessToken":"secret"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalCheckout := ensurePinnedBenchmarkCheckout
+	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) {
+		return filepath.Join(repository, "pinned-checkout"), nil
+	}
+	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = originalCheckout })
+
+	argvPath := installFakePier(t, "task-checksum")
+	model, effort, err := ParseModelSelection("fable:high")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := &TreatmentBundle{
+		Root:        filepath.Join(repository, "bundle"),
+		AdapterPath: filepath.Join(repository, "bundle", "pier_agent_layer", "__init__.py"),
+		Manifest: TreatmentManifest{
+			Mode:                   TreatmentInstructionsAndSkills,
+			RequiredRoles:          []string{requiredRolePlanReviewer, requiredRoleImplementer},
+			AgentTimeoutMultiplier: skillsAgentTimeoutFactor,
+		},
+	}
+	request := ExecutionRequest{
+		RepoRoot:     repository,
+		EvidenceDir:  filepath.Join(repository, "evidence"),
+		EventID:      "event-two",
+		Attempt:      1,
+		Task:         "example-task",
+		Model:        model,
+		Effort:       effort,
+		Arm:          ArmTreatment,
+		Bundle:       bundle,
+		TaskChecksum: "task-checksum",
+	}
+
+	result, err := PierExecutor{}.Execute(context.Background(), request)
+	if err != nil {
+		t.Fatalf("treatment execution failed: %v", err)
+	}
+	// Treatment cost is accounted per component so a dispatched child's spend
+	// cannot be hidden inside the coordinator's reported total.
+	if result.CostKind != costKindProviderTotal || *result.CoordinatorCostUSD != 2.5 ||
+		*result.ChildCostUSD != 0 || *result.CostUSD != 2.5 {
+		t.Fatalf("treatment cost accounting = %#v", result)
+	}
+	// The fake run performs no dispatch, so the required roles are unmet and the
+	// run must be reported as non-conformant instead of silently counting.
+	if result.DispatchConformant {
+		t.Fatal("a run with no dispatch lifecycle was reported as dispatch-conformant")
+	}
+
+	argv := fakePierArgv(t, argvPath)
+	for _, pair := range [][2]string{
+		{"--agent-import-path", "pier_agent_layer:AgentLayerClaudeCode"},
+		{"--agent-timeout-multiplier", "4"},
+		{pierAgentKwarg, "treatment_bundle=" + bundle.Root},
+		{pierAgentKwarg, "treatment_mode=" + TreatmentInstructionsAndSkills},
+		{pierAgentKwarg, "required_dispatch_roles=" + requiredRolePlanReviewer + "," + requiredRoleImplementer},
+		{pierAgentKwarg, "claude_credentials_path=" + credentials},
+	} {
+		if !argvContainsPair(argv, pair[0], pair[1]) {
+			t.Fatalf("treatment run did not pin %s %s; argv = %#v", pair[0], pair[1], argv)
+		}
+	}
+	for _, argument := range argv {
+		if argument == "--agent" {
+			t.Fatalf("treatment run fell back to the baseline agent; argv = %#v", argv)
+		}
+	}
+}
+
+func TestPierExecutionRejectsIncompleteRequests(t *testing.T) {
+	valid := ExecutionRequest{
+		RepoRoot: t.TempDir(), EvidenceDir: t.TempDir(), EventID: "event",
+		Attempt: 1, Task: "example-task", Arm: ArmBaseline,
+	}
+	tests := []struct {
+		name   string
+		broken func(*ExecutionRequest)
+	}{
+		{"no repository root", func(r *ExecutionRequest) { r.RepoRoot = "" }},
+		{"no evidence directory", func(r *ExecutionRequest) { r.EvidenceDir = "" }},
+		{"no event identity", func(r *ExecutionRequest) { r.EventID = "" }},
+		{"unnumbered attempt", func(r *ExecutionRequest) { r.Attempt = 0 }},
+		{"task is not a catalog identifier", func(r *ExecutionRequest) { r.Task = "../escape" }},
+		{"arm is neither baseline nor treatment", func(r *ExecutionRequest) { r.Arm = "control" }},
+		{"treatment without a bundle", func(r *ExecutionRequest) { r.Arm = ArmTreatment }},
+	}
+	originalCheckout := ensurePinnedBenchmarkCheckout
+	ensurePinnedBenchmarkCheckout = func(context.Context, string) (string, error) {
+		return "", nil
+	}
+	t.Cleanup(func() { ensurePinnedBenchmarkCheckout = originalCheckout })
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := valid
+			test.broken(&request)
+			if _, err := (PierExecutor{}).Execute(context.Background(), request); err == nil {
+				t.Fatal("a paid run was started from an incomplete request")
+			}
+		})
+	}
+}

--- a/internal/benchmark/normalize_verifier_test.go
+++ b/internal/benchmark/normalize_verifier_test.go
@@ -1,0 +1,103 @@
+package benchmark
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeVerifierStageFile(t *testing.T, stage string, relativePath string, content string) {
+	t.Helper()
+	fullPath := filepath.Join(stage, relativePath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func buildOutputEvents(outputs ...string) string {
+	var builder strings.Builder
+	for _, output := range outputs {
+		fmt.Fprintf(&builder, "{\"Action\":\"build-output\",\"Output\":%q}\n", output)
+	}
+	return builder.String()
+}
+
+// TestVerifierBuildFailureIsDetectedOnlyFromVerifierLogs covers the signal that
+// separates "the agent's patch scored zero" from "the score is not evidence at
+// all". A build failure the verifier hit must be reported so analysis can
+// discount the run, and agent-side output that merely mentions a build failure
+// must not be mistaken for one.
+func TestVerifierBuildFailureIsDetectedOnlyFromVerifierLogs(t *testing.T) {
+	t.Run("clean verifier reports no failure", func(t *testing.T) {
+		stage := t.TempDir()
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "verifier", "run.log"), "ok\n")
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "build-events.jsonl"), buildOutputEvents("warning: unused import"))
+		failed, excerpt, err := verifierBuildFailed(stage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if failed || excerpt != "" {
+			t.Fatalf("clean verifier reported failed=%t excerpt=%q", failed, excerpt)
+		}
+	})
+
+	t.Run("agent output outside the verifier is not a verifier failure", func(t *testing.T) {
+		stage := t.TempDir()
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "agent", "test-stdout.txt"), "[build failed]\n")
+		failed, _, err := verifierBuildFailed(stage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if failed {
+			t.Fatal("agent-side log was counted as a verifier build failure")
+		}
+	})
+
+	t.Run("failure is reported with its build output excerpt", func(t *testing.T) {
+		stage := t.TempDir()
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "verifier", "test-stdout.txt"), "[build failed]\n")
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "build-events.jsonl"), strings.Join([]string{
+			`{"Action":"run","Output":"ignored non-build output"}`,
+			`not-json`,
+			buildOutputEvents("main.go:3:2: undefined: helper\n\n", "main.go:9:1: syntax error"),
+		}, "\n"))
+		failed, excerpt, err := verifierBuildFailed(stage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !failed {
+			t.Fatal("verifier build failure was not detected")
+		}
+		if excerpt != "main.go:3:2: undefined: helper\nmain.go:9:1: syntax error" {
+			t.Fatalf("excerpt = %q, want only the build output lines", excerpt)
+		}
+	})
+
+	t.Run("excerpt is bounded", func(t *testing.T) {
+		stage := t.TempDir()
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "verifier", "run.log"), `{"FailedBuild":"package"}`)
+		outputs := make([]string, 0, buildErrorExcerptLines*2)
+		for index := range buildErrorExcerptLines * 2 {
+			outputs = append(outputs, fmt.Sprintf("error line %d", index))
+		}
+		writeVerifierStageFile(t, stage, filepath.Join("jobs", "one", "build-events.jsonl"), buildOutputEvents(outputs...))
+		failed, excerpt, err := verifierBuildFailed(stage)
+		if err != nil || !failed {
+			t.Fatalf("failed=%t, err=%v", failed, err)
+		}
+		if lines := strings.Count(excerpt, "\n") + 1; lines != buildErrorExcerptLines {
+			t.Fatalf("excerpt kept %d lines, want it capped at %d", lines, buildErrorExcerptLines)
+		}
+	})
+
+	t.Run("missing job output is an error, not a clean verifier", func(t *testing.T) {
+		if _, _, err := verifierBuildFailed(t.TempDir()); err == nil {
+			t.Fatal("a stage with no job output was reported as a passing verifier build")
+		}
+	})
+}

--- a/internal/benchmark/observed_report_test.go
+++ b/internal/benchmark/observed_report_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 )
 
-func TestBuildObservedReportValidatesAndRendersExecutiveResult(t *testing.T) {
+// validObservedAnalysisDocument returns a canonical analysis artifact whose
+// identity, statistics, costs, and per-task evidence all reconcile.
+func validObservedAnalysisDocument() observedAnalysisDocument {
 	document := observedAnalysisDocument{
 		Schema:        observedAnalysisSchema,
 		SchemaVersion: observedAnalysisSchemaVersion,
@@ -58,6 +60,11 @@ func TestBuildObservedReportValidatesAndRendersExecutiveResult(t *testing.T) {
 	document.CostAxis.ReferenceEstimatedArmCostUSD = 310.61
 	document.CostAxis.RoundingIncrementUSD = observedCostAxisRoundingUSD
 	document.CostAxis.MaximumUSD = 350
+	return document
+}
+
+func TestBuildObservedReportValidatesAndRendersExecutiveResult(t *testing.T) {
+	document := validObservedAnalysisDocument()
 
 	data, err := json.Marshal(document)
 	if err != nil {
@@ -134,5 +141,85 @@ func TestBuildObservedReportValidatesAndRendersExecutiveResult(t *testing.T) {
 	}
 	if _, err := BuildObservedCampaignReport(invalid); err == nil {
 		t.Fatal("observed report accepted a verdict that contradicted its threshold")
+	}
+}
+
+// TestObservedReportRejectsEvidenceThatDoesNotReconcile covers the guarantee
+// that makes a published benchmark report trustworthy: the report is derived
+// only from an analysis artifact whose statistics, costs, and per-task scores
+// are internally consistent. Each case breaks exactly one of those invariants,
+// so a report that renders anyway would be presenting a claim its own evidence
+// does not support.
+func TestObservedReportRejectsEvidenceThatDoesNotReconcile(t *testing.T) {
+	tests := []struct {
+		name   string
+		broken func(*observedAnalysisDocument)
+	}{
+		{"unsupported schema version", func(d *observedAnalysisDocument) {
+			d.SchemaVersion = observedAnalysisSchemaVersion + 1
+		}},
+		{"missing generation time", func(d *observedAnalysisDocument) {
+			d.GeneratedAt = time.Time{}
+		}},
+		{"plan identity is not a full digest", func(d *observedAnalysisDocument) {
+			d.PlanID = strings.Repeat("a", 32)
+		}},
+		{"task count contradicts the task evidence", func(d *observedAnalysisDocument) {
+			d.Experiment.Tasks = 2
+		}},
+		{"tasks are not weighted equally", func(d *observedAnalysisDocument) {
+			d.Experiment.EqualTaskWeighting = false
+		}},
+		{"significance level is not a probability", func(d *observedAnalysisDocument) {
+			d.Experiment.TwoSidedSignificanceLevel = 1
+		}},
+		{"cost axis maximum is not the rounded reference", func(d *observedAnalysisDocument) {
+			d.CostAxis.MaximumUSD = 400
+		}},
+		{"threshold is not the critical value times the standard error", func(d *observedAnalysisDocument) {
+			d.Result.DecisionThreshold = .3
+		}},
+		{"observed difference contradicts the arm means", func(d *observedAnalysisDocument) {
+			d.Result.ObservedDifference = .1
+		}},
+		{"cost range is inverted", func(d *observedAnalysisDocument) {
+			d.CostUSD.Treatment.Maximum = 1
+		}},
+		{"total cost does not reconcile with the arms", func(d *observedAnalysisDocument) {
+			d.CostUSD.Total.Midpoint = 4
+		}},
+		{"baseline cost cannot anchor a cost multiple", func(d *observedAnalysisDocument) {
+			d.CostUSD.Baseline = ObservedCostRange{}
+			d.CostUSD.Total = ObservedCostRange{Midpoint: 2, Minimum: 1.9, Maximum: 2.1}
+		}},
+		{"more runs claimed conformant than were run", func(d *observedAnalysisDocument) {
+			d.TreatmentDiagnostics.DispatchConformantRuns = d.TreatmentDiagnostics.TotalRuns + 1
+		}},
+		{"task has fewer scores than repetitions", func(d *observedAnalysisDocument) {
+			d.Tasks[0].TreatmentScores = []float64{.7}
+		}},
+		{"task score is outside the score range", func(d *observedAnalysisDocument) {
+			d.Tasks[0].BaselineScores = []float64{.4, 1.6}
+		}},
+		{"task mean contradicts its scores", func(d *observedAnalysisDocument) {
+			d.Tasks[0].TreatmentMean = .9
+		}},
+		{"run total contradicts the per-task repetitions", func(d *observedAnalysisDocument) {
+			d.TreatmentDiagnostics.TotalRuns = 3
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			document := validObservedAnalysisDocument()
+			test.broken(&document)
+			data, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := BuildObservedCampaignReport(data); err == nil {
+				t.Fatal("observed report accepted analysis evidence that does not reconcile")
+			}
+		})
 	}
 }

--- a/internal/benchmark/plan_validation_test.go
+++ b/internal/benchmark/plan_validation_test.go
@@ -1,0 +1,158 @@
+package benchmark
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validBenchmarkPlanDocument returns the exported plan fixture as a mutable
+// document so a single field can be invalidated per case.
+func validBenchmarkPlanDocument(t *testing.T) map[string]any {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plan.json")
+	writeBenchmarkPlanFixture(t, path)
+	addCostAxisToPlanFixture(t, path)
+	raw, err := os.ReadFile(path) // #nosec G304 -- test-owned path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	return document
+}
+
+func planTasksFixture(document map[string]any) []any {
+	return document["tasks"].([]any)
+}
+
+func planTaskFixture(document map[string]any, index int) map[string]any {
+	return planTasksFixture(document)[index].(map[string]any)
+}
+
+// TestBenchmarkPlanRejectsAnythingItCannotVouchFor covers the only gate between
+// a JSON file the user pastes in and a run that spends real money against a
+// provider. The plan carries the task selection, repetition counts, and spend
+// estimate the campaign is later reported under, so a plan whose own numbers do
+// not agree — or whose provenance is missing — must never be loaded.
+func TestBenchmarkPlanRejectsAnythingItCannotVouchFor(t *testing.T) {
+	if _, err := loadBenchmarkPlanJSON(nil); err == nil {
+		t.Fatal("an empty plan was accepted")
+	}
+	if _, err := loadBenchmarkPlanJSON([]byte("not-json")); err == nil {
+		t.Fatal("a plan that is not JSON was accepted")
+	}
+
+	tests := []struct {
+		name    string
+		breakIt func(map[string]any)
+	}{
+		{"unsupported schema", func(d map[string]any) { d["schema"] = "some-other-schema" }},
+		{"unsupported schema version", func(d map[string]any) { d["schemaVersion"] = 99 }},
+		{"the website never marked the result valid", func(d map[string]any) {
+			d["result"].(map[string]any)["valid"] = false
+		}},
+		{"snapshot provenance points elsewhere", func(d map[string]any) {
+			d["snapshot"].(map[string]any)["url"] = "https://example.com/trials.json"
+		}},
+		{"snapshot digest is not a full hash", func(d map[string]any) {
+			d["snapshot"].(map[string]any)["sha256"] = strings.Repeat("a", 32)
+		}},
+		{"target model is not a supported selection", func(d map[string]any) {
+			d["target"].(map[string]any)["model"] = "some-unreleased-model"
+		}},
+		{"no published harness", func(d map[string]any) {
+			d["target"].(map[string]any)["harnesses"] = []any{}
+		}},
+		{"a published harness is unnamed", func(d map[string]any) {
+			d["target"].(map[string]any)["harnesses"] = []any{""}
+		}},
+		{"no tasks selected", func(d map[string]any) { d["tasks"] = []any{} }},
+		{"significance level is not a probability", func(d map[string]any) {
+			d["parameters"].(map[string]any)["twoSidedSignificanceLevel"] = 1.0
+		}},
+		{"estimated spend exceeds the plan budget", func(d map[string]any) {
+			d["parameters"].(map[string]any)["baselineBudgetUsd"] = .05
+		}},
+		{"decision threshold is outside the score range", func(d map[string]any) {
+			d["result"].(map[string]any)["decisionThreshold"] = 1.5
+		}},
+		{"a task is repeated", func(d map[string]any) {
+			planTaskFixture(d, 1)["id"] = planTaskFixture(d, 0)["id"]
+		}},
+		{"a task name is not a catalog identifier", func(d map[string]any) {
+			planTaskFixture(d, 0)["id"] = "First Benchmark Task"
+		}},
+		{"a task has too few repetitions to estimate variance", func(d map[string]any) {
+			planTaskFixture(d, 0)["repetitionsPerArm"] = 1
+		}},
+		{"a task has more repetitions than the plan allows", func(d map[string]any) {
+			planTaskFixture(d, 0)["repetitionsPerArm"] = 5
+		}},
+		{"a task target mean is outside the score range", func(d map[string]any) {
+			planTaskFixture(d, 0)["target"].(map[string]any)["mean"] = 1.5
+		}},
+		{"a task carries no cost estimate", func(d map[string]any) {
+			planTaskFixture(d, 0)["targetEstimatedBaselineCostUsd"] = 0
+		}},
+		{"task costs do not sum to the estimated spend", func(d map[string]any) {
+			planTaskFixture(d, 0)["targetEstimatedBaselineCostUsd"] = .05
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			document := validBenchmarkPlanDocument(t)
+			test.breakIt(document)
+			raw, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadBenchmarkPlanJSON(raw); err == nil {
+				t.Fatal("an unusable benchmark plan was accepted for a paid run")
+			}
+		})
+	}
+}
+
+// TestBenchmarkPlanIdentityIsContentAddressed covers the property that lets
+// evidence be reused safely: a plan's ID is derived from its exact bytes, so a
+// plan edited after a run cannot silently adopt the previous run's evidence.
+func TestBenchmarkPlanIdentityIsContentAddressed(t *testing.T) {
+	document := validBenchmarkPlanDocument(t)
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := loadBenchmarkPlanJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := loadBenchmarkPlanJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != again.ID || len(first.ID) != 64 {
+		t.Fatalf("plan identity = %q and %q, want one stable digest", first.ID, again.ID)
+	}
+	if first.RunCount != 4 {
+		t.Fatalf("run count = %d, want the sum of the plan's repetitions", first.RunCount)
+	}
+
+	planTaskFixture(document, 0)["target"].(map[string]any)["mean"] = .30
+	edited, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err := loadBenchmarkPlanJSON(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.ID == first.ID {
+		t.Fatal("an edited plan reused the original plan's evidence identity")
+	}
+}

--- a/internal/config/load_fs_test.go
+++ b/internal/config/load_fs_test.go
@@ -300,3 +300,35 @@ func TestLoadCommandsAllowFS_ScannerError(t *testing.T) {
 		t.Fatalf("expected error for scanner overflow")
 	}
 }
+
+// TestLoadImportedSkillsFS covers the two facts projection depends on: imported
+// skills are optional, so a project that never imported one still loads; and
+// every skill that does come from the import directory is marked imported, which
+// is what keeps a Git-owned skill from being treated as user-authored.
+func TestLoadImportedSkillsFS(t *testing.T) {
+	const dir = ".agent-layer/imported-skills"
+	manifest := []byte("---\nname: alpha\ndescription: An imported skill.\n---\n\nBody")
+
+	skills, err := LoadImportedSkillsFS(fstest.MapFS{}, "root", dir)
+	if err != nil || len(skills) != 0 {
+		t.Fatalf("a project with no imports = %#v, %v", skills, err)
+	}
+
+	fsys := fstest.MapFS{
+		dir:                     {Mode: fs.ModeDir},
+		dir + "/alpha":          {Mode: fs.ModeDir},
+		dir + "/alpha/SKILL.md": {Data: manifest},
+	}
+	skills, err = LoadImportedSkillsFS(fsys, "root", dir)
+	if err != nil {
+		t.Fatalf("LoadImportedSkillsFS: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Name != "alpha" || !skills[0].Imported {
+		t.Fatalf("imported skills = %#v, want one skill marked imported", skills)
+	}
+
+	failing := errorFS{FS: fsys, errPath: dir, err: fs.ErrPermission}
+	if _, err := LoadImportedSkillsFS(failing, "root", dir); err == nil {
+		t.Fatal("an unreadable import directory was treated as no imports")
+	}
+}

--- a/internal/config/skillimports_edit_test.go
+++ b/internal/config/skillimports_edit_test.go
@@ -347,3 +347,75 @@ ref = "v1"
 		t.Fatalf("adjacent blocks were not edited independently: %+v", cfg.Skills.Imports)
 	}
 }
+
+// TestSetSkillImportSelectorsScansArrayDelimitersOutsideStringsAndComments
+// proves a selector edit finds the true end of the array. A `]` inside a
+// quoted selector, an escaped quote, a literal string, or a trailing comment
+// must not be mistaken for the closing bracket: doing so would truncate the
+// array and silently delete the user's remaining configuration.
+func TestSetSkillImportSelectorsScansArrayDelimitersOutsideStringsAndComments(t *testing.T) {
+	t.Parallel()
+	identity := SkillImport{Repository: "https://example.test/skills.git"}.Identity()
+	content := baseConfigTOML + `
+[[skills.imports]]
+repository = "https://example.test/skills.git"
+selectors = [ # keep everything below ]
+  "skills/bracket]name",       # ] in a comment
+  "skills/quote\"name",        # escaped quote
+  'skills/literal]name',
+]
+
+# trailing user configuration marker
+[dispatch]
+max_depth = 3
+`
+
+	updated, err := SetSkillImportSelectors(content, identity, []string{"skills/a"})
+	if err != nil {
+		t.Fatalf("SetSkillImportSelectors: %v", err)
+	}
+	cfg, err := ParseConfig([]byte(updated), "config.toml")
+	if err != nil {
+		t.Fatalf("edited config does not parse: %v\n%s", err, updated)
+	}
+	if len(cfg.Skills.Imports) != 1 || len(cfg.Skills.Imports[0].Selectors) != 1 ||
+		cfg.Skills.Imports[0].Selectors[0] != "skills/a" {
+		t.Fatalf("selectors were not replaced: %+v", cfg.Skills.Imports)
+	}
+	if !strings.Contains(updated, "# trailing user configuration marker") || !strings.Contains(updated, "max_depth = 3") {
+		t.Fatalf("configuration after the selectors array was lost:\n%s", updated)
+	}
+	for _, stale := range []string{"skills/bracket]name", "skills/literal]name"} {
+		if strings.Contains(updated, stale) {
+			t.Fatalf("replaced selector %q survived the edit:\n%s", stale, updated)
+		}
+	}
+}
+
+// TestSetSkillImportSelectorsRecordsAnExplicitPushDestination proves a new
+// block writes push_repository only when publication targets a repository
+// other than the import source, so a reader can tell where writes will land.
+func TestSetSkillImportSelectorsRecordsAnExplicitPushDestination(t *testing.T) {
+	t.Parallel()
+	identity := SkillImport{
+		Repository:     "https://example.test/skills.git",
+		WritePolicy:    SkillWritePolicyBranch,
+		PushRepository: "https://example.test/fork.git",
+		PushBranch:     "skill-updates",
+	}.Identity()
+
+	added, err := SetSkillImportSelectors(baseConfigTOML, identity, []string{"skills/a"})
+	if err != nil {
+		t.Fatalf("SetSkillImportSelectors: %v", err)
+	}
+	cfg, err := ParseConfig([]byte(added), "config.toml")
+	if err != nil {
+		t.Fatalf("appended config does not parse: %v\n%s", err, added)
+	}
+	if len(cfg.Skills.Imports) != 1 || cfg.Skills.Imports[0].Identity() != identity {
+		t.Fatalf("appended block identity mismatch: %+v", cfg.Skills.Imports)
+	}
+	if !strings.Contains(added, "push_repository = ") || !strings.Contains(added, "https://example.test/fork.git") {
+		t.Fatalf("append omitted the distinct push destination:\n%s", added)
+	}
+}

--- a/internal/probe/antigravity/probe_run_test.go
+++ b/internal/probe/antigravity/probe_run_test.go
@@ -1,0 +1,145 @@
+package antigravity
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFakeAgy puts an `agy` stand-in on PATH whose run body is supplied by
+// the caller, so a probe can be driven over the same command line, workspace,
+// and log directory the real client is given.
+func installFakeAgy(t *testing.T, runBody string) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "agy 1.2.3-fake"
+  exit 0
+fi
+gemini_dir=""
+for arg in "$@"; do
+  case "$arg" in
+    --gemini_dir=*) gemini_dir="${arg#--gemini_dir=}" ;;
+  esac
+done
+log_dir="$gemini_dir/antigravity-cli/log"
+` + runBody
+	path := filepath.Join(binDir, "agy")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil { // #nosec G306 -- the fake client must be executable.
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestProbeReportsObservedCapabilitiesFromRealArtifacts covers the probe's
+// reason to exist: the capability matrix must be derived from artifacts the
+// client actually produced in the seeded workspace — its log, its stdout, and
+// the MCP fixture it invoked — never assumed. A run that produces those
+// artifacts is the only thing that may report live MCP support.
+func TestProbeReportsObservedCapabilitiesFromRealArtifacts(t *testing.T) {
+	installFakeAgy(t, `mkdir -p "$log_dir"
+cat > "$log_dir/cli.log" <<'LOG'
+I0101 00:00:00.000000 1 cli_setting_manager.go:42] CLI settings initialized: permissions=allow[command(echo PROBEALLOWMARKER)]
+I0101 00:00:00.000000 1 migrate.go:17] Migrating file /cfg/antigravity-cli/mcp_config.json to /cfg/config/mcp_config.json
+I0101 00:00:00.000000 1 discovery.go:88] MCP server probe-mcp registered
+LOG
+printf '%s' "PROBEMCPTOOL33" > "$AL_PROBE_MCP_MARKER"
+echo "INSTRUCTIONMARKER88 WORKSPACEALLOWMARKER"
+echo "skills: probe-marker-skill, shared-tier-dup, global-only-skill"
+echo "mcp servers: probe-mcp"
+`)
+
+	result, err := Probe(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("probe of a healthy client failed: %v", err)
+	}
+	if result.ExitCode != 0 || result.TimedOut || result.Error != "" {
+		t.Fatalf("healthy run reported exit=%d timedOut=%t error=%q", result.ExitCode, result.TimedOut, result.Error)
+	}
+	if result.AgyVersion != "agy 1.2.3-fake" {
+		t.Fatalf("agy version = %q, want the version the client reported", result.AgyVersion)
+	}
+	want := CapabilityMatrix{
+		PermissionsLoaded:        true,
+		MCPConfigMigrated:        true,
+		MCPRuntimeDiscovery:      true,
+		MCPToolInvoked:           true,
+		WorkspacePermissionsRead: true,
+		InstructionsLoaded:       true,
+		SkillNamesVisible:        true,
+		MCPConfigNamesVisible:    true,
+		SharedSkillDedupObserved: true,
+	}
+	if result.Capabilities != want {
+		t.Fatalf("capabilities = %#v, want %#v", result.Capabilities, want)
+	}
+	if len(result.Evidence) != 9 {
+		t.Fatalf("evidence = %#v, want one entry per observed capability", result.Evidence)
+	}
+
+	// The probe must hand the client a workspace that can distinguish the
+	// capabilities it reports; without these seeds the matrix means nothing.
+	for _, seeded := range []string{
+		filepath.Join(result.WorkspaceDir, "AGENTS.md"),
+		filepath.Join(result.WorkspaceDir, ".agents", "mcp_config.json"),
+		filepath.Join(result.WorkspaceDir, ".agents", "skills", "shared-tier-dup", "SKILL.md"),
+		filepath.Join(result.AgyConfigDir, "skills", "shared-tier-dup", "SKILL.md"),
+		filepath.Join(result.AgyConfigDir, "antigravity-cli", "mcp_config.json"),
+		filepath.Join(result.AgyConfigDir, "antigravity-cli", "settings.json"),
+	} {
+		if _, err := os.Stat(seeded); err != nil {
+			t.Fatalf("probe workspace is missing %s: %v", seeded, err)
+		}
+	}
+	if result.LogPath != filepath.Join(result.AgyConfigDir, "antigravity-cli", "log", "cli.log") {
+		t.Fatalf("log path = %q, want the client log the probe read", result.LogPath)
+	}
+	stdout, err := os.ReadFile(filepath.Join(result.ProbeDir, "stdout.txt"))
+	if err != nil || !strings.Contains(string(stdout), "INSTRUCTIONMARKER88") {
+		t.Fatalf("probe did not retain the client stdout it parsed: %v", err)
+	}
+}
+
+// TestProbeReportsFailedRunsWithoutClaimingCapabilities covers the other half
+// of the contract: a client that fails still yields a report, and that report
+// must carry the failure rather than an empty success. Claiming capabilities
+// from a failed run would be worse than reporting nothing.
+func TestProbeReportsFailedRunsWithoutClaimingCapabilities(t *testing.T) {
+	installFakeAgy(t, `echo "client exploded" >&2
+exit 3
+`)
+
+	result, err := Probe(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("probe surfaced a client failure as a probe failure: %v", err)
+	}
+	if result.ExitCode != 3 {
+		t.Fatalf("exit code = %d, want the client's own exit status", result.ExitCode)
+	}
+	if !strings.Contains(result.Error, "exit status 3") || !strings.Contains(result.Error, "no antigravity log") {
+		t.Fatalf("error = %q, want both the run failure and the missing log recorded", result.Error)
+	}
+	if result.Capabilities != (CapabilityMatrix{}) {
+		t.Fatalf("failed run claimed capabilities: %#v", result.Capabilities)
+	}
+	stderr, err := os.ReadFile(filepath.Join(result.ProbeDir, "stderr.txt"))
+	if err != nil || !strings.Contains(string(stderr), "client exploded") {
+		t.Fatalf("probe did not retain the failing client's stderr: %v", err)
+	}
+}
+
+func TestProbeRequiresATemporaryRootAndAnInstalledClient(t *testing.T) {
+	installFakeAgy(t, "exit 0\n")
+	if _, err := Probe(context.Background(), ""); err == nil {
+		t.Fatal("probe accepted an empty temporary root")
+	}
+
+	t.Setenv("PATH", t.TempDir())
+	if _, err := Probe(context.Background(), t.TempDir()); err == nil ||
+		!strings.Contains(err.Error(), "requires agy on PATH") {
+		t.Fatalf("probe without an installed client = %v", err)
+	}
+}

--- a/internal/projection/approvals_test.go
+++ b/internal/projection/approvals_test.go
@@ -1,6 +1,7 @@
 package projection
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/config"
@@ -32,5 +33,35 @@ func TestBuildApprovalsYOLO(t *testing.T) {
 	}
 	if len(result.Commands) != 1 || result.Commands[0] != "make test" {
 		t.Fatalf("unexpected commands: %+v", result.Commands)
+	}
+}
+
+// TestClaudeAllowRulesGrantOnlyWhatTheModeAllows pins the pre-approval boundary
+// that headless dispatch passes to Claude on the command line. Every rule
+// returned here bypasses a permission prompt, so a mode must never leak a grant
+// for the feature it does not cover.
+func TestClaudeAllowRulesGrantOnlyWhatTheModeAllows(t *testing.T) {
+	commands := []string{"git status", "make test"}
+	servers := []string{"context7", "agent-layer"}
+
+	tests := []struct {
+		mode string
+		want []string
+	}{
+		{config.ApprovalModeNone, nil},
+		{config.ApprovalModeCommands, []string{"Bash(git status:*)", "Bash(make test:*)"}},
+		{config.ApprovalModeMCP, []string{"mcp__agent-layer__*", "mcp__context7__*"}},
+		{config.ApprovalModeAll, []string{"Bash(git status:*)", "Bash(make test:*)", "mcp__agent-layer__*", "mcp__context7__*"}},
+		{config.ApprovalModeYOLO, []string{"Bash(git status:*)", "Bash(make test:*)", "mcp__agent-layer__*", "mcp__context7__*"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.mode, func(t *testing.T) {
+			cfg := config.Config{Approvals: config.ApprovalsConfig{Mode: test.mode}}
+			got := ClaudeAllowRules(cfg, commands, servers)
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("allow rules for mode %q = %#v, want %#v", test.mode, got, test.want)
+			}
+		})
 	}
 }

--- a/internal/skillimport/reset_guard_test.go
+++ b/internal/skillimport/reset_guard_test.go
@@ -1,0 +1,77 @@
+package skillimport
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestResetRefusesToDiscardLocalEditsItCannotReplace covers the safety contract
+// of the one permanently destructive skill operation: reset overwrites a user's
+// local edits, so it must refuse whenever the replacement it would install is
+// not unambiguously the configured upstream for that skill. Every refusal must
+// leave the local content untouched.
+func TestResetRefusesToDiscardLocalEditsItCannotReplace(t *testing.T) {
+	tests := []struct {
+		name       string
+		arrange    func(t *testing.T, source *gitRepo, proj *project)
+		wantReason string
+	}{
+		{
+			name: "the skill is no longer selected by configuration",
+			arrange: func(t *testing.T, _ *gitRepo, proj *project) {
+				proj.ReplaceInConfig(`"skills/alpha"`, `"skills/nothing"`)
+			},
+			wantReason: "no longer selected by configuration",
+		},
+		{
+			name: "upstream path is no longer a valid skill",
+			arrange: func(t *testing.T, source *gitRepo, _ *project) {
+				source.WriteFile("skills/alpha/SKILL.md", "no front matter\n", 0o644)
+				source.Commit("break alpha upstream")
+			},
+			wantReason: "not a valid skill",
+		},
+		{
+			name: "a user-managed skill already owns the name",
+			arrange: func(t *testing.T, _ *gitRepo, proj *project) {
+				proj.WriteUserSkill("alpha")
+			},
+			wantReason: "already owns the name",
+		},
+		{
+			name:       "the name has no lock entry",
+			arrange:    func(t *testing.T, _ *gitRepo, _ *project) {},
+			wantReason: "has no lock entry",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := newGitRepo(t, "main")
+			source.WriteSkill("skills/alpha", "alpha", "Alpha original")
+			source.Commit("add alpha")
+
+			proj := newProject(t)
+			proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+			if _, err := proj.Service().Pull(context.Background()); err != nil {
+				t.Fatalf("initial pull: %v", err)
+			}
+			proj.WriteImportedFile("alpha", "notes.md", "local work\n")
+			test.arrange(t, source, proj)
+
+			target := "alpha"
+			if test.wantReason == "has no lock entry" {
+				target = "never-imported"
+			}
+			if _, err := proj.Service().Reset(context.Background(), target); err == nil {
+				t.Fatal("reset discarded local edits it could not safely replace")
+			} else if !strings.Contains(err.Error(), test.wantReason) {
+				t.Fatalf("error = %v, want it to explain %q", err, test.wantReason)
+			}
+			if got := proj.ImportedFile("alpha", "notes.md"); got != "local work\n" {
+				t.Fatalf("refused reset still changed local content: %q", got)
+			}
+		})
+	}
+}

--- a/internal/skillimport/selector_dedup_test.go
+++ b/internal/skillimport/selector_dedup_test.go
@@ -1,0 +1,49 @@
+package skillimport
+
+import (
+	"context"
+	"testing"
+)
+
+// TestOverlappingSelectorsImportEachSkillOnce covers selector resolution when a
+// user names the same skill twice — once literally and once through a wildcard
+// that also matches it. Each upstream skill must resolve to exactly one import,
+// because a second candidate for the same path would either duplicate the skill
+// or make its lock ownership ambiguous.
+func TestOverlappingSelectorsImportEachSkillOnce(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteSkill("skills/beta", "beta", "Beta body")
+	source.WriteSkill("other/gamma", "gamma", "Gamma body")
+	source.Commit("add skills")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{
+		"skills/alpha",
+		"skills/*",
+	}))
+
+	report, err := proj.Service().Pull(context.Background())
+	if err != nil {
+		t.Fatalf("Pull: %v\n%s", err, report.Render("pull"))
+	}
+	requireOutcome(t, report, "alpha", OutcomeImported)
+	requireOutcome(t, report, "beta", OutcomeImported)
+
+	lock := proj.Lock()
+	if _, ok := lock.Entry("gamma"); ok {
+		t.Fatal("a selector matched a skill outside the configured prefix")
+	}
+	alphaResults := 0
+	for _, result := range report.Skills {
+		if result.Name == "alpha" {
+			alphaResults++
+		}
+	}
+	if alphaResults != 1 {
+		t.Fatalf("alpha was reported %d times, want exactly one import", alphaResults)
+	}
+	if body := proj.ImportedFile("alpha", "SKILL.md"); body == "" {
+		t.Fatal("alpha was not imported")
+	}
+}

--- a/internal/wizard/env_preview_test.go
+++ b/internal/wizard/env_preview_test.go
@@ -1,0 +1,77 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvPreviewNeverShowsASecretValue covers the wizard's `.env` diff preview.
+// The preview is printed to the terminal and is the one place a stored API key
+// could be echoed back, so every parsed value must be replaced with a redaction
+// marker while the surrounding text a user needs to read the diff — keys,
+// `export` prefixes, comments, and blank lines — is preserved verbatim.
+func TestEnvPreviewNeverShowsASecretValue(t *testing.T) {
+	const kept = "kept-secret-value"
+	const rotated = "rotated-secret-value"
+	const added = "added-secret-value"
+
+	current := strings.Join([]string{
+		"# Agent Layer secrets",
+		"",
+		"KEPT=" + kept,
+		`ROTATED="` + rotated + `x" # rotate me`,
+		"export EXPORTED='" + kept + "' # exported form",
+		"EMPTY=",
+		"",
+	}, "\n")
+	next := strings.Join([]string{
+		"# Agent Layer secrets",
+		"",
+		"KEPT=" + kept,
+		`ROTATED="` + rotated + `" # rotate me`,
+		"export EXPORTED='" + kept + "' # exported form",
+		"ADDED=" + added,
+		"EMPTY=",
+		"",
+	}, "\n")
+
+	currentPreview, nextPreview, err := redactEnvPreviewContent(current, next)
+	require.NoError(t, err)
+
+	for _, secret := range []string{kept, rotated, added} {
+		assert.NotContains(t, currentPreview, secret, "current preview leaked a secret")
+		assert.NotContains(t, nextPreview, secret, "proposed preview leaked a secret")
+	}
+
+	// An unchanged value is redacted without implying it changed.
+	assert.Contains(t, currentPreview, `KEPT="<redacted>"`)
+	assert.Contains(t, nextPreview, `KEPT="<redacted>"`)
+	// A value that differs between the two sides is labelled per side, so the
+	// diff still shows the user that the secret is being replaced.
+	assert.Contains(t, currentPreview, `ROTATED="<redacted current>"`)
+	assert.Contains(t, nextPreview, `ROTATED="<redacted proposed>"`)
+	assert.Contains(t, nextPreview, `ADDED="<redacted proposed>"`)
+	// An unset key stays visibly unset rather than looking like a hidden value.
+	assert.Contains(t, nextPreview, `EMPTY=""`)
+
+	// Context a reader needs to interpret the diff survives untouched.
+	assert.Contains(t, nextPreview, `export EXPORTED="<redacted>" # exported form`)
+	assert.Contains(t, nextPreview, `ROTATED="<redacted proposed>" # rotate me`)
+	assert.Contains(t, nextPreview, "# Agent Layer secrets")
+	assert.Equal(t, strings.Count(next, "\n"), strings.Count(nextPreview, "\n"))
+}
+
+func TestEnvPreviewFailsOnUnparseableEnvContent(t *testing.T) {
+	_, _, err := redactEnvPreviewContent("KEY=value\n", "not an assignment\n")
+	assert.Error(t, err, "the wizard previewed a .env file it could not parse")
+}
+
+func TestEmptyEnvPreviewIsLeftAlone(t *testing.T) {
+	currentPreview, nextPreview, err := redactEnvPreviewContent("", "KEY=secret\n")
+	require.NoError(t, err)
+	assert.Equal(t, "", currentPreview)
+	assert.Contains(t, nextPreview, `KEY="<redacted proposed>"`)
+}

--- a/internal/wizard/env_preview_test.go
+++ b/internal/wizard/env_preview_test.go
@@ -11,8 +11,10 @@ import (
 // TestEnvPreviewNeverShowsASecretValue covers the wizard's `.env` diff preview.
 // The preview is printed to the terminal and is the one place a stored API key
 // could be echoed back, so every parsed value must be replaced with a redaction
-// marker while the surrounding text a user needs to read the diff — keys,
-// `export` prefixes, comments, and blank lines — is preserved verbatim.
+// marker. An assignment line is rebuilt rather than copied — the key is trimmed
+// and the value is requoted — so what is asserted here is that the parts a user
+// needs to read the diff survive that rewrite: the key, any `export` prefix, any
+// trailing comment, comment-only lines, and the line count.
 func TestEnvPreviewNeverShowsASecretValue(t *testing.T) {
 	const kept = "kept-secret-value"
 	const rotated = "rotated-secret-value"

--- a/internal/wizard/helpers_test.go
+++ b/internal/wizard/helpers_test.go
@@ -3,6 +3,7 @@ package wizard
 import (
 	"errors"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -345,4 +346,59 @@ func TestBuildSummary(t *testing.T) {
 		assert.Contains(t, summary, "- GITHUB_TOKEN")
 		assert.Contains(t, summary, "- OTHER_TOKEN")
 	})
+}
+
+// TestBuildSummaryReportsEveryClaudeHardeningChoice covers the confirmation
+// step the user actually reads before the wizard writes anything: a choice that
+// turns off a Claude capability must appear in the summary, and a capability
+// left at its client default must not — otherwise the user confirms a change
+// they were never shown, or is warned about one they did not make.
+func TestBuildSummaryReportsEveryClaudeHardeningChoice(t *testing.T) {
+	disabled := NewChoices()
+	disabled.ApprovalMode = "none"
+	disabled.EnabledAgentsTouched = true
+	disabled.EnabledAgents[AgentClaude] = true
+	disabled.ClaudeModel = "opus"
+	disabled.ClaudeReasoning = "high"
+	for _, touched := range []*bool{
+		&disabled.ClaudeDisableIDEReadingTouched, &disabled.ClaudeDisableMemoryTouched,
+		&disabled.ClaudeDisableConnectorsTouched, &disabled.ClaudeDisableQuestionToolTouched,
+	} {
+		*touched = true
+	}
+	for _, value := range []*bool{
+		&disabled.ClaudeDisableIDEReading, &disabled.ClaudeDisableMemory,
+		&disabled.ClaudeDisableConnectors, &disabled.ClaudeDisableQuestionTool,
+	} {
+		*value = true
+	}
+
+	summary := buildSummary(disabled)
+	for _, line := range []string{
+		messages.WizardSummaryClaudeIDEReadingDisabled,
+		messages.WizardSummaryClaudeMemoryDisabled,
+		messages.WizardSummaryClaudeConnectorsDisabled,
+		messages.WizardSummaryClaudeQuestionToolDisabled,
+	} {
+		assert.Contains(t, summary, strings.TrimSpace(line))
+	}
+	assert.Contains(t, summary, "opus (high)")
+
+	// The same choices left at the client default report nothing.
+	kept := NewChoices()
+	kept.ApprovalMode = "none"
+	kept.EnabledAgentsTouched = true
+	kept.EnabledAgents[AgentClaude] = true
+	kept.ClaudeDisableIDEReadingTouched = true
+	kept.ClaudeDisableMemoryTouched = true
+	keptSummary := buildSummary(kept)
+	assert.NotContains(t, keptSummary, strings.TrimSpace(messages.WizardSummaryClaudeIDEReadingDisabled))
+	assert.NotContains(t, keptSummary, strings.TrimSpace(messages.WizardSummaryClaudeMemoryDisabled))
+
+	// A reasoning effort chosen without a model still has to be reported.
+	reasoningOnly := NewChoices()
+	reasoningOnly.ApprovalMode = "none"
+	reasoningOnly.EnabledAgents[AgentClaude] = true
+	reasoningOnly.ClaudeReasoning = "high"
+	assert.Contains(t, buildSummary(reasoningOnly), "reasoning: high")
 }


### PR DESCRIPTION
## Summary

- Raises total statement coverage from 90.02% to 91.42% using behavior-level tests only, buying margin above the repository's 90% gate.
- `COVERAGE_THRESHOLD` stays at 90.0 by design. This PR is margin, not a stricter gate.
- Every test added pins a contract the code is responsible for. None assert implementation details, and none were added purely to move the number.

## Changes

New tests:

- **`internal/agentdispatch/structured_json_test.go`** — the hand-written selective JSON reader rejects 18 kinds of malformed provider record with a diagnostic reason and still delivers the following record; separately, it accepts the parts of the JSON grammar the reducers never read (numbers, `\u` escapes, literals, insignificant whitespace).
- **`internal/agentdispatch/async_worker_test.go`** — `Start` publishes an invocation and the detached worker executes it exactly once: the request is consumed, so a replayed worker cannot bill the provider again. A request prepared for another project terminalizes the run as failed.
- **`internal/probe/antigravity/probe_run_test.go`** — drives `Probe` end to end against a fake `agy` on `PATH`. Capabilities are reported only from artifacts the client actually produced (log, stdout, MCP fixture marker), and a failed client run carries its exit code and error instead of claiming capabilities.
- **`internal/benchmark/execution_run_test.go`** — every paid Pier run is pinned to the checked-out task set, requested model, and the correct arm agent; treatment runs load the bundle adapter and account cost per component; incomplete requests never start a run.
- **`internal/benchmark/plan_validation_test.go`** — 19 ways an exported plan can fail to vouch for itself, plus content-addressed plan identity so an edited plan cannot adopt a previous run's evidence.
- **`internal/benchmark/evidence_test.go`** — 22 ways attempt evidence can be incomplete or self-contradictory before entering analysis.
- **`internal/benchmark/campaign_guard_test.go`** — a treatment refuses to run against an unusable baseline and makes zero provider calls when it does.
- **`internal/benchmark/normalize_verifier_test.go`** — verifier build failures are detected only from verifier logs, with a bounded diagnostic excerpt.
- **`internal/skillimport/reset_guard_test.go`** — reset, the one permanently destructive skill operation, refuses whenever it cannot identify the replacement, and leaves local content untouched on every refusal.
- **`internal/skillimport/selector_dedup_test.go`** — a skill named both literally and by a matching wildcard imports exactly once.
- **`internal/wizard/env_preview_test.go`** — the wizard's `.env` diff preview never echoes a secret while preserving keys, `export` prefixes, and comments.

Extended tests:

- **`internal/projection/approvals_test.go`** — each approval mode grants exactly its own pre-approved Claude rules; `mcp` mode never leaks a `Bash(...)` grant.
- **`internal/benchmark/observed_report_test.go`** — 17 ways an analysis artifact can fail to reconcile before a report renders.
- **`internal/config/skillimports_edit_test.go`** — a selector array is not truncated by a `]` inside a quoted selector, an escaped quote, a literal string, or a trailing comment; a distinct push destination is recorded explicitly.
- **`internal/config/load_fs_test.go`** — imported skills are optional, and skills loaded from the import directory are marked imported.
- **`internal/wizard/helpers_test.go`** — the confirmation summary reports every Claude hardening choice the user made, and nothing they left at the client default.

Documentation:

- **`docs/agent-layer/ISSUES.md`** — records why coverage stops here.

## Verification

- `make fmt-check` — passed
- `make lint` — passed, 0 issues
- `make coverage` — passed, total coverage 91.42% against the unchanged 90.00% threshold
- Pre-commit gate on commit — trailing whitespace, EOF, merge conflicts, large files, case conflicts, line endings, private keys, gofmt + goimports, `go mod tidy` check, golangci-lint, and `go test ./...` all passed

## Notes

- No production code changed. This PR is tests plus one memory-file entry.
- Coverage stops at 91.42% deliberately. Every remaining uncovered region is a 1–5 statement block, overwhelmingly `if err != nil` wrappers around `os`, `git`, and process calls, plus branches that are unreachable in practice (device/socket nodes in `skilltree.describeNode`, non-finite floats `encoding/json` cannot decode, and a duplicate-selector check that config validation already rejects — both confirmed by attempting to reach them). Closing the last gap to 92% would need roughly 60–100 fault-injection tests, which would mean adding injectable filesystem/command seams to production code. `docs/agent-layer/ISSUES.md` carries that as an open question rather than deciding it here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for asynchronous worker authorization, invocation replay prevention, and structured JSON parsing.
  * Added validation coverage for benchmark plans, evidence, execution, reports, verifier output, and campaign prerequisites.
  * Added tests for imported skills, selector handling, approval rules, safe skill resets, capability probing, and `.env` secret redaction.
* **Documentation**
  * Documented remaining low-priority coverage gaps and potential fault-injection areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->