### PR TITLE
docs: complete the Codex approvals evidence for v0.16.0

### DIFF
--- a/docs/release-evidence/v0.16.0-agent-dispatch.md
+++ b/docs/release-evidence/v0.16.0-agent-dispatch.md
@@ -37,7 +37,7 @@ v0.16.0 fixes headless dispatch approvals: `approvals.mode` is now delivered to
 the provider, so a dispatched agent approved to run commands can actually edit
 files. Before this release only `yolo` could write. The probes above run under
 this repository's `yolo` configuration, so they do not exercise the fix; this
-section does.
+section does. Both providers whose approval delivery changed are covered.
 
 Probe: a separate scratch repository initialized with `al init --no-wizard`, its
 `[approvals] mode` set to `commands`, then
@@ -47,33 +47,35 @@ followed by `al dispatch wait <handle>`.
 | Provider | Handle | Expected artifact | Result |
 | --- | --- | --- | --- |
 | Claude | `short-steady-relay` | `claude-write.txt` containing `claude-v016-approvals-ok` | Pass — file written under `commands` |
-| Codex | `short-gentle-oscillator`, `nimble-silent-amplifier` | `codex-write.txt` | Not established — provider authentication failure, see below |
+| Codex | `nimble-square-relay` | `codex-write.txt` containing `codex-v016-approvals-ok` | Pass — file written under `commands` |
 
 The Claude probe confirms `--permission-mode acceptEdits` reaches the provider
 and that the allowlisted tools are delivered via `--allowedTools`: the write
-succeeded without an interactive trust dialog.
+succeeded without an interactive trust dialog. The Codex probe confirms
+`sandbox_mode = workspace-write` reaches the provider: a `read-only` sandbox
+would have failed on the first write.
 
-### Codex probe not established
+### Codex credential scope when probing from a scratch repository
 
-Both Codex attempts failed with `capture dispatch provider output: Your access
-token could not be refreshed because your refresh token was already used. Please
-log out and sign in again.` This is a provider credential failure, not an Agent
-Layer regression: invoking the provider directly from the same scratch repository
-with `codex exec --sandbox read-only` reproduces the identical
-`codex_login::auth::manager: Failed to refresh token` error and a `401
-Unauthorized` from the Codex backend, with no Agent Layer process involved. The
-Codex fresh and continuation probes recorded above completed successfully earlier
-in the same session, before the refresh token was consumed.
+`agents.codex.local_config_dir` points `CODEX_HOME` at a repository-local
+`.codex`, so Codex credentials are per-repository. A freshly initialized scratch
+repository has `.codex/config.toml` but no `.codex/auth.json`, and a dispatch
+there fails with a provider authentication error that is unrelated to the
+approvals change under test. Two earlier attempts in this session failed for
+exactly that reason.
 
-Agent Dispatch surfaced the failure loudly and did not report success, which is
-the behavior v0.16.0 requires of a failed dispatch.
-
-Re-run after `codex login` to complete this row:
+Run the probe with `CODEX_HOME` pointed at an authenticated home. Agent Layer
+honors a pre-set `CODEX_HOME` and warns when it differs from the repository-local
+path, so no credential copying is required:
 
 ```bash
-al dispatch start --agent codex --prompt "Create a file named codex-write.txt in the current directory containing exactly: codex-v016-approvals-ok . Then reply DONE."
-al dispatch wait <handle>
+CODEX_HOME=/path/to/authenticated/.codex \
+  al dispatch start --agent codex --prompt "..."
 ```
+
+Note that a bare `codex exec` invocation does not reproduce this environment: with
+no `CODEX_HOME` set it falls back to `~/.codex`, which is a different credential
+store than the one Agent Dispatch uses.
 
 ## Safe Antigravity missing-ID behavior
 


### PR DESCRIPTION
Corrects the Codex row in the v0.16.0 Agent Dispatch evidence, which #180 recorded as "not established" on a wrong diagnosis.

## What was wrong

The row claimed a provider refresh-token failure and cited a bare `codex exec` run as reproducing it "without Agent Layer involved." That reasoning does not hold:

`agents.codex.local_config_dir` points `CODEX_HOME` at a **repository-local** `.codex`, so Codex credentials are per-repository. The scratch repository built for the approvals probe had `.codex/config.toml` but no `.codex/auth.json` — it had no credentials at all. Meanwhile the "reproduction" ran `codex exec` with no `CODEX_HOME` set, falling back to `~/.codex` — a different credential store than the dispatch used. It tested unrelated credentials and was not evidence about the dispatch.

## Result

Re-running with `CODEX_HOME` pointed at an authenticated home passes. Codex writes `codex-write.txt` containing `codex-v016-approvals-ok` under `approvals.mode = "commands"`, confirming `sandbox_mode = workspace-write` reaches the provider — a `read-only` sandbox would have failed on the first write.

| Provider | Handle | Result |
|---|---|---|
| Claude | `short-steady-relay` | Pass |
| Codex | `nimble-square-relay` | Pass |

Both providers whose approval delivery changed in v0.16.0 are now covered, closing the last open item before tagging.

No credential copying is involved: `ConfigureEnvironment` honors a pre-set `CODEX_HOME` and warns on mismatch. The doc now records this credential-scope pitfall so the probe is reproducible.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)